### PR TITLE
fix: Add dummy location data to conform to SARIF spec

### DIFF
--- a/src/axe-raw-sarif-converter.ts
+++ b/src/axe-raw-sarif-converter.ts
@@ -15,7 +15,7 @@ import { EnvironmentData } from './environment-data';
 import { getInvocations } from './invocation-provider';
 import { ResultToRuleConverter } from './result-to-rule-converter';
 import { formatSarifResultMessage } from './sarif-result-message-formatter';
-import { axeTagsToWcagLinkData, WCAGLinkData } from './wcag-link-data';
+import { WCAGLinkData, axeTagsToWcagLinkData } from './wcag-link-data';
 import { WCAGLinkDataIndexer } from './wcag-link-data-indexer';
 import { getWcagTaxonomy } from './wcag-taxonomy-provider';
 
@@ -174,6 +174,9 @@ export class AxeRawSarifConverter {
                     physicalLocation: {
                         artifactLocation: getArtifactLocation(environmentData),
                         region: {
+                            startLine: 1,
+                            startColumn: 1,
+                            endColumn: 1,
                             snippet: {
                                 text: axeRawNodeResult.node.source,
                             },

--- a/src/axe-raw-sarif-converter.ts
+++ b/src/axe-raw-sarif-converter.ts
@@ -175,8 +175,6 @@ export class AxeRawSarifConverter {
                         artifactLocation: getArtifactLocation(environmentData),
                         region: {
                             startLine: 1,
-                            startColumn: 1,
-                            endColumn: 1,
                             snippet: {
                                 text: axeRawNodeResult.node.source,
                             },

--- a/src/axe-raw-sarif-converter.ts
+++ b/src/axe-raw-sarif-converter.ts
@@ -175,6 +175,8 @@ export class AxeRawSarifConverter {
                         artifactLocation: getArtifactLocation(environmentData),
                         region: {
                             startLine: 1,
+                            startColumn: 1,
+                            endColumn: 1,
                             snippet: {
                                 text: axeRawNodeResult.node.source,
                             },

--- a/src/sarif-converter.ts
+++ b/src/sarif-converter.ts
@@ -177,6 +177,8 @@ export class SarifConverter {
                         artifactLocation: getArtifactLocation(environmentData),
                         region: {
                             startLine: 1,
+                            startColumn: 1,
+                            endColumn: 1,
                             snippet: {
                                 text: node.html,
                             },

--- a/src/sarif-converter.ts
+++ b/src/sarif-converter.ts
@@ -177,8 +177,6 @@ export class SarifConverter {
                         artifactLocation: getArtifactLocation(environmentData),
                         region: {
                             startLine: 1,
-                            startColumn: 1,
-                            endColumn: 1,
                             snippet: {
                                 text: node.html,
                             },

--- a/src/sarif-converter.ts
+++ b/src/sarif-converter.ts
@@ -15,7 +15,7 @@ import { getEnvironmentDataFromResults } from './environment-data-provider';
 import { getInvocations } from './invocation-provider';
 import { ResultToRuleConverter } from './result-to-rule-converter';
 import { formatSarifResultMessage } from './sarif-result-message-formatter';
-import { axeTagsToWcagLinkData, WCAGLinkData } from './wcag-link-data';
+import { WCAGLinkData, axeTagsToWcagLinkData } from './wcag-link-data';
 import { WCAGLinkDataIndexer } from './wcag-link-data-indexer';
 import { getWcagTaxonomy } from './wcag-taxonomy-provider';
 
@@ -176,6 +176,9 @@ export class SarifConverter {
                     physicalLocation: {
                         artifactLocation: getArtifactLocation(environmentData),
                         region: {
+                            startLine: 1,
+                            startColumn: 1,
+                            endColumn: 1,
                             snippet: {
                                 text: node.html,
                             },

--- a/src/test-resources/basic-axe-v3.2.2.sarif
+++ b/src/test-resources/basic-axe-v3.2.2.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body></body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.2.2.sarif
+++ b/src/test-resources/basic-axe-v3.2.2.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body></body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.2.2.sarif
+++ b/src/test-resources/basic-axe-v3.2.2.sarif
@@ -1,767 +1,769 @@
 {
-    "version": "2.1.0",
-    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-    "runs": [
-      {
-        "conversion": {
-          "tool": {
-            "driver": {
-              "name": "axe-sarif-converter",
-              "fullName": "axe-sarif-converter v0.0.0-managed-by-semantic-release",
-              "version": "0.0.0-managed-by-semantic-release",
-              "semanticVersion": "0.0.0-managed-by-semantic-release",
-              "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v0.0.0-managed-by-semantic-release",
-              "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/0.0.0-managed-by-semantic-release"
-            }
-          }
-        },
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "conversion": {
         "tool": {
           "driver": {
-            "name": "axe-core",
-            "fullName": "axe for Web v3.2.2",
-            "shortDescription": {
-              "text": "An open source accessibility rules library for automated testing."
-            },
-            "version": "3.2.2",
-            "semanticVersion": "3.2.2",
-            "informationUri": "https://www.deque.com/axe/axe-for-web/",
-            "downloadUri": "https://www.npmjs.com/package/axe-core/v/3.2.2",
-            "properties": {
-              "microsoft/qualityDomain": "Accessibility"
-            },
-            "supportedTaxonomies": [
-              {
-                "name": "WCAG",
-                "index": 0,
-                "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18"
-              }
-            ],
-            "rules": [
-              {
-                "id": "document-title",
-                "name": "Documents must have <title> element to aid in navigation",
-                "fullDescription": {
-                  "text": "Ensures each HTML document contains a non-empty <title> element."
-                },
-                "helpUri": "https://dequeuniversity.com/rules/axe/3.2/document-title?application=axeAPI",
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "wcag242",
-                      "index": 45,
-                      "toolComponent": {
-                        "name": "WCAG",
-                        "index": 0,
-                        "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              }
-            ]
+            "name": "axe-sarif-converter",
+            "fullName": "axe-sarif-converter v0.0.0-managed-by-semantic-release",
+            "version": "0.0.0-managed-by-semantic-release",
+            "semanticVersion": "0.0.0-managed-by-semantic-release",
+            "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v0.0.0-managed-by-semantic-release",
+            "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/0.0.0-managed-by-semantic-release"
           }
-        },
-        "invocations": [
-          {
-            "startTimeUtc": "2000-01-02T03:04:05.006Z",
-            "endTimeUtc": "2000-01-02T03:04:05.006Z",
-            "executionSuccessful": true
-          }
-        ],
-        "artifacts": [
-          {
-            "location": {
-              "uri": "http://localhost/",
-              "index": 0
-            },
-            "sourceLanguage": "html",
-            "roles": [
-              "analysisTarget"
-            ]
-          }
-        ],
-        "results": [
-          {
-            "ruleId": "document-title",
-            "ruleIndex": 0,
-            "kind": "fail",
-            "level": "error",
-            "message": {
-              "text": "Fix any of the following: Document does not have a non-empty <title> element.",
-              "markdown": "Fix any of the following:\n- Document does not have a non-empty &lt;title> element."
-            },
-            "locations": [
-              {
-                "physicalLocation": {
-                  "artifactLocation": {
-                    "uri": "http://localhost/",
-                    "index": 0
-                  },
-                  "region": {
-                    "snippet": {
-                      "text": "<html><head></head><body></body></html>"
+        }
+      },
+      "tool": {
+        "driver": {
+          "name": "axe-core",
+          "fullName": "axe for Web v3.2.2",
+          "shortDescription": {
+            "text": "An open source accessibility rules library for automated testing."
+          },
+          "version": "3.2.2",
+          "semanticVersion": "3.2.2",
+          "informationUri": "https://www.deque.com/axe/axe-for-web/",
+          "downloadUri": "https://www.npmjs.com/package/axe-core/v/3.2.2",
+          "properties": {
+            "microsoft/qualityDomain": "Accessibility"
+          },
+          "supportedTaxonomies": [
+            {
+              "name": "WCAG",
+              "index": 0,
+              "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18"
+            }
+          ],
+          "rules": [
+            {
+              "id": "document-title",
+              "name": "Documents must have <title> element to aid in navigation",
+              "fullDescription": {
+                "text": "Ensures each HTML document contains a non-empty <title> element."
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/document-title?application=axeAPI",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "wcag242",
+                    "index": 45,
+                    "toolComponent": {
+                      "name": "WCAG",
+                      "index": 0,
+                      "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18"
                     }
-                  }
+                  },
+                  "kinds": [
+                    "superset"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "invocations": [
+        {
+          "startTimeUtc": "2000-01-02T03:04:05.006Z",
+          "endTimeUtc": "2000-01-02T03:04:05.006Z",
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "http://localhost/",
+            "index": 0
+          },
+          "sourceLanguage": "html",
+          "roles": [
+            "analysisTarget"
+          ]
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "document-title",
+          "ruleIndex": 0,
+          "kind": "fail",
+          "level": "error",
+          "message": {
+            "text": "Fix any of the following: Document does not have a non-empty <title> element.",
+            "markdown": "Fix any of the following:\n- Document does not have a non-empty &lt;title> element."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "http://localhost/",
+                  "index": 0
                 },
-                "logicalLocations": [
-                  {
-                    "fullyQualifiedName": "html",
-                    "kind": "element"
-                  },
-                  {
-                    "fullyQualifiedName": "/html",
-                    "kind": "element"
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
+                  "snippet": {
+                    "text": "<html><head></head><body></body></html>"
                   }
-                ]
-              }
-            ]
-          }
-        ],
-        "taxonomies": [
-          {
-            "name": "WCAG",
-            "fullName": "Web Content Accessibility Guidelines (WCAG) 2.1",
-            "organization": "W3C",
-            "informationUri": "https://www.w3.org/TR/WCAG21",
-            "version": "2.1",
-            "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18",
-            "isComprehensive": true,
-            "taxa": [
-              {
-                  "id": "best-practice",
-                  "name": "Best Practice"
-              },
-              {
-                  "id": "wcag111",
-                  "name": "WCAG 1.1.1",
-                  "shortDescription": {
-                  "text": "Non-text Content"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/non-text-content"
-              },
-              {
-                  "id": "wcag121",
-                  "name": "WCAG 1.2.1",
-                  "shortDescription": {
-                  "text": "Audio-only and Video-only (Prerecorded)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded"
-              },
-              {
-                  "id": "wcag122",
-                  "name": "WCAG 1.2.2",
-                  "shortDescription": {
-                  "text": "Captions (Prerecorded)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded"
-              },
-              {
-                  "id": "wcag123",
-                  "name": "WCAG 1.2.3",
-                  "shortDescription": {
-                  "text": "Audio Description or Media Alternative (Prerecorded)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded"
-              },
-              {
-                  "id": "wcag124",
-                  "name": "WCAG 1.2.4",
-                  "shortDescription": {
-                  "text": "Captions (Live)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/captions-live"
-              },
-              {
-                  "id": "wcag125",
-                  "name": "WCAG 1.2.5",
-                  "shortDescription": {
-                  "text": "Audio Description (Prerecorded)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded"
-              },
-              {
-                  "id": "wcag126",
-                  "name": "WCAG 1.2.6",
-                  "shortDescription": {
-                  "text": "Sign Language (Prerecorded)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/sign-language-prerecorded"
-              },
-              {
-                  "id": "wcag127",
-                  "name": "WCAG 1.2.7",
-                  "shortDescription": {
-                  "text": "Extended Audio Description (Prerecorded)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/extended-audio-description-prerecorded"
-              },
-              {
-                  "id": "wcag128",
-                  "name": "WCAG 1.2.8",
-                  "shortDescription": {
-                  "text": "Media Alternative (Prerecorded)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/media-alternative-prerecorded"
-              },
-              {
-                  "id": "wcag129",
-                  "name": "WCAG 1.2.9",
-                  "shortDescription": {
-                  "text": "Audio-only (Live)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-only-live"
-              },
-              {
-                  "id": "wcag131",
-                  "name": "WCAG 1.3.1",
-                  "shortDescription": {
-                  "text": "Info and Relationships"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
-              },
-              {
-                  "id": "wcag132",
-                  "name": "WCAG 1.3.2",
-                  "shortDescription": {
-                  "text": "Meaningful Sequence"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence"
-              },
-              {
-                  "id": "wcag133",
-                  "name": "WCAG 1.3.3",
-                  "shortDescription": {
-                  "text": "Sensory Characteristics"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics"
-              },
-              {
-                  "id": "wcag134",
-                  "name": "WCAG 1.3.4",
-                  "shortDescription": {
-                  "text": "Orientation"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/orientation"
-              },
-              {
-                  "id": "wcag135",
-                  "name": "WCAG 1.3.5",
-                  "shortDescription": {
-                  "text": "Identify Input Purpose"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose"
-              },
-              {
-                  "id": "wcag136",
-                  "name": "WCAG 1.3.6",
-                  "shortDescription": {
-                  "text": "Identify Purpose"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/identify-purpose"
-              },
-              {
-                  "id": "wcag141",
-                  "name": "WCAG 1.4.1",
-                  "shortDescription": {
-                  "text": "Use of Color"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/use-of-color"
-              },
-              {
-                  "id": "wcag1410",
-                  "name": "WCAG 1.4.10",
-                  "shortDescription": {
-                  "text": "Reflow"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/reflow"
-              },
-              {
-                  "id": "wcag1411",
-                  "name": "WCAG 1.4.11",
-                  "shortDescription": {
-                  "text": "Non-text Contrast"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast"
-              },
-              {
-                  "id": "wcag1412",
-                  "name": "WCAG 1.4.12",
-                  "shortDescription": {
-                  "text": "Text Spacing"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/text-spacing"
-              },
-              {
-                  "id": "wcag1413",
-                  "name": "WCAG 1.4.13",
-                  "shortDescription": {
-                  "text": "Content on Hover or Focus"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus"
-              },
-              {
-                  "id": "wcag142",
-                  "name": "WCAG 1.4.2",
-                  "shortDescription": {
-                  "text": "Audio Control"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-control"
-              },
-              {
-                  "id": "wcag143",
-                  "name": "WCAG 1.4.3",
-                  "shortDescription": {
-                  "text": "Contrast (Minimum)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum"
-              },
-              {
-                  "id": "wcag144",
-                  "name": "WCAG 1.4.4",
-                  "shortDescription": {
-                  "text": "Resize text"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/resize-text"
-              },
-              {
-                  "id": "wcag145",
-                  "name": "WCAG 1.4.5",
-                  "shortDescription": {
-                  "text": "Images of Text"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/images-of-text"
-              },
-              {
-                  "id": "wcag146",
-                  "name": "WCAG 1.4.6",
-                  "shortDescription": {
-                  "text": "Contrast (Enhanced)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced"
-              },
-              {
-                  "id": "wcag147",
-                  "name": "WCAG 1.4.7",
-                  "shortDescription": {
-                  "text": "Low or No Background Audio"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio"
-              },
-              {
-                  "id": "wcag148",
-                  "name": "WCAG 1.4.8",
-                  "shortDescription": {
-                  "text": "Visual Presentation"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation"
-              },
-              {
-                  "id": "wcag149",
-                  "name": "WCAG 1.4.9",
-                  "shortDescription": {
-                  "text": "Images of Text (No Exception)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/images-of-text-no-exception"
-              },
-              {
-                  "id": "wcag211",
-                  "name": "WCAG 2.1.1",
-                  "shortDescription": {
-                  "text": "Keyboard"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/keyboard"
-              },
-              {
-                  "id": "wcag212",
-                  "name": "WCAG 2.1.2",
-                  "shortDescription": {
-                  "text": "No Keyboard Trap"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap"
-              },
-              {
-                  "id": "wcag213",
-                  "name": "WCAG 2.1.3",
-                  "shortDescription": {
-                  "text": "Keyboard (No Exception)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/keyboard-no-exception"
-              },
-              {
-                  "id": "wcag214",
-                  "name": "WCAG 2.1.4",
-                  "shortDescription": {
-                  "text": "Character Key Shortcuts"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts"
-              },
-              {
-                  "id": "wcag221",
-                  "name": "WCAG 2.2.1",
-                  "shortDescription": {
-                  "text": "Timing Adjustable"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable"
-              },
-              {
-                  "id": "wcag222",
-                  "name": "WCAG 2.2.2",
-                  "shortDescription": {
-                  "text": "Pause, Stop, Hide"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide"
-              },
-              {
-                  "id": "wcag223",
-                  "name": "WCAG 2.2.3",
-                  "shortDescription": {
-                  "text": "No Timing"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/no-timing"
-              },
-              {
-                  "id": "wcag224",
-                  "name": "WCAG 2.2.4",
-                  "shortDescription": {
-                  "text": "Interruptions"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/interruptions"
-              },
-              {
-                  "id": "wcag225",
-                  "name": "WCAG 2.2.5",
-                  "shortDescription": {
-                  "text": "Re-authenticating"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/re-authenticating"
-              },
-              {
-                  "id": "wcag226",
-                  "name": "WCAG 2.2.6",
-                  "shortDescription": {
-                  "text": "Timeouts"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/timeouts"
-              },
-              {
-                  "id": "wcag231",
-                  "name": "WCAG 2.3.1",
-                  "shortDescription": {
-                  "text": "Three Flashes or Below Threshold"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold"
-              },
-              {
-                  "id": "wcag232",
-                  "name": "WCAG 2.3.2",
-                  "shortDescription": {
-                  "text": "Three Flashes"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/three-flashes"
-              },
-              {
-                  "id": "wcag233",
-                  "name": "WCAG 2.3.3",
-                  "shortDescription": {
-                  "text": "Animation from Interactions"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions"
-              },
-              {
-                  "id": "wcag241",
-                  "name": "WCAG 2.4.1",
-                  "shortDescription": {
-                  "text": "Bypass Blocks"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
-              },
-              {
-                  "id": "wcag2410",
-                  "name": "WCAG 2.4.10",
-                  "shortDescription": {
-                  "text": "Section Headings"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/section-headings"
-              },
-              {
-                  "id": "wcag242",
-                  "name": "WCAG 2.4.2",
-                  "shortDescription": {
-                  "text": "Page Titled"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/page-titled"
-              },
-              {
-                  "id": "wcag243",
-                  "name": "WCAG 2.4.3",
-                  "shortDescription": {
-                  "text": "Focus Order"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/focus-order"
-              },
-              {
-                  "id": "wcag244",
-                  "name": "WCAG 2.4.4",
-                  "shortDescription": {
-                  "text": "Link Purpose (In Context)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context"
-              },
-              {
-                  "id": "wcag245",
-                  "name": "WCAG 2.4.5",
-                  "shortDescription": {
-                  "text": "Multiple Ways"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/multiple-ways"
-              },
-              {
-                  "id": "wcag246",
-                  "name": "WCAG 2.4.6",
-                  "shortDescription": {
-                  "text": "Headings and Labels"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels"
-              },
-              {
-                  "id": "wcag247",
-                  "name": "WCAG 2.4.7",
-                  "shortDescription": {
-                  "text": "Focus Visible"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/focus-visible"
-              },
-              {
-                  "id": "wcag248",
-                  "name": "WCAG 2.4.8",
-                  "shortDescription": {
-                  "text": "Location"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/location"
-              },
-              {
-                  "id": "wcag249",
-                  "name": "WCAG 2.4.9",
-                  "shortDescription": {
-                  "text": "Link Purpose (Link Only)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only"
-              },
-              {
-                  "id": "wcag251",
-                  "name": "WCAG 2.5.1",
-                  "shortDescription": {
-                  "text": "Pointer Gestures"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures"
-              },
-              {
-                  "id": "wcag252",
-                  "name": "WCAG 2.5.2",
-                  "shortDescription": {
-                  "text": "Pointer Cancellation"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation"
-              },
-              {
-                  "id": "wcag253",
-                  "name": "WCAG 2.5.3",
-                  "shortDescription": {
-                  "text": "Label in Name"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/label-in-name"
-              },
-              {
-                  "id": "wcag254",
-                  "name": "WCAG 2.5.4",
-                  "shortDescription": {
-                  "text": "Motion Actuation"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation"
-              },
-              {
-                  "id": "wcag255",
-                  "name": "WCAG 2.5.5",
-                  "shortDescription": {
-                  "text": "Target Size"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/target-size"
-              },
-              {
-                  "id": "wcag256",
-                  "name": "WCAG 2.5.6",
-                  "shortDescription": {
-                  "text": "Concurrent Input Mechanisms"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms"
-              },
-              {
-                  "id": "wcag311",
-                  "name": "WCAG 3.1.1",
-                  "shortDescription": {
-                  "text": "Language of Page"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/language-of-page"
-              },
-              {
-                  "id": "wcag312",
-                  "name": "WCAG 3.1.2",
-                  "shortDescription": {
-                  "text": "Language of Parts"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts"
-              },
-              {
-                  "id": "wcag313",
-                  "name": "WCAG 3.1.3",
-                  "shortDescription": {
-                  "text": "Unusual Words"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/unusual-words"
-              },
-              {
-                  "id": "wcag314",
-                  "name": "WCAG 3.1.4",
-                  "shortDescription": {
-                  "text": "Abbreviations"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/abbreviations"
-              },
-              {
-                  "id": "wcag315",
-                  "name": "WCAG 3.1.5",
-                  "shortDescription": {
-                  "text": "Reading Level"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/reading-level"
-              },
-              {
-                  "id": "wcag316",
-                  "name": "WCAG 3.1.6",
-                  "shortDescription": {
-                  "text": "Pronunciation"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pronunciation"
-              },
-              {
-                  "id": "wcag321",
-                  "name": "WCAG 3.2.1",
-                  "shortDescription": {
-                  "text": "On Focus"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/on-focus"
-              },
-              {
-                  "id": "wcag322",
-                  "name": "WCAG 3.2.2",
-                  "shortDescription": {
-                  "text": "On Input"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/on-input"
-              },
-              {
-                  "id": "wcag323",
-                  "name": "WCAG 3.2.3",
-                  "shortDescription": {
-                  "text": "Consistent Navigation"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation"
-              },
-              {
-                  "id": "wcag324",
-                  "name": "WCAG 3.2.4",
-                  "shortDescription": {
-                  "text": "Consistent Identification"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification"
-              },
-              {
-                  "id": "wcag325",
-                  "name": "WCAG 3.2.5",
-                  "shortDescription": {
-                  "text": "Change on Request"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/change-on-request"
-              },
-              {
-                  "id": "wcag331",
-                  "name": "WCAG 3.3.1",
-                  "shortDescription": {
-                  "text": "Error Identification"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-identification"
-              },
-              {
-                  "id": "wcag332",
-                  "name": "WCAG 3.3.2",
-                  "shortDescription": {
-                  "text": "Labels or Instructions"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions"
-              },
-              {
-                  "id": "wcag333",
-                  "name": "WCAG 3.3.3",
-                  "shortDescription": {
-                  "text": "Error Suggestion"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion"
-              },
-              {
-                  "id": "wcag334",
-                  "name": "WCAG 3.3.4",
-                  "shortDescription": {
-                  "text": "Error Prevention (Legal, Financial, Data)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data"
-              },
-              {
-                  "id": "wcag335",
-                  "name": "WCAG 3.3.5",
-                  "shortDescription": {
-                  "text": "Help"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/help"
-              },
-              {
-                  "id": "wcag336",
-                  "name": "WCAG 3.3.6",
-                  "shortDescription": {
-                  "text": "Error Prevention (All)"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-all"
-              },
-              {
-                  "id": "wcag411",
-                  "name": "WCAG 4.1.1",
-                  "shortDescription": {
-                  "text": "Parsing"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/parsing"
-              },
-              {
-                  "id": "wcag412",
-                  "name": "WCAG 4.1.2",
-                  "shortDescription": {
-                  "text": "Name, Role, Value"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/name-role-value"
-              },
-              {
-                  "id": "wcag413",
-                  "name": "WCAG 4.1.3",
-                  "shortDescription": {
-                  "text": "Status Messages"
-                  },
-                  "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/status-messages"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "html",
+                  "kind": "element"
+                },
+                {
+                  "fullyQualifiedName": "/html",
+                  "kind": "element"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "taxonomies": [
+        {
+          "name": "WCAG",
+          "fullName": "Web Content Accessibility Guidelines (WCAG) 2.1",
+          "organization": "W3C",
+          "informationUri": "https://www.w3.org/TR/WCAG21",
+          "version": "2.1",
+          "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18",
+          "isComprehensive": true,
+          "taxa": [
+            {
+              "id": "best-practice",
+              "name": "Best Practice"
+            },
+            {
+              "id": "wcag111",
+              "name": "WCAG 1.1.1",
+              "shortDescription": {
+                "text": "Non-text Content"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/non-text-content"
+            },
+            {
+              "id": "wcag121",
+              "name": "WCAG 1.2.1",
+              "shortDescription": {
+                "text": "Audio-only and Video-only (Prerecorded)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded"
+            },
+            {
+              "id": "wcag122",
+              "name": "WCAG 1.2.2",
+              "shortDescription": {
+                "text": "Captions (Prerecorded)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded"
+            },
+            {
+              "id": "wcag123",
+              "name": "WCAG 1.2.3",
+              "shortDescription": {
+                "text": "Audio Description or Media Alternative (Prerecorded)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded"
+            },
+            {
+              "id": "wcag124",
+              "name": "WCAG 1.2.4",
+              "shortDescription": {
+                "text": "Captions (Live)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/captions-live"
+            },
+            {
+              "id": "wcag125",
+              "name": "WCAG 1.2.5",
+              "shortDescription": {
+                "text": "Audio Description (Prerecorded)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded"
+            },
+            {
+              "id": "wcag126",
+              "name": "WCAG 1.2.6",
+              "shortDescription": {
+                "text": "Sign Language (Prerecorded)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/sign-language-prerecorded"
+            },
+            {
+              "id": "wcag127",
+              "name": "WCAG 1.2.7",
+              "shortDescription": {
+                "text": "Extended Audio Description (Prerecorded)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/extended-audio-description-prerecorded"
+            },
+            {
+              "id": "wcag128",
+              "name": "WCAG 1.2.8",
+              "shortDescription": {
+                "text": "Media Alternative (Prerecorded)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/media-alternative-prerecorded"
+            },
+            {
+              "id": "wcag129",
+              "name": "WCAG 1.2.9",
+              "shortDescription": {
+                "text": "Audio-only (Live)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-only-live"
+            },
+            {
+              "id": "wcag131",
+              "name": "WCAG 1.3.1",
+              "shortDescription": {
+                "text": "Info and Relationships"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+            },
+            {
+              "id": "wcag132",
+              "name": "WCAG 1.3.2",
+              "shortDescription": {
+                "text": "Meaningful Sequence"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence"
+            },
+            {
+              "id": "wcag133",
+              "name": "WCAG 1.3.3",
+              "shortDescription": {
+                "text": "Sensory Characteristics"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics"
+            },
+            {
+              "id": "wcag134",
+              "name": "WCAG 1.3.4",
+              "shortDescription": {
+                "text": "Orientation"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/orientation"
+            },
+            {
+              "id": "wcag135",
+              "name": "WCAG 1.3.5",
+              "shortDescription": {
+                "text": "Identify Input Purpose"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose"
+            },
+            {
+              "id": "wcag136",
+              "name": "WCAG 1.3.6",
+              "shortDescription": {
+                "text": "Identify Purpose"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/identify-purpose"
+            },
+            {
+              "id": "wcag141",
+              "name": "WCAG 1.4.1",
+              "shortDescription": {
+                "text": "Use of Color"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/use-of-color"
+            },
+            {
+              "id": "wcag1410",
+              "name": "WCAG 1.4.10",
+              "shortDescription": {
+                "text": "Reflow"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/reflow"
+            },
+            {
+              "id": "wcag1411",
+              "name": "WCAG 1.4.11",
+              "shortDescription": {
+                "text": "Non-text Contrast"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast"
+            },
+            {
+              "id": "wcag1412",
+              "name": "WCAG 1.4.12",
+              "shortDescription": {
+                "text": "Text Spacing"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/text-spacing"
+            },
+            {
+              "id": "wcag1413",
+              "name": "WCAG 1.4.13",
+              "shortDescription": {
+                "text": "Content on Hover or Focus"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus"
+            },
+            {
+              "id": "wcag142",
+              "name": "WCAG 1.4.2",
+              "shortDescription": {
+                "text": "Audio Control"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-control"
+            },
+            {
+              "id": "wcag143",
+              "name": "WCAG 1.4.3",
+              "shortDescription": {
+                "text": "Contrast (Minimum)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum"
+            },
+            {
+              "id": "wcag144",
+              "name": "WCAG 1.4.4",
+              "shortDescription": {
+                "text": "Resize text"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/resize-text"
+            },
+            {
+              "id": "wcag145",
+              "name": "WCAG 1.4.5",
+              "shortDescription": {
+                "text": "Images of Text"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/images-of-text"
+            },
+            {
+              "id": "wcag146",
+              "name": "WCAG 1.4.6",
+              "shortDescription": {
+                "text": "Contrast (Enhanced)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced"
+            },
+            {
+              "id": "wcag147",
+              "name": "WCAG 1.4.7",
+              "shortDescription": {
+                "text": "Low or No Background Audio"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio"
+            },
+            {
+              "id": "wcag148",
+              "name": "WCAG 1.4.8",
+              "shortDescription": {
+                "text": "Visual Presentation"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation"
+            },
+            {
+              "id": "wcag149",
+              "name": "WCAG 1.4.9",
+              "shortDescription": {
+                "text": "Images of Text (No Exception)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/images-of-text-no-exception"
+            },
+            {
+              "id": "wcag211",
+              "name": "WCAG 2.1.1",
+              "shortDescription": {
+                "text": "Keyboard"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/keyboard"
+            },
+            {
+              "id": "wcag212",
+              "name": "WCAG 2.1.2",
+              "shortDescription": {
+                "text": "No Keyboard Trap"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap"
+            },
+            {
+              "id": "wcag213",
+              "name": "WCAG 2.1.3",
+              "shortDescription": {
+                "text": "Keyboard (No Exception)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/keyboard-no-exception"
+            },
+            {
+              "id": "wcag214",
+              "name": "WCAG 2.1.4",
+              "shortDescription": {
+                "text": "Character Key Shortcuts"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts"
+            },
+            {
+              "id": "wcag221",
+              "name": "WCAG 2.2.1",
+              "shortDescription": {
+                "text": "Timing Adjustable"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable"
+            },
+            {
+              "id": "wcag222",
+              "name": "WCAG 2.2.2",
+              "shortDescription": {
+                "text": "Pause, Stop, Hide"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide"
+            },
+            {
+              "id": "wcag223",
+              "name": "WCAG 2.2.3",
+              "shortDescription": {
+                "text": "No Timing"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/no-timing"
+            },
+            {
+              "id": "wcag224",
+              "name": "WCAG 2.2.4",
+              "shortDescription": {
+                "text": "Interruptions"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/interruptions"
+            },
+            {
+              "id": "wcag225",
+              "name": "WCAG 2.2.5",
+              "shortDescription": {
+                "text": "Re-authenticating"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/re-authenticating"
+            },
+            {
+              "id": "wcag226",
+              "name": "WCAG 2.2.6",
+              "shortDescription": {
+                "text": "Timeouts"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/timeouts"
+            },
+            {
+              "id": "wcag231",
+              "name": "WCAG 2.3.1",
+              "shortDescription": {
+                "text": "Three Flashes or Below Threshold"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold"
+            },
+            {
+              "id": "wcag232",
+              "name": "WCAG 2.3.2",
+              "shortDescription": {
+                "text": "Three Flashes"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/three-flashes"
+            },
+            {
+              "id": "wcag233",
+              "name": "WCAG 2.3.3",
+              "shortDescription": {
+                "text": "Animation from Interactions"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions"
+            },
+            {
+              "id": "wcag241",
+              "name": "WCAG 2.4.1",
+              "shortDescription": {
+                "text": "Bypass Blocks"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
+            },
+            {
+              "id": "wcag2410",
+              "name": "WCAG 2.4.10",
+              "shortDescription": {
+                "text": "Section Headings"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/section-headings"
+            },
+            {
+              "id": "wcag242",
+              "name": "WCAG 2.4.2",
+              "shortDescription": {
+                "text": "Page Titled"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/page-titled"
+            },
+            {
+              "id": "wcag243",
+              "name": "WCAG 2.4.3",
+              "shortDescription": {
+                "text": "Focus Order"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/focus-order"
+            },
+            {
+              "id": "wcag244",
+              "name": "WCAG 2.4.4",
+              "shortDescription": {
+                "text": "Link Purpose (In Context)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context"
+            },
+            {
+              "id": "wcag245",
+              "name": "WCAG 2.4.5",
+              "shortDescription": {
+                "text": "Multiple Ways"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/multiple-ways"
+            },
+            {
+              "id": "wcag246",
+              "name": "WCAG 2.4.6",
+              "shortDescription": {
+                "text": "Headings and Labels"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels"
+            },
+            {
+              "id": "wcag247",
+              "name": "WCAG 2.4.7",
+              "shortDescription": {
+                "text": "Focus Visible"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/focus-visible"
+            },
+            {
+              "id": "wcag248",
+              "name": "WCAG 2.4.8",
+              "shortDescription": {
+                "text": "Location"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/location"
+            },
+            {
+              "id": "wcag249",
+              "name": "WCAG 2.4.9",
+              "shortDescription": {
+                "text": "Link Purpose (Link Only)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only"
+            },
+            {
+              "id": "wcag251",
+              "name": "WCAG 2.5.1",
+              "shortDescription": {
+                "text": "Pointer Gestures"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures"
+            },
+            {
+              "id": "wcag252",
+              "name": "WCAG 2.5.2",
+              "shortDescription": {
+                "text": "Pointer Cancellation"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation"
+            },
+            {
+              "id": "wcag253",
+              "name": "WCAG 2.5.3",
+              "shortDescription": {
+                "text": "Label in Name"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/label-in-name"
+            },
+            {
+              "id": "wcag254",
+              "name": "WCAG 2.5.4",
+              "shortDescription": {
+                "text": "Motion Actuation"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation"
+            },
+            {
+              "id": "wcag255",
+              "name": "WCAG 2.5.5",
+              "shortDescription": {
+                "text": "Target Size"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/target-size"
+            },
+            {
+              "id": "wcag256",
+              "name": "WCAG 2.5.6",
+              "shortDescription": {
+                "text": "Concurrent Input Mechanisms"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms"
+            },
+            {
+              "id": "wcag311",
+              "name": "WCAG 3.1.1",
+              "shortDescription": {
+                "text": "Language of Page"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/language-of-page"
+            },
+            {
+              "id": "wcag312",
+              "name": "WCAG 3.1.2",
+              "shortDescription": {
+                "text": "Language of Parts"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts"
+            },
+            {
+              "id": "wcag313",
+              "name": "WCAG 3.1.3",
+              "shortDescription": {
+                "text": "Unusual Words"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/unusual-words"
+            },
+            {
+              "id": "wcag314",
+              "name": "WCAG 3.1.4",
+              "shortDescription": {
+                "text": "Abbreviations"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/abbreviations"
+            },
+            {
+              "id": "wcag315",
+              "name": "WCAG 3.1.5",
+              "shortDescription": {
+                "text": "Reading Level"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/reading-level"
+            },
+            {
+              "id": "wcag316",
+              "name": "WCAG 3.1.6",
+              "shortDescription": {
+                "text": "Pronunciation"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pronunciation"
+            },
+            {
+              "id": "wcag321",
+              "name": "WCAG 3.2.1",
+              "shortDescription": {
+                "text": "On Focus"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/on-focus"
+            },
+            {
+              "id": "wcag322",
+              "name": "WCAG 3.2.2",
+              "shortDescription": {
+                "text": "On Input"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/on-input"
+            },
+            {
+              "id": "wcag323",
+              "name": "WCAG 3.2.3",
+              "shortDescription": {
+                "text": "Consistent Navigation"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation"
+            },
+            {
+              "id": "wcag324",
+              "name": "WCAG 3.2.4",
+              "shortDescription": {
+                "text": "Consistent Identification"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification"
+            },
+            {
+              "id": "wcag325",
+              "name": "WCAG 3.2.5",
+              "shortDescription": {
+                "text": "Change on Request"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/change-on-request"
+            },
+            {
+              "id": "wcag331",
+              "name": "WCAG 3.3.1",
+              "shortDescription": {
+                "text": "Error Identification"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-identification"
+            },
+            {
+              "id": "wcag332",
+              "name": "WCAG 3.3.2",
+              "shortDescription": {
+                "text": "Labels or Instructions"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions"
+            },
+            {
+              "id": "wcag333",
+              "name": "WCAG 3.3.3",
+              "shortDescription": {
+                "text": "Error Suggestion"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion"
+            },
+            {
+              "id": "wcag334",
+              "name": "WCAG 3.3.4",
+              "shortDescription": {
+                "text": "Error Prevention (Legal, Financial, Data)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data"
+            },
+            {
+              "id": "wcag335",
+              "name": "WCAG 3.3.5",
+              "shortDescription": {
+                "text": "Help"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/help"
+            },
+            {
+              "id": "wcag336",
+              "name": "WCAG 3.3.6",
+              "shortDescription": {
+                "text": "Error Prevention (All)"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-all"
+            },
+            {
+              "id": "wcag411",
+              "name": "WCAG 4.1.1",
+              "shortDescription": {
+                "text": "Parsing"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/parsing"
+            },
+            {
+              "id": "wcag412",
+              "name": "WCAG 4.1.2",
+              "shortDescription": {
+                "text": "Name, Role, Value"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/name-role-value"
+            },
+            {
+              "id": "wcag413",
+              "name": "WCAG 4.1.3",
+              "shortDescription": {
+                "text": "Status Messages"
+              },
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/status-messages"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test-resources/basic-axe-v3.3.2.sarif
+++ b/src/test-resources/basic-axe-v3.3.2.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.3.2.sarif
+++ b/src/test-resources/basic-axe-v3.3.2.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.3.2.sarif
+++ b/src/test-resources/basic-axe-v3.3.2.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.4.1.sarif
+++ b/src/test-resources/basic-axe-v3.4.1.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.4.1.sarif
+++ b/src/test-resources/basic-axe-v3.4.1.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.4.1.sarif
+++ b/src/test-resources/basic-axe-v3.4.1.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.4.2.sarif
+++ b/src/test-resources/basic-axe-v3.4.2.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.4.2.sarif
+++ b/src/test-resources/basic-axe-v3.4.2.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.4.2.sarif
+++ b/src/test-resources/basic-axe-v3.4.2.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.1.sarif
+++ b/src/test-resources/basic-axe-v3.5.1.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.1.sarif
+++ b/src/test-resources/basic-axe-v3.5.1.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.1.sarif
+++ b/src/test-resources/basic-axe-v3.5.1.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.2.sarif
+++ b/src/test-resources/basic-axe-v3.5.2.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.2.sarif
+++ b/src/test-resources/basic-axe-v3.5.2.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.2.sarif
+++ b/src/test-resources/basic-axe-v3.5.2.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.3.sarif
+++ b/src/test-resources/basic-axe-v3.5.3.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.3.sarif
+++ b/src/test-resources/basic-axe-v3.5.3.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.3.sarif
+++ b/src/test-resources/basic-axe-v3.5.3.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.4.sarif
+++ b/src/test-resources/basic-axe-v3.5.4.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.4.sarif
+++ b/src/test-resources/basic-axe-v3.5.4.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.4.sarif
+++ b/src/test-resources/basic-axe-v3.5.4.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.5.sarif
+++ b/src/test-resources/basic-axe-v3.5.5.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.5.sarif
+++ b/src/test-resources/basic-axe-v3.5.5.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v3.5.5.sarif
+++ b/src/test-resources/basic-axe-v3.5.5.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.0.1.sarif
+++ b/src/test-resources/basic-axe-v4.0.1.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.0.1.sarif
+++ b/src/test-resources/basic-axe-v4.0.1.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.0.1.sarif
+++ b/src/test-resources/basic-axe-v4.0.1.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.0.2.sarif
+++ b/src/test-resources/basic-axe-v4.0.2.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.0.2.sarif
+++ b/src/test-resources/basic-axe-v4.0.2.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.0.2.sarif
+++ b/src/test-resources/basic-axe-v4.0.2.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.1.1.sarif
+++ b/src/test-resources/basic-axe-v4.1.1.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.1.1.sarif
+++ b/src/test-resources/basic-axe-v4.1.1.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.1.1.sarif
+++ b/src/test-resources/basic-axe-v4.1.1.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.2.0.sarif
+++ b/src/test-resources/basic-axe-v4.2.0.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.2.0.sarif
+++ b/src/test-resources/basic-axe-v4.2.0.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.2.0.sarif
+++ b/src/test-resources/basic-axe-v4.2.0.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.3.2.sarif
+++ b/src/test-resources/basic-axe-v4.3.2.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.3.2.sarif
+++ b/src/test-resources/basic-axe-v4.3.2.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.3.2.sarif
+++ b/src/test-resources/basic-axe-v4.3.2.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.4.1.sarif
+++ b/src/test-resources/basic-axe-v4.4.1.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.4.1.sarif
+++ b/src/test-resources/basic-axe-v4.4.1.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.4.1.sarif
+++ b/src/test-resources/basic-axe-v4.4.1.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.6.3.sarif
+++ b/src/test-resources/basic-axe-v4.6.3.sarif
@@ -102,6 +102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.6.3.sarif
+++ b/src/test-resources/basic-axe-v4.6.3.sarif
@@ -101,6 +101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/basic-axe-v4.6.3.sarif
+++ b/src/test-resources/basic-axe-v4.6.3.sarif
@@ -102,8 +102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html><head></head><body>\n</body></html>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.2.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.2.2.sarif
@@ -1780,8 +1780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1814,8 +1812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1848,8 +1844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -1882,8 +1876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -1916,8 +1908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -1950,8 +1940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -1984,8 +1972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2018,8 +2004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2052,8 +2036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2086,8 +2068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2120,8 +2100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2154,8 +2132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2188,8 +2164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2222,8 +2196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2256,8 +2228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2290,8 +2260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2324,8 +2292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2358,8 +2324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2392,8 +2356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2426,8 +2388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2460,8 +2420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2494,8 +2452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2528,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2562,8 +2516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2596,8 +2548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2630,8 +2580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2664,8 +2612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2698,8 +2644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2732,8 +2676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2766,8 +2708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -2800,8 +2740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2834,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -2868,8 +2804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -2902,8 +2836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2936,8 +2868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -2970,8 +2900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3004,8 +2932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3038,8 +2964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3072,8 +2996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3106,8 +3028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3140,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3174,8 +3092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3208,8 +3124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3242,8 +3156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3276,8 +3188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3310,8 +3220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3344,8 +3252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3378,8 +3284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3412,8 +3316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3446,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -3480,8 +3380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3514,8 +3412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -3548,8 +3444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -3582,8 +3476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -3616,8 +3508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -3650,8 +3540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -3684,8 +3572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -3718,8 +3604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -3752,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -3786,8 +3668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -3820,8 +3700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -3854,8 +3732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -3888,8 +3764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3922,8 +3796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -3956,8 +3828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -3990,8 +3860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -4024,8 +3892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4058,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4092,8 +3956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4126,8 +3988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4160,8 +4020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4194,8 +4052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4228,8 +4084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4262,8 +4116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4296,8 +4148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4330,8 +4180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4364,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4398,8 +4244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4432,8 +4276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4466,8 +4308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -4500,8 +4340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -4534,8 +4372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4568,8 +4404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -4602,8 +4436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4636,8 +4468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -4670,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -4704,8 +4532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -4738,8 +4564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -4772,8 +4596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -4806,8 +4628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -4840,8 +4660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -4874,8 +4692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4908,8 +4724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -4942,8 +4756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -4976,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5010,8 +4820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5044,8 +4852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5078,8 +4884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5112,8 +4916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5146,8 +4948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5180,8 +4980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5214,8 +5012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5248,8 +5044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5282,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5316,8 +5108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5350,8 +5140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -5384,8 +5172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -5418,8 +5204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -5452,8 +5236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5486,8 +5268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5520,8 +5300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5554,8 +5332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5588,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5622,8 +5396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5656,8 +5428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5690,8 +5460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -5724,8 +5492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -5758,8 +5524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -5792,8 +5556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -5826,8 +5588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -5860,8 +5620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -5894,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5928,8 +5684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -5962,8 +5716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -5996,8 +5748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6030,8 +5780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6064,8 +5812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6098,8 +5844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -6132,8 +5876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -6166,8 +5908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -6200,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -6234,8 +5972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -6268,8 +6004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -6302,8 +6036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -6336,8 +6068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -6370,8 +6100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -6404,8 +6132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6438,8 +6164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -6472,8 +6196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6506,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -6540,8 +6260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -6574,8 +6292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -6608,8 +6324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6642,8 +6356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6676,8 +6388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6710,8 +6420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6744,8 +6452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6778,8 +6484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6812,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6846,8 +6548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -6880,8 +6580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6914,8 +6612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -6948,8 +6644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -6982,8 +6676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -7016,8 +6708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -7050,8 +6740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -7084,8 +6772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -7118,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -7152,8 +6836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -7186,8 +6868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -7220,8 +6900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -7254,8 +6932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -7288,8 +6964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -7322,8 +6996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -7356,8 +7028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -7390,8 +7060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -7424,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -7458,8 +7124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -7492,8 +7156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -7526,8 +7188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -7560,8 +7220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -7594,8 +7252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7628,8 +7284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -7662,8 +7316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -7696,8 +7348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -7730,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -7764,8 +7412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -7798,8 +7444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -7832,8 +7476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -7866,8 +7508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -7900,8 +7540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -7934,8 +7572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -7968,8 +7604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -8002,8 +7636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -8036,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -8070,8 +7700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -8104,8 +7732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -8138,8 +7764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8172,8 +7796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8206,8 +7828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -8240,8 +7860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -8274,8 +7892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8308,8 +7924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -8342,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8376,8 +7988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -8410,8 +8020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8444,8 +8052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8478,8 +8084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -8512,8 +8116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8546,8 +8148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8580,8 +8180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -8614,8 +8212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8648,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8682,8 +8276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -8716,8 +8308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8750,8 +8340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -8784,8 +8372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8818,8 +8404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -8852,8 +8436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -8886,8 +8468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8920,8 +8500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8954,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8988,8 +8564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -9022,8 +8596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -9056,8 +8628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -9090,8 +8660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -9124,8 +8692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -9158,8 +8724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9192,8 +8756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9226,8 +8788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -9260,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -9294,8 +8852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -9328,8 +8884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -9362,8 +8916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -9396,8 +8948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -9430,8 +8980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -9464,8 +9012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -9498,8 +9044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9532,8 +9076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -9566,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -9600,8 +9140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -9634,8 +9172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -9668,8 +9204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -9702,8 +9236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -9736,8 +9268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9770,8 +9300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -9804,8 +9332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9838,8 +9364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9872,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9906,8 +9428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9940,8 +9460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9974,8 +9492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -10008,8 +9524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -10042,8 +9556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -10076,8 +9588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -10110,8 +9620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -10144,8 +9652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10178,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10212,8 +9716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10246,8 +9748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10280,8 +9780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10314,8 +9812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10348,8 +9844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -10382,8 +9876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10416,8 +9908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10450,8 +9940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10484,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10518,8 +10004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10552,8 +10036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10586,8 +10068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -10620,8 +10100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10654,8 +10132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10688,8 +10164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10722,8 +10196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10756,8 +10228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10790,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10824,8 +10292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10858,8 +10324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10892,8 +10356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10926,8 +10388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10960,8 +10420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10994,8 +10452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11028,8 +10484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11062,8 +10516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11096,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11130,8 +10580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11164,8 +10612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11198,8 +10644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11232,8 +10676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11266,8 +10708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11300,8 +10740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11334,8 +10772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11368,8 +10804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11402,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -11436,8 +10868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11470,8 +10900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11504,8 +10932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11538,8 +10964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11572,8 +10996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11606,8 +11028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11640,8 +11060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11674,8 +11092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11708,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11742,8 +11156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11776,8 +11188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11810,8 +11220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11844,8 +11252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11878,8 +11284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11912,8 +11316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11946,8 +11348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11980,8 +11380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12014,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12048,8 +11444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12082,8 +11476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12116,8 +11508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12150,8 +11540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12184,8 +11572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12218,8 +11604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12252,8 +11636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12286,8 +11668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12320,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12354,8 +11732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12388,8 +11764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12422,8 +11796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12456,8 +11828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12490,8 +11860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12524,8 +11892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12558,8 +11924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12592,8 +11956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12626,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12660,8 +12020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12694,8 +12052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12728,8 +12084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12762,8 +12116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12796,8 +12148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12830,8 +12180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12864,8 +12212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12898,8 +12244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12932,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12966,8 +12308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13000,8 +12340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13034,8 +12372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13068,8 +12404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13102,8 +12436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13136,8 +12468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13170,8 +12500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13204,8 +12532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13238,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13272,8 +12596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13306,8 +12628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13340,8 +12660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13374,8 +12692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13408,8 +12724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13442,8 +12756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13476,8 +12788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -13510,8 +12820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13544,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13578,8 +12884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13612,8 +12916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13646,8 +12948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13680,8 +12980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13714,8 +13012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13748,8 +13044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13782,8 +13076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -13816,8 +13108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -13850,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13884,8 +13172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13918,8 +13204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13952,8 +13236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13986,8 +13268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -14020,8 +13300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -14054,8 +13332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -14088,8 +13364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -14122,8 +13396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -14156,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14190,8 +13460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14224,8 +13492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.2.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.2.2.sarif
@@ -1780,6 +1780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1812,6 +1814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1844,6 +1848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -1876,6 +1882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -1908,6 +1916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -1940,6 +1950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -1972,6 +1984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2004,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2036,6 +2052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2068,6 +2086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2100,6 +2120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2132,6 +2154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2164,6 +2188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2196,6 +2222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2228,6 +2256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2260,6 +2290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2292,6 +2324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2324,6 +2358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2356,6 +2392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2388,6 +2426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2420,6 +2460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2452,6 +2494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2484,6 +2528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2516,6 +2562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2548,6 +2596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2580,6 +2630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2612,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2644,6 +2698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2676,6 +2732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2708,6 +2766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -2740,6 +2800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2772,6 +2834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -2804,6 +2868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -2836,6 +2902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2868,6 +2936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -2900,6 +2970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2932,6 +3004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -2964,6 +3038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2996,6 +3072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3028,6 +3106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3060,6 +3140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3092,6 +3174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3124,6 +3208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3156,6 +3242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3188,6 +3276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3220,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3252,6 +3344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3284,6 +3378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3316,6 +3412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3348,6 +3446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -3380,6 +3480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3412,6 +3514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -3444,6 +3548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -3476,6 +3582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -3508,6 +3616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -3540,6 +3650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -3572,6 +3684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -3604,6 +3718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -3636,6 +3752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -3668,6 +3786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -3700,6 +3820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -3732,6 +3854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -3764,6 +3888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3796,6 +3922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -3828,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -3860,6 +3990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -3892,6 +4024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -3924,6 +4058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3956,6 +4092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3988,6 +4126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4020,6 +4160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4052,6 +4194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4084,6 +4228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4116,6 +4262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4148,6 +4296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4180,6 +4330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4212,6 +4364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4244,6 +4398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4276,6 +4432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4308,6 +4466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -4340,6 +4500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -4372,6 +4534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4404,6 +4568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -4436,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4468,6 +4636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -4500,6 +4670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -4532,6 +4704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -4564,6 +4738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -4596,6 +4772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -4628,6 +4806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -4660,6 +4840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -4692,6 +4874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4724,6 +4908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -4756,6 +4942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -4788,6 +4976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -4820,6 +5010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -4852,6 +5044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -4884,6 +5078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -4916,6 +5112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -4948,6 +5146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -4980,6 +5180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5012,6 +5214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5044,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5076,6 +5282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5108,6 +5316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5140,6 +5350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -5172,6 +5384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -5204,6 +5418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -5236,6 +5452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5268,6 +5486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5300,6 +5520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5332,6 +5554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5364,6 +5588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5396,6 +5622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5428,6 +5656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5460,6 +5690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -5492,6 +5724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -5524,6 +5758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -5556,6 +5792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -5588,6 +5826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -5620,6 +5860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -5652,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5684,6 +5928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -5716,6 +5962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -5748,6 +5996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -5780,6 +6030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -5812,6 +6064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -5844,6 +6098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -5876,6 +6132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -5908,6 +6166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -5940,6 +6200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -5972,6 +6234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -6004,6 +6268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -6036,6 +6302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -6068,6 +6336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -6100,6 +6370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -6132,6 +6404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6164,6 +6438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -6196,6 +6472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6228,6 +6506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -6260,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -6292,6 +6574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -6324,6 +6608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6356,6 +6642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6388,6 +6676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6420,6 +6710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6452,6 +6744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6484,6 +6778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6516,6 +6812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6548,6 +6846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -6580,6 +6880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6612,6 +6914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -6644,6 +6948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -6676,6 +6982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -6708,6 +7016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -6740,6 +7050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -6772,6 +7084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -6804,6 +7118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -6836,6 +7152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -6868,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -6900,6 +7220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -6932,6 +7254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -6964,6 +7288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -6996,6 +7322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -7028,6 +7356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -7060,6 +7390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -7092,6 +7424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -7124,6 +7458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -7156,6 +7492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -7188,6 +7526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -7220,6 +7560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -7252,6 +7594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7284,6 +7628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -7316,6 +7662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -7348,6 +7696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -7380,6 +7730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -7412,6 +7764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -7444,6 +7798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -7476,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -7508,6 +7866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -7540,6 +7900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -7572,6 +7934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -7604,6 +7968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -7636,6 +8002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -7668,6 +8036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -7700,6 +8070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -7732,6 +8104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -7764,6 +8138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7796,6 +8172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -7828,6 +8206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -7860,6 +8240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -7892,6 +8274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -7924,6 +8308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -7956,6 +8342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7988,6 +8376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -8020,6 +8410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8052,6 +8444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8084,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -8116,6 +8512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8148,6 +8546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8180,6 +8580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -8212,6 +8614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8244,6 +8648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8276,6 +8682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -8308,6 +8716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8340,6 +8750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -8372,6 +8784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8404,6 +8818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -8436,6 +8852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -8468,6 +8886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8500,6 +8920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8532,6 +8954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8564,6 +8988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -8596,6 +9022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -8628,6 +9056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -8660,6 +9090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -8692,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -8724,6 +9158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8756,6 +9192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8788,6 +9226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -8820,6 +9260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -8852,6 +9294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -8884,6 +9328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8916,6 +9362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -8948,6 +9396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -8980,6 +9430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -9012,6 +9464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -9044,6 +9498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9076,6 +9532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -9108,6 +9566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -9140,6 +9600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -9172,6 +9634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -9204,6 +9668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -9236,6 +9702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -9268,6 +9736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9300,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -9332,6 +9804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9364,6 +9838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9396,6 +9872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9428,6 +9906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9460,6 +9940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9492,6 +9974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -9524,6 +10008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -9556,6 +10042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -9588,6 +10076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -9620,6 +10110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -9652,6 +10144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9684,6 +10178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9716,6 +10212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9748,6 +10246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9780,6 +10280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9812,6 +10314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9844,6 +10348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -9876,6 +10382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9908,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9940,6 +10450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9972,6 +10484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10004,6 +10518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10036,6 +10552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10068,6 +10586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -10100,6 +10620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10132,6 +10654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10164,6 +10688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10196,6 +10722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10228,6 +10756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10260,6 +10790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10292,6 +10824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10324,6 +10858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10356,6 +10892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10388,6 +10926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10420,6 +10960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10452,6 +10994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -10484,6 +11028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -10516,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -10548,6 +11096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -10580,6 +11130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -10612,6 +11164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -10644,6 +11198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -10676,6 +11232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -10708,6 +11266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -10740,6 +11300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -10772,6 +11334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -10804,6 +11368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -10836,6 +11402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -10868,6 +11436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -10900,6 +11470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -10932,6 +11504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -10964,6 +11538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -10996,6 +11572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11028,6 +11606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11060,6 +11640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11092,6 +11674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11124,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11156,6 +11742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11188,6 +11776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11220,6 +11810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11252,6 +11844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11284,6 +11878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11316,6 +11912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11348,6 +11946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11380,6 +11980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11412,6 +12014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11444,6 +12048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11476,6 +12082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11508,6 +12116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11540,6 +12150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11572,6 +12184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11604,6 +12218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11636,6 +12252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11668,6 +12286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -11700,6 +12320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -11732,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -11764,6 +12388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -11796,6 +12422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -11828,6 +12456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -11860,6 +12490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -11892,6 +12524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -11924,6 +12558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -11956,6 +12592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -11988,6 +12626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12020,6 +12660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12052,6 +12694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12084,6 +12728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12116,6 +12762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12148,6 +12796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12180,6 +12830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12212,6 +12864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12244,6 +12898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12276,6 +12932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12308,6 +12966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12340,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12372,6 +13034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12404,6 +13068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12436,6 +13102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12468,6 +13136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12500,6 +13170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12532,6 +13204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12564,6 +13238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -12596,6 +13272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -12628,6 +13306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -12660,6 +13340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -12692,6 +13374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -12724,6 +13408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -12756,6 +13442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12788,6 +13476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12820,6 +13510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12852,6 +13544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12884,6 +13578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12916,6 +13612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12948,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12980,6 +13680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13012,6 +13714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13044,6 +13748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13076,6 +13782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -13108,6 +13816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -13140,6 +13850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13172,6 +13884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13204,6 +13918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13236,6 +13952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -13268,6 +13986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13300,6 +14020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -13332,6 +14054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13364,6 +14088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13396,6 +14122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -13428,6 +14156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13460,6 +14190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -13492,6 +14224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.2.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.2.2.sarif
@@ -1779,6 +1779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1810,6 +1813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1841,6 +1847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -1872,6 +1881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -1903,6 +1915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -1934,6 +1949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -1965,6 +1983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -1996,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2027,6 +2051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2058,6 +2085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2089,6 +2119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2120,6 +2153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2151,6 +2187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2182,6 +2221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2213,6 +2255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2244,6 +2289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2275,6 +2323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2306,6 +2357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2337,6 +2391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2368,6 +2425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2399,6 +2459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2430,6 +2493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2461,6 +2527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2492,6 +2561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2523,6 +2595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2554,6 +2629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2585,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2616,6 +2697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2647,6 +2731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2678,6 +2765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -2709,6 +2799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2740,6 +2833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -2771,6 +2867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -2802,6 +2901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2833,6 +2935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -2864,6 +2969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2895,6 +3003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -2926,6 +3037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2957,6 +3071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -2988,6 +3105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3019,6 +3139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3050,6 +3173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3081,6 +3207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3112,6 +3241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3143,6 +3275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3174,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3205,6 +3343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3236,6 +3377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3267,6 +3411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3298,6 +3445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -3329,6 +3479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3360,6 +3513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -3391,6 +3547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -3422,6 +3581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -3453,6 +3615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -3484,6 +3649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -3515,6 +3683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -3546,6 +3717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -3577,6 +3751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -3608,6 +3785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -3639,6 +3819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -3670,6 +3853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -3701,6 +3887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3732,6 +3921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -3763,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -3794,6 +3989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -3825,6 +4023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -3856,6 +4057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3887,6 +4091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3918,6 +4125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -3949,6 +4159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -3980,6 +4193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4011,6 +4227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4042,6 +4261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4073,6 +4295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4104,6 +4329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4135,6 +4363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4166,6 +4397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4197,6 +4431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4228,6 +4465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -4259,6 +4499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -4290,6 +4533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4321,6 +4567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -4352,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4383,6 +4635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -4414,6 +4669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -4445,6 +4703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -4476,6 +4737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -4507,6 +4771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -4538,6 +4805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -4569,6 +4839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -4600,6 +4873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4631,6 +4907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -4662,6 +4941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -4693,6 +4975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -4724,6 +5009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -4755,6 +5043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -4786,6 +5077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -4817,6 +5111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -4848,6 +5145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -4879,6 +5179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4910,6 +5213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -4941,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -4972,6 +5281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5003,6 +5315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5034,6 +5349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -5065,6 +5383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -5096,6 +5417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -5127,6 +5451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5158,6 +5485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5189,6 +5519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5220,6 +5553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5251,6 +5587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5282,6 +5621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5313,6 +5655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5344,6 +5689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -5375,6 +5723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -5406,6 +5757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -5437,6 +5791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -5468,6 +5825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -5499,6 +5859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -5530,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5561,6 +5927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -5592,6 +5961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -5623,6 +5995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -5654,6 +6029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -5685,6 +6063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -5716,6 +6097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -5747,6 +6131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -5778,6 +6165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -5809,6 +6199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -5840,6 +6233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -5871,6 +6267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -5902,6 +6301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -5933,6 +6335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -5964,6 +6369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -5995,6 +6403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6026,6 +6437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -6057,6 +6471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6088,6 +6505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -6119,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -6150,6 +6573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -6181,6 +6607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6212,6 +6641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6243,6 +6675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -6274,6 +6709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6305,6 +6743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6336,6 +6777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -6367,6 +6811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6398,6 +6845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -6429,6 +6879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6460,6 +6913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -6491,6 +6947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -6522,6 +6981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -6553,6 +7015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -6584,6 +7049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -6615,6 +7083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -6646,6 +7117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -6677,6 +7151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -6708,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -6739,6 +7219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -6770,6 +7253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -6801,6 +7287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -6832,6 +7321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -6863,6 +7355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -6894,6 +7389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -6925,6 +7423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -6956,6 +7457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -6987,6 +7491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -7018,6 +7525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -7049,6 +7559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -7080,6 +7593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7111,6 +7627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -7142,6 +7661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -7173,6 +7695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -7204,6 +7729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -7235,6 +7763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -7266,6 +7797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -7297,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -7328,6 +7865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -7359,6 +7899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -7390,6 +7933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -7421,6 +7967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -7452,6 +8001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -7483,6 +8035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -7514,6 +8069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -7545,6 +8103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -7576,6 +8137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7607,6 +8171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -7638,6 +8205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -7669,6 +8239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -7700,6 +8273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -7731,6 +8307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -7762,6 +8341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7793,6 +8375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -7824,6 +8409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -7855,6 +8443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7886,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -7917,6 +8511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -7948,6 +8545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7979,6 +8579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -8010,6 +8613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8041,6 +8647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8072,6 +8681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -8103,6 +8715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8134,6 +8749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -8165,6 +8783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8196,6 +8817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -8227,6 +8851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -8258,6 +8885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8289,6 +8919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8320,6 +8953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8351,6 +8987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -8382,6 +9021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -8413,6 +9055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -8444,6 +9089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -8475,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -8506,6 +9157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8537,6 +9191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8568,6 +9225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -8599,6 +9259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -8630,6 +9293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -8661,6 +9327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8692,6 +9361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -8723,6 +9395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -8754,6 +9429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -8785,6 +9463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -8816,6 +9497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -8847,6 +9531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -8878,6 +9565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -8909,6 +9599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -8940,6 +9633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -8971,6 +9667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -9002,6 +9701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -9033,6 +9735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9064,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -9095,6 +9803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9126,6 +9837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9157,6 +9871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9188,6 +9905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9219,6 +9939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9250,6 +9973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -9281,6 +10007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -9312,6 +10041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -9343,6 +10075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -9374,6 +10109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -9405,6 +10143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9436,6 +10177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9467,6 +10211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9498,6 +10245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9529,6 +10279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9560,6 +10313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9591,6 +10347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -9622,6 +10381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9653,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9684,6 +10449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9715,6 +10483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9746,6 +10517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9777,6 +10551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9808,6 +10585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -9839,6 +10619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9870,6 +10653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9901,6 +10687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9932,6 +10721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9963,6 +10755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9994,6 +10789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10025,6 +10823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10056,6 +10857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10087,6 +10891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10118,6 +10925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10149,6 +10959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10180,6 +10993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -10211,6 +11027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -10242,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -10273,6 +11095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -10304,6 +11129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -10335,6 +11163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -10366,6 +11197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -10397,6 +11231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -10428,6 +11265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -10459,6 +11299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -10490,6 +11333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -10521,6 +11367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -10552,6 +11401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -10583,6 +11435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -10614,6 +11469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -10645,6 +11503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -10676,6 +11537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -10707,6 +11571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -10738,6 +11605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -10769,6 +11639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -10800,6 +11673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -10831,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -10862,6 +11741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -10893,6 +11775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -10924,6 +11809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -10955,6 +11843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -10986,6 +11877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11017,6 +11911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11048,6 +11945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11079,6 +11979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11110,6 +12013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11141,6 +12047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11172,6 +12081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11203,6 +12115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11234,6 +12149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11265,6 +12183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11296,6 +12217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11327,6 +12251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11358,6 +12285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -11389,6 +12319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -11420,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -11451,6 +12387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -11482,6 +12421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -11513,6 +12455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -11544,6 +12489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -11575,6 +12523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -11606,6 +12557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -11637,6 +12591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -11668,6 +12625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -11699,6 +12659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -11730,6 +12693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11761,6 +12727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11792,6 +12761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11823,6 +12795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11854,6 +12829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11885,6 +12863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -11916,6 +12897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -11947,6 +12931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -11978,6 +12965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12009,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12040,6 +13033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12071,6 +13067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12102,6 +13101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12133,6 +13135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12164,6 +13169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12195,6 +13203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12226,6 +13237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -12257,6 +13271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -12288,6 +13305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -12319,6 +13339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -12350,6 +13373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -12381,6 +13407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -12412,6 +13441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12443,6 +13475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12474,6 +13509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12505,6 +13543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12536,6 +13577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12567,6 +13611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12598,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12629,6 +13679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12660,6 +13713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12691,6 +13747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12722,6 +13781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12753,6 +13815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12784,6 +13849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12815,6 +13883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12846,6 +13917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12877,6 +13951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12908,6 +13985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12939,6 +14019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12970,6 +14053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13001,6 +14087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -13032,6 +14121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -13063,6 +14155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13094,6 +14189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -13125,6 +14223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.3.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.3.2.sarif
@@ -1962,8 +1962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2000,8 +1998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2038,8 +2034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2076,8 +2070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2114,8 +2106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2152,8 +2142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2190,8 +2178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2228,8 +2214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2266,8 +2250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2304,8 +2286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2342,8 +2322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2380,8 +2358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2418,8 +2394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2456,8 +2430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2494,8 +2466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2532,8 +2502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2570,8 +2538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2608,8 +2574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2646,8 +2610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2684,8 +2646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2722,8 +2682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2760,8 +2718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2798,8 +2754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2836,8 +2790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2874,8 +2826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2912,8 +2862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2950,8 +2898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2988,8 +2934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3026,8 +2970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3064,8 +3006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3102,8 +3042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3140,8 +3078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3178,8 +3114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3216,8 +3150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3254,8 +3186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3292,8 +3222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3330,8 +3258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3368,8 +3294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3406,8 +3330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3444,8 +3366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3482,8 +3402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3520,8 +3438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3558,8 +3474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3596,8 +3510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3634,8 +3546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3672,8 +3582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3710,8 +3618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3748,8 +3654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3786,8 +3690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3824,8 +3726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3862,8 +3762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3900,8 +3798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3938,8 +3834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3976,8 +3870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4014,8 +3906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4052,8 +3942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4090,8 +3978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4128,8 +4014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4166,8 +4050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4204,8 +4086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4242,8 +4122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4280,8 +4158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4318,8 +4194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4356,8 +4230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4394,8 +4266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4432,8 +4302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4470,8 +4338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4508,8 +4374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4546,8 +4410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4584,8 +4446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4622,8 +4482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4660,8 +4518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4698,8 +4554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4736,8 +4590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4774,8 +4626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4812,8 +4662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4850,8 +4698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4888,8 +4734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4926,8 +4770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4964,8 +4806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5002,8 +4842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5040,8 +4878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5078,8 +4914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5116,8 +4950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5154,8 +4986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5192,8 +5022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5230,8 +5058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5268,8 +5094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5306,8 +5130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5344,8 +5166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5382,8 +5202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5420,8 +5238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5458,8 +5274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5496,8 +5310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5534,8 +5346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5572,8 +5382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5610,8 +5418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5648,8 +5454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5686,8 +5490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5724,8 +5526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5762,8 +5562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5800,8 +5598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5838,8 +5634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5876,8 +5670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5914,8 +5706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5952,8 +5742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5990,8 +5778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6028,8 +5814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6066,8 +5850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6104,8 +5886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6142,8 +5922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6180,8 +5958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6218,8 +5994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6256,8 +6030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6294,8 +6066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6332,8 +6102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6370,8 +6138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6408,8 +6174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6446,8 +6210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6484,8 +6246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6522,8 +6282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6560,8 +6318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6598,8 +6354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6636,8 +6390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6674,8 +6426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6712,8 +6462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6750,8 +6498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6788,8 +6534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6826,8 +6570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6864,8 +6606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6902,8 +6642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6940,8 +6678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6978,8 +6714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7016,8 +6750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7054,8 +6786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7092,8 +6822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7130,8 +6858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7168,8 +6894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7206,8 +6930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7244,8 +6966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7282,8 +7002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7320,8 +7038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7358,8 +7074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7396,8 +7110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7434,8 +7146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7472,8 +7182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7510,8 +7218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7548,8 +7254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7586,8 +7290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7624,8 +7326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7662,8 +7362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7700,8 +7398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7738,8 +7434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7776,8 +7470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7814,8 +7506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7852,8 +7542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7890,8 +7578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7928,8 +7614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7966,8 +7650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8004,8 +7686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -8042,8 +7722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8080,8 +7758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -8118,8 +7794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8156,8 +7830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -8194,8 +7866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -8232,8 +7902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -8270,8 +7938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -8308,8 +7974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8346,8 +8010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8384,8 +8046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -8422,8 +8082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -8460,8 +8118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8498,8 +8154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8536,8 +8190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8574,8 +8226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8612,8 +8262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8650,8 +8298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8688,8 +8334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8726,8 +8370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8764,8 +8406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8802,8 +8442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8840,8 +8478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8878,8 +8514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8916,8 +8550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8954,8 +8586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8992,8 +8622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9030,8 +8658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9068,8 +8694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9106,8 +8730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9144,8 +8766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -9182,8 +8802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9220,8 +8838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -9258,8 +8874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9296,8 +8910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -9334,8 +8946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -9372,8 +8982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9410,8 +9018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -9448,8 +9054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9486,8 +9090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -9524,8 +9126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9562,8 +9162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9600,8 +9198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -9638,8 +9234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9676,8 +9270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9714,8 +9306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9752,8 +9342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9790,8 +9378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9828,8 +9414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9866,8 +9450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9904,8 +9486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9942,8 +9522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -9980,8 +9558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -10018,8 +9594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -10056,8 +9630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -10094,8 +9666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -10132,8 +9702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -10170,8 +9738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -10208,8 +9774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -10246,8 +9810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -10284,8 +9846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -10322,8 +9882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -10360,8 +9918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -10398,8 +9954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -10436,8 +9990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -10474,8 +10026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -10512,8 +10062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -10550,8 +10098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -10588,8 +10134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10626,8 +10170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10664,8 +10206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10702,8 +10242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10740,8 +10278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10778,8 +10314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10816,8 +10350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10854,8 +10386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10892,8 +10422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10930,8 +10458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10968,8 +10494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -11006,8 +10530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -11044,8 +10566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -11082,8 +10602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -11120,8 +10638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -11158,8 +10674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -11196,8 +10710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -11234,8 +10746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -11272,8 +10782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -11310,8 +10818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -11348,8 +10854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -11386,8 +10890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11424,8 +10926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11462,8 +10962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11500,8 +10998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11538,8 +11034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11576,8 +11070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -11614,8 +11106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -11652,8 +11142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -11690,8 +11178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -11728,8 +11214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -11766,8 +11250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -11804,8 +11286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11842,8 +11322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11880,8 +11358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -11918,8 +11394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -11956,8 +11430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11994,8 +11466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -12032,8 +11502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -12070,8 +11538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -12108,8 +11574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -12146,8 +11610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -12184,8 +11646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -12222,8 +11682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12260,8 +11718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12298,8 +11754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12336,8 +11790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12374,8 +11826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12412,8 +11862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12450,8 +11898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12488,8 +11934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12526,8 +11970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12564,8 +12006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12602,8 +12042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12640,8 +12078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12678,8 +12114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12716,8 +12150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12754,8 +12186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12792,8 +12222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12830,8 +12258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12868,8 +12294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12906,8 +12330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12944,8 +12366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12982,8 +12402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -13020,8 +12438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13058,8 +12474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -13096,8 +12510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.3.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.3.2.sarif
@@ -1961,6 +1961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1996,6 +1999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2031,6 +2037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2066,6 +2075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2101,6 +2113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2136,6 +2151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2171,6 +2189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2206,6 +2227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2241,6 +2265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2276,6 +2303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2311,6 +2341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2346,6 +2379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2381,6 +2417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2416,6 +2455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2451,6 +2493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2486,6 +2531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2521,6 +2569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2556,6 +2607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2591,6 +2645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2626,6 +2683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2661,6 +2721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2696,6 +2759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2731,6 +2797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2766,6 +2835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2801,6 +2873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2836,6 +2911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2871,6 +2949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2906,6 +2987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2941,6 +3025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2976,6 +3063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3011,6 +3101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3046,6 +3139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3081,6 +3177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3116,6 +3215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3151,6 +3253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3186,6 +3291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3221,6 +3329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3256,6 +3367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3291,6 +3405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3326,6 +3443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3361,6 +3481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3396,6 +3519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3431,6 +3557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3466,6 +3595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3501,6 +3633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3536,6 +3671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3571,6 +3709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3606,6 +3747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3641,6 +3785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3676,6 +3823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3711,6 +3861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3746,6 +3899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3781,6 +3937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3816,6 +3975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3851,6 +4013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3886,6 +4051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3921,6 +4089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3956,6 +4127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -3991,6 +4165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4026,6 +4203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4061,6 +4241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4096,6 +4279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4131,6 +4317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4166,6 +4355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4201,6 +4393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4236,6 +4431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4271,6 +4469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4306,6 +4507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4341,6 +4545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4376,6 +4583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4411,6 +4621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4446,6 +4659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4481,6 +4697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4516,6 +4735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4551,6 +4773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4586,6 +4811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4621,6 +4849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4656,6 +4887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4691,6 +4925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4726,6 +4963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4761,6 +5001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4796,6 +5039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4831,6 +5077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4866,6 +5115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4901,6 +5153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4936,6 +5191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4971,6 +5229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5006,6 +5267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5041,6 +5305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5076,6 +5343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5111,6 +5381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5146,6 +5419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5181,6 +5457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5216,6 +5495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5251,6 +5533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5286,6 +5571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5321,6 +5609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5356,6 +5647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5391,6 +5685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5426,6 +5723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5461,6 +5761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5496,6 +5799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5531,6 +5837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5566,6 +5875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5601,6 +5913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5636,6 +5951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5671,6 +5989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5706,6 +6027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5741,6 +6065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5776,6 +6103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5811,6 +6141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5846,6 +6179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5881,6 +6217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5916,6 +6255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -5951,6 +6293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -5986,6 +6331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6021,6 +6369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6056,6 +6407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6091,6 +6445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6126,6 +6483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6161,6 +6521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6196,6 +6559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6231,6 +6597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6266,6 +6635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6301,6 +6673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6336,6 +6711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6371,6 +6749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6406,6 +6787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6441,6 +6825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6476,6 +6863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6511,6 +6901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6546,6 +6939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6581,6 +6977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6616,6 +7015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6651,6 +7053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6686,6 +7091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -6721,6 +7129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -6756,6 +7167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -6791,6 +7205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -6826,6 +7243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -6861,6 +7281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -6896,6 +7319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -6931,6 +7357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -6966,6 +7395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7001,6 +7433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7036,6 +7471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7071,6 +7509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7106,6 +7547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7141,6 +7585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7176,6 +7623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7211,6 +7661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7246,6 +7699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7281,6 +7737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7316,6 +7775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7351,6 +7813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7386,6 +7851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7421,6 +7889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7456,6 +7927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7491,6 +7965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7526,6 +8003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7561,6 +8041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7596,6 +8079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -7631,6 +8117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7666,6 +8155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -7701,6 +8193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -7736,6 +8231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -7771,6 +8269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -7806,6 +8307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7841,6 +8345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7876,6 +8383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -7911,6 +8421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -7946,6 +8459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7981,6 +8497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8016,6 +8535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8051,6 +8573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8086,6 +8611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8121,6 +8649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8156,6 +8687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8191,6 +8725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8226,6 +8763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8261,6 +8801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8296,6 +8839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8331,6 +8877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8366,6 +8915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8401,6 +8953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8436,6 +8991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8471,6 +9029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8506,6 +9067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8541,6 +9105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8576,6 +9143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -8611,6 +9181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8646,6 +9219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -8681,6 +9257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8716,6 +9295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -8751,6 +9333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -8786,6 +9371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8821,6 +9409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -8856,6 +9447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8891,6 +9485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8926,6 +9523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8961,6 +9561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8996,6 +9599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -9031,6 +9637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9066,6 +9675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9101,6 +9713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9136,6 +9751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9171,6 +9789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9206,6 +9827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9241,6 +9865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9276,6 +9903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9311,6 +9941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -9346,6 +9979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -9381,6 +10017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -9416,6 +10055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -9451,6 +10093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -9486,6 +10131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -9521,6 +10169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -9556,6 +10207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -9591,6 +10245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9626,6 +10283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9661,6 +10321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9696,6 +10359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9731,6 +10397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9766,6 +10435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9801,6 +10473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9836,6 +10511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9871,6 +10549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9906,6 +10587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9941,6 +10625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9976,6 +10663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10011,6 +10701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10046,6 +10739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10081,6 +10777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10116,6 +10815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10151,6 +10853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10186,6 +10891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10221,6 +10929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10256,6 +10967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10291,6 +11005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10326,6 +11043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10361,6 +11081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10396,6 +11119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10431,6 +11157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10466,6 +11195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10501,6 +11233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10536,6 +11271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10571,6 +11309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10606,6 +11347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10641,6 +11385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10676,6 +11423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10711,6 +11461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10746,6 +11499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10781,6 +11537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10816,6 +11575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10851,6 +11613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10886,6 +11651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10921,6 +11689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10956,6 +11727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10991,6 +11765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -11026,6 +11803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11061,6 +11841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11096,6 +11879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -11131,6 +11917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -11166,6 +11955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11201,6 +11993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -11236,6 +12031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -11271,6 +12069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -11306,6 +12107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -11341,6 +12145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -11376,6 +12183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11411,6 +12221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11446,6 +12259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11481,6 +12297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11516,6 +12335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11551,6 +12373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11586,6 +12411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11621,6 +12449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11656,6 +12487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11691,6 +12525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11726,6 +12563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11761,6 +12601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -11796,6 +12639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11831,6 +12677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11866,6 +12715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11901,6 +12753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11936,6 +12791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11971,6 +12829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12006,6 +12867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12041,6 +12905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12076,6 +12943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12111,6 +12981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12146,6 +13019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -12181,6 +13057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12216,6 +13095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.3.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.3.2.sarif
@@ -1962,6 +1962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1998,6 +2000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2034,6 +2038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2070,6 +2076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2106,6 +2114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2142,6 +2152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2178,6 +2190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2214,6 +2228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2250,6 +2266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2286,6 +2304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2322,6 +2342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2358,6 +2380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2394,6 +2418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2430,6 +2456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2466,6 +2494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2502,6 +2532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2538,6 +2570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2574,6 +2608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2610,6 +2646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2646,6 +2684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2682,6 +2722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2718,6 +2760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2754,6 +2798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2790,6 +2836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2826,6 +2874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2862,6 +2912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2898,6 +2950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2934,6 +2988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2970,6 +3026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3006,6 +3064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3042,6 +3102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3078,6 +3140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3114,6 +3178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3150,6 +3216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3186,6 +3254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3222,6 +3292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3258,6 +3330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3294,6 +3368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3330,6 +3406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3366,6 +3444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3402,6 +3482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3438,6 +3520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3474,6 +3558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3510,6 +3596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3546,6 +3634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3582,6 +3672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3618,6 +3710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3654,6 +3748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3690,6 +3786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3726,6 +3824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3762,6 +3862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3798,6 +3900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3834,6 +3938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3870,6 +3976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3906,6 +4014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3942,6 +4052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3978,6 +4090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4014,6 +4128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4050,6 +4166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4086,6 +4204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4122,6 +4242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4158,6 +4280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4194,6 +4318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4230,6 +4356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4266,6 +4394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4302,6 +4432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4338,6 +4470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4374,6 +4508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4410,6 +4546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4446,6 +4584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4482,6 +4622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4518,6 +4660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4554,6 +4698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4590,6 +4736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4626,6 +4774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4662,6 +4812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4698,6 +4850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4734,6 +4888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4770,6 +4926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4806,6 +4964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4842,6 +5002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4878,6 +5040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4914,6 +5078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4950,6 +5116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4986,6 +5154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5022,6 +5192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5058,6 +5230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5094,6 +5268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5130,6 +5306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5166,6 +5344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5202,6 +5382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5238,6 +5420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5274,6 +5458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5310,6 +5496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5346,6 +5534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5382,6 +5572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5418,6 +5610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5454,6 +5648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5490,6 +5686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5526,6 +5724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5562,6 +5762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5598,6 +5800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5634,6 +5838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5670,6 +5876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5706,6 +5914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5742,6 +5952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5778,6 +5990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5814,6 +6028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5850,6 +6066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5886,6 +6104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5922,6 +6142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5958,6 +6180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5994,6 +6218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6030,6 +6256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6066,6 +6294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6102,6 +6332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6138,6 +6370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6174,6 +6408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6210,6 +6446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6246,6 +6484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6282,6 +6522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6318,6 +6560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6354,6 +6598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6390,6 +6636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6426,6 +6674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6462,6 +6712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6498,6 +6750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6534,6 +6788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6570,6 +6826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6606,6 +6864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6642,6 +6902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6678,6 +6940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6714,6 +6978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6750,6 +7016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6786,6 +7054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6822,6 +7092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -6858,6 +7130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -6894,6 +7168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -6930,6 +7206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -6966,6 +7244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7002,6 +7282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7038,6 +7320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7074,6 +7358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7110,6 +7396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7146,6 +7434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7182,6 +7472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7218,6 +7510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7254,6 +7548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7290,6 +7586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7326,6 +7624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7362,6 +7662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7398,6 +7700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7434,6 +7738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7470,6 +7776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7506,6 +7814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7542,6 +7852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7578,6 +7890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7614,6 +7928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7650,6 +7966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7686,6 +8004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7722,6 +8042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7758,6 +8080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -7794,6 +8118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7830,6 +8156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -7866,6 +8194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -7902,6 +8232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -7938,6 +8270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -7974,6 +8308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8010,6 +8346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8046,6 +8384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -8082,6 +8422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -8118,6 +8460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8154,6 +8498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8190,6 +8536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8226,6 +8574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8262,6 +8612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8298,6 +8650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8334,6 +8688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8370,6 +8726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8406,6 +8764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8442,6 +8802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8478,6 +8840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8514,6 +8878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8550,6 +8916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8586,6 +8954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8622,6 +8992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8658,6 +9030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8694,6 +9068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8730,6 +9106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8766,6 +9144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -8802,6 +9182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8838,6 +9220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -8874,6 +9258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8910,6 +9296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -8946,6 +9334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -8982,6 +9372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9018,6 +9410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -9054,6 +9448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9090,6 +9486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -9126,6 +9524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9162,6 +9562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9198,6 +9600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -9234,6 +9638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9270,6 +9676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9306,6 +9714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9342,6 +9752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9378,6 +9790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9414,6 +9828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9450,6 +9866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9486,6 +9904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9522,6 +9942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -9558,6 +9980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -9594,6 +10018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -9630,6 +10056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -9666,6 +10094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -9702,6 +10132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -9738,6 +10170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -9774,6 +10208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -9810,6 +10246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9846,6 +10284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9882,6 +10322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9918,6 +10360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9954,6 +10398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9990,6 +10436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -10026,6 +10474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -10062,6 +10512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -10098,6 +10550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -10134,6 +10588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10170,6 +10626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10206,6 +10664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10242,6 +10702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10278,6 +10740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10314,6 +10778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10350,6 +10816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10386,6 +10854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10422,6 +10892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10458,6 +10930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10494,6 +10968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10530,6 +11006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10566,6 +11044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10602,6 +11082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10638,6 +11120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10674,6 +11158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10710,6 +11196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10746,6 +11234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10782,6 +11272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10818,6 +11310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10854,6 +11348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10890,6 +11386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10926,6 +11424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10962,6 +11462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10998,6 +11500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11034,6 +11538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11070,6 +11576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -11106,6 +11614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -11142,6 +11652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -11178,6 +11690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -11214,6 +11728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -11250,6 +11766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -11286,6 +11804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11322,6 +11842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11358,6 +11880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -11394,6 +11918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -11430,6 +11956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11466,6 +11994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -11502,6 +12032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -11538,6 +12070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -11574,6 +12108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -11610,6 +12146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -11646,6 +12184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11682,6 +12222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11718,6 +12260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11754,6 +12298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11790,6 +12336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11826,6 +12374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11862,6 +12412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11898,6 +12450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11934,6 +12488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11970,6 +12526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12006,6 +12564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12042,6 +12602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12078,6 +12640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12114,6 +12678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12150,6 +12716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12186,6 +12754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12222,6 +12792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12258,6 +12830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12294,6 +12868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12330,6 +12906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12366,6 +12944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12402,6 +12982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12438,6 +13020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -12474,6 +13058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12510,6 +13096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.4.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.1.sarif
@@ -1914,8 +1914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1952,8 +1950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1990,8 +1986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2028,8 +2022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2066,8 +2058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2104,8 +2094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2142,8 +2130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2180,8 +2166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2218,8 +2202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2256,8 +2238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2294,8 +2274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2332,8 +2310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2370,8 +2346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2408,8 +2382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2446,8 +2418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2484,8 +2454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2522,8 +2490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2560,8 +2526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2598,8 +2562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2636,8 +2598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2674,8 +2634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2712,8 +2670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2750,8 +2706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2788,8 +2742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2826,8 +2778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2864,8 +2814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2902,8 +2850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2940,8 +2886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2978,8 +2922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3016,8 +2958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3054,8 +2994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3092,8 +3030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3130,8 +3066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3168,8 +3102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3206,8 +3138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3244,8 +3174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3282,8 +3210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3320,8 +3246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3358,8 +3282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3396,8 +3318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3434,8 +3354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3472,8 +3390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3510,8 +3426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3548,8 +3462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3586,8 +3498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3624,8 +3534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3662,8 +3570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3700,8 +3606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3738,8 +3642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3776,8 +3678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3814,8 +3714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3852,8 +3750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3890,8 +3786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3928,8 +3822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3966,8 +3858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4004,8 +3894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4042,8 +3930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4080,8 +3966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4118,8 +4002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4156,8 +4038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4194,8 +4074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4232,8 +4110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4270,8 +4146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4308,8 +4182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4346,8 +4218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4384,8 +4254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4422,8 +4290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4460,8 +4326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4498,8 +4362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4536,8 +4398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4574,8 +4434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4612,8 +4470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4650,8 +4506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4688,8 +4542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4726,8 +4578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4764,8 +4614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4802,8 +4650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4840,8 +4686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4878,8 +4722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4916,8 +4758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4954,8 +4794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4992,8 +4830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5030,8 +4866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5068,8 +4902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5106,8 +4938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5144,8 +4974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5182,8 +5010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5220,8 +5046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5258,8 +5082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5296,8 +5118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5334,8 +5154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5372,8 +5190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5410,8 +5226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5448,8 +5262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5486,8 +5298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5524,8 +5334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5562,8 +5370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5600,8 +5406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5638,8 +5442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5676,8 +5478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5714,8 +5514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5752,8 +5550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5790,8 +5586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5828,8 +5622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5866,8 +5658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5904,8 +5694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5942,8 +5730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5980,8 +5766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6018,8 +5802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6056,8 +5838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6094,8 +5874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6132,8 +5910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6170,8 +5946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6208,8 +5982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6246,8 +6018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6284,8 +6054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6322,8 +6090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6360,8 +6126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6398,8 +6162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6436,8 +6198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6474,8 +6234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6512,8 +6270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6550,8 +6306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6588,8 +6342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6626,8 +6378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6664,8 +6414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6702,8 +6450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6740,8 +6486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6778,8 +6522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6816,8 +6558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6854,8 +6594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6892,8 +6630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6930,8 +6666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6968,8 +6702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7006,8 +6738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7044,8 +6774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7082,8 +6810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7120,8 +6846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7158,8 +6882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7196,8 +6918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7234,8 +6954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7272,8 +6990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7310,8 +7026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7348,8 +7062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7386,8 +7098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7424,8 +7134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7462,8 +7170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7500,8 +7206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7538,8 +7242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7576,8 +7278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7614,8 +7314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7652,8 +7350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7690,8 +7386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7728,8 +7422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7766,8 +7458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7804,8 +7494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7842,8 +7530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7880,8 +7566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7918,8 +7602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7956,8 +7638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7994,8 +7674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8032,8 +7710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -8070,8 +7746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8108,8 +7782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -8146,8 +7818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -8184,8 +7854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -8222,8 +7890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -8260,8 +7926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8298,8 +7962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8336,8 +7998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -8374,8 +8034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -8412,8 +8070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8450,8 +8106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8488,8 +8142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8526,8 +8178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8564,8 +8214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8602,8 +8250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8640,8 +8286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8678,8 +8322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8716,8 +8358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8754,8 +8394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8792,8 +8430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8830,8 +8466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8868,8 +8502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8906,8 +8538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8944,8 +8574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8982,8 +8610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9020,8 +8646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9058,8 +8682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9096,8 +8718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -9134,8 +8754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9172,8 +8790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -9210,8 +8826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9248,8 +8862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -9286,8 +8898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -9324,8 +8934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9362,8 +8970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -9400,8 +9006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9438,8 +9042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -9476,8 +9078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9514,8 +9114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9552,8 +9150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -9590,8 +9186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9628,8 +9222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9666,8 +9258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9704,8 +9294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9742,8 +9330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9780,8 +9366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9818,8 +9402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9856,8 +9438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9894,8 +9474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -9932,8 +9510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -9970,8 +9546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -10008,8 +9582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -10046,8 +9618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -10084,8 +9654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -10122,8 +9690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -10160,8 +9726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -10198,8 +9762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -10236,8 +9798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -10274,8 +9834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -10312,8 +9870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -10350,8 +9906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -10388,8 +9942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -10426,8 +9978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -10464,8 +10014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -10502,8 +10050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -10540,8 +10086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10578,8 +10122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10616,8 +10158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10654,8 +10194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10692,8 +10230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10730,8 +10266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10768,8 +10302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10806,8 +10338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10844,8 +10374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10882,8 +10410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10920,8 +10446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10958,8 +10482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10996,8 +10518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -11034,8 +10554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -11072,8 +10590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -11110,8 +10626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -11148,8 +10662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -11186,8 +10698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -11224,8 +10734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -11262,8 +10770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -11300,8 +10806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -11338,8 +10842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11376,8 +10878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11414,8 +10914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11452,8 +10950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11490,8 +10986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11528,8 +11022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -11566,8 +11058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -11604,8 +11094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -11642,8 +11130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -11680,8 +11166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -11718,8 +11202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -11756,8 +11238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11794,8 +11274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11832,8 +11310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -11870,8 +11346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -11908,8 +11382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11946,8 +11418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -11984,8 +11454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -12022,8 +11490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -12060,8 +11526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -12098,8 +11562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -12136,8 +11598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -12174,8 +11634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12212,8 +11670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12250,8 +11706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12288,8 +11742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12326,8 +11778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12364,8 +11814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12402,8 +11850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12440,8 +11886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12478,8 +11922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12516,8 +11958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12554,8 +11994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12592,8 +12030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12630,8 +12066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12668,8 +12102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12706,8 +12138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12744,8 +12174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12782,8 +12210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12820,8 +12246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12858,8 +12282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12896,8 +12318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12934,8 +12354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12972,8 +12390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13010,8 +12426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -13048,8 +12462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.4.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.1.sarif
@@ -1914,6 +1914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1950,6 +1952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1986,6 +1990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2022,6 +2028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2058,6 +2066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2094,6 +2104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2130,6 +2142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2166,6 +2180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2202,6 +2218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2238,6 +2256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2274,6 +2294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2310,6 +2332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2346,6 +2370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2382,6 +2408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2418,6 +2446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2454,6 +2484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2490,6 +2522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2526,6 +2560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2562,6 +2598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2598,6 +2636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2634,6 +2674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2670,6 +2712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2706,6 +2750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2742,6 +2788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2778,6 +2826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2814,6 +2864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2850,6 +2902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2886,6 +2940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2922,6 +2978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2958,6 +3016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -2994,6 +3054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3030,6 +3092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3066,6 +3130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3102,6 +3168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3138,6 +3206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3174,6 +3244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3210,6 +3282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3246,6 +3320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3282,6 +3358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3318,6 +3396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3354,6 +3434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3390,6 +3472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3426,6 +3510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3462,6 +3548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3498,6 +3586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3534,6 +3624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3570,6 +3662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3606,6 +3700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3642,6 +3738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3678,6 +3776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3714,6 +3814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3750,6 +3852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3786,6 +3890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3822,6 +3928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3858,6 +3966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3894,6 +4004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3930,6 +4042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3966,6 +4080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4002,6 +4118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4038,6 +4156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4074,6 +4194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4110,6 +4232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4146,6 +4270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4182,6 +4308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4218,6 +4346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4254,6 +4384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4290,6 +4422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4326,6 +4460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4362,6 +4498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4398,6 +4536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4434,6 +4574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4470,6 +4612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4506,6 +4650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4542,6 +4688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4578,6 +4726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4614,6 +4764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4650,6 +4802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4686,6 +4840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4722,6 +4878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4758,6 +4916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4794,6 +4954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4830,6 +4992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4866,6 +5030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4902,6 +5068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4938,6 +5106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4974,6 +5144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5010,6 +5182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5046,6 +5220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5082,6 +5258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5118,6 +5296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5154,6 +5334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5190,6 +5372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5226,6 +5410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5262,6 +5448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5298,6 +5486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5334,6 +5524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5370,6 +5562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5406,6 +5600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5442,6 +5638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5478,6 +5676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5514,6 +5714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5550,6 +5752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5586,6 +5790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5622,6 +5828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5658,6 +5866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5694,6 +5904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5730,6 +5942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5766,6 +5980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5802,6 +6018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5838,6 +6056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5874,6 +6094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5910,6 +6132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5946,6 +6170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5982,6 +6208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6018,6 +6246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6054,6 +6284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6090,6 +6322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6126,6 +6360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6162,6 +6398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6198,6 +6436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6234,6 +6474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6270,6 +6512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6306,6 +6550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6342,6 +6588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6378,6 +6626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6414,6 +6664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6450,6 +6702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6486,6 +6740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6522,6 +6778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6558,6 +6816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6594,6 +6854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6630,6 +6892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6666,6 +6930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6702,6 +6968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6738,6 +7006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6774,6 +7044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -6810,6 +7082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -6846,6 +7120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -6882,6 +7158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -6918,6 +7196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -6954,6 +7234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -6990,6 +7272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7026,6 +7310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7062,6 +7348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7098,6 +7386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7134,6 +7424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7170,6 +7462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7206,6 +7500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7242,6 +7538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7278,6 +7576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7314,6 +7614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7350,6 +7652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7386,6 +7690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7422,6 +7728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7458,6 +7766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7494,6 +7804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7530,6 +7842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7566,6 +7880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7602,6 +7918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7638,6 +7956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7674,6 +7994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7710,6 +8032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -7746,6 +8070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7782,6 +8108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -7818,6 +8146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -7854,6 +8184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -7890,6 +8222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -7926,6 +8260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7962,6 +8298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7998,6 +8336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -8034,6 +8374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -8070,6 +8412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8106,6 +8450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8142,6 +8488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8178,6 +8526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8214,6 +8564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8250,6 +8602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8286,6 +8640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8322,6 +8678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8358,6 +8716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8394,6 +8754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8430,6 +8792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8466,6 +8830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8502,6 +8868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8538,6 +8906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8574,6 +8944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8610,6 +8982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8646,6 +9020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8682,6 +9058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8718,6 +9096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -8754,6 +9134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8790,6 +9172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -8826,6 +9210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8862,6 +9248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -8898,6 +9286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -8934,6 +9324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8970,6 +9362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -9006,6 +9400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9042,6 +9438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -9078,6 +9476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9114,6 +9514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9150,6 +9552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -9186,6 +9590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9222,6 +9628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9258,6 +9666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9294,6 +9704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9330,6 +9742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9366,6 +9780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9402,6 +9818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9438,6 +9856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9474,6 +9894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -9510,6 +9932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -9546,6 +9970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -9582,6 +10008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -9618,6 +10046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -9654,6 +10084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -9690,6 +10122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -9726,6 +10160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -9762,6 +10198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9798,6 +10236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9834,6 +10274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9870,6 +10312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9906,6 +10350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9942,6 +10388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9978,6 +10426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -10014,6 +10464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -10050,6 +10502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -10086,6 +10540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10122,6 +10578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10158,6 +10616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10194,6 +10654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10230,6 +10692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10266,6 +10730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10302,6 +10768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10338,6 +10806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10374,6 +10844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10410,6 +10882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10446,6 +10920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10482,6 +10958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10518,6 +10996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10554,6 +11034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10590,6 +11072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10626,6 +11110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10662,6 +11148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10698,6 +11186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10734,6 +11224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10770,6 +11262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10806,6 +11300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10842,6 +11338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10878,6 +11376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10914,6 +11414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10950,6 +11452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10986,6 +11490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11022,6 +11528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -11058,6 +11566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -11094,6 +11604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -11130,6 +11642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -11166,6 +11680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -11202,6 +11718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -11238,6 +11756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11274,6 +11794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11310,6 +11832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -11346,6 +11870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -11382,6 +11908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11418,6 +11946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -11454,6 +11984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -11490,6 +12022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -11526,6 +12060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -11562,6 +12098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -11598,6 +12136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11634,6 +12174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11670,6 +12212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11706,6 +12250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11742,6 +12288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11778,6 +12326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11814,6 +12364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11850,6 +12402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11886,6 +12440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11922,6 +12478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11958,6 +12516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11994,6 +12554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12030,6 +12592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12066,6 +12630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12102,6 +12668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12138,6 +12706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12174,6 +12744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12210,6 +12782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12246,6 +12820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12282,6 +12858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12318,6 +12896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12354,6 +12934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12390,6 +12972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -12426,6 +13010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12462,6 +13048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.4.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.1.sarif
@@ -1913,6 +1913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1948,6 +1951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1983,6 +1989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2018,6 +2027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2053,6 +2065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2088,6 +2103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2123,6 +2141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2158,6 +2179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2193,6 +2217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2228,6 +2255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2263,6 +2293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2298,6 +2331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2333,6 +2369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2368,6 +2407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2403,6 +2445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2438,6 +2483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2473,6 +2521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2508,6 +2559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2543,6 +2597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2578,6 +2635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2613,6 +2673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2648,6 +2711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2683,6 +2749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2718,6 +2787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2753,6 +2825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2788,6 +2863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2823,6 +2901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2858,6 +2939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2893,6 +2977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2928,6 +3015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -2963,6 +3053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2998,6 +3091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3033,6 +3129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3068,6 +3167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3103,6 +3205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3138,6 +3243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3173,6 +3281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3208,6 +3319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3243,6 +3357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3278,6 +3395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3313,6 +3433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3348,6 +3471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3383,6 +3509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3418,6 +3547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3453,6 +3585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3488,6 +3623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3523,6 +3661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3558,6 +3699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3593,6 +3737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3628,6 +3775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3663,6 +3813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3698,6 +3851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3733,6 +3889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3768,6 +3927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3803,6 +3965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3838,6 +4003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3873,6 +4041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3908,6 +4079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -3943,6 +4117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3978,6 +4155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4013,6 +4193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4048,6 +4231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4083,6 +4269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4118,6 +4307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4153,6 +4345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4188,6 +4383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4223,6 +4421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4258,6 +4459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4293,6 +4497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4328,6 +4535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4363,6 +4573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4398,6 +4611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4433,6 +4649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4468,6 +4687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4503,6 +4725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4538,6 +4763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4573,6 +4801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4608,6 +4839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4643,6 +4877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4678,6 +4915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4713,6 +4953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4748,6 +4991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4783,6 +5029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4818,6 +5067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4853,6 +5105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4888,6 +5143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4923,6 +5181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4958,6 +5219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -4993,6 +5257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5028,6 +5295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5063,6 +5333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5098,6 +5371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5133,6 +5409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5168,6 +5447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5203,6 +5485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5238,6 +5523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5273,6 +5561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5308,6 +5599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5343,6 +5637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5378,6 +5675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5413,6 +5713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5448,6 +5751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5483,6 +5789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5518,6 +5827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5553,6 +5865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5588,6 +5903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5623,6 +5941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5658,6 +5979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5693,6 +6017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5728,6 +6055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5763,6 +6093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5798,6 +6131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5833,6 +6169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5868,6 +6207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -5903,6 +6245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -5938,6 +6283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -5973,6 +6321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,6 +6359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6043,6 +6397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6078,6 +6435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6113,6 +6473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6148,6 +6511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6183,6 +6549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6218,6 +6587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6253,6 +6625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6288,6 +6663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6323,6 +6701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6358,6 +6739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6393,6 +6777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6428,6 +6815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6463,6 +6853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6498,6 +6891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6533,6 +6929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6568,6 +6967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6603,6 +7005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6638,6 +7043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -6673,6 +7081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -6708,6 +7119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -6743,6 +7157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -6778,6 +7195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -6813,6 +7233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -6848,6 +7271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -6883,6 +7309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -6918,6 +7347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -6953,6 +7385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6988,6 +7423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7023,6 +7461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7058,6 +7499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7093,6 +7537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7128,6 +7575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7163,6 +7613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7198,6 +7651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7233,6 +7689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7268,6 +7727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7303,6 +7765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7338,6 +7803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7373,6 +7841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7408,6 +7879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7443,6 +7917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7478,6 +7955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7513,6 +7993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7548,6 +8031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -7583,6 +8069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7618,6 +8107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -7653,6 +8145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -7688,6 +8183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -7723,6 +8221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -7758,6 +8259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7793,6 +8297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7828,6 +8335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -7863,6 +8373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -7898,6 +8411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7933,6 +8449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -7968,6 +8487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8003,6 +8525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8038,6 +8563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8073,6 +8601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8108,6 +8639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8143,6 +8677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8178,6 +8715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8213,6 +8753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8248,6 +8791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8283,6 +8829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8318,6 +8867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8353,6 +8905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8388,6 +8943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8423,6 +8981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8458,6 +9019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8493,6 +9057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8528,6 +9095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -8563,6 +9133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8598,6 +9171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -8633,6 +9209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8668,6 +9247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -8703,6 +9285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -8738,6 +9323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8773,6 +9361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -8808,6 +9399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8843,6 +9437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8878,6 +9475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8913,6 +9513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8948,6 +9551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -8983,6 +9589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9018,6 +9627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9053,6 +9665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9088,6 +9703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -9123,6 +9741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9158,6 +9779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -9193,6 +9817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9228,6 +9855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -9263,6 +9893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -9298,6 +9931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -9333,6 +9969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -9368,6 +10007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -9403,6 +10045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -9438,6 +10083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -9473,6 +10121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -9508,6 +10159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -9543,6 +10197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9578,6 +10235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9613,6 +10273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9648,6 +10311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9683,6 +10349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9718,6 +10387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9753,6 +10425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9788,6 +10463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9823,6 +10501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9858,6 +10539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9893,6 +10577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9928,6 +10615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9963,6 +10653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9998,6 +10691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10033,6 +10729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10068,6 +10767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10103,6 +10805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10138,6 +10843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10173,6 +10881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10208,6 +10919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10243,6 +10957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10278,6 +10995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10313,6 +11033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10348,6 +11071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10383,6 +11109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10418,6 +11147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10453,6 +11185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10488,6 +11223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10523,6 +11261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10558,6 +11299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10593,6 +11337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10628,6 +11375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10663,6 +11413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10698,6 +11451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10733,6 +11489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10768,6 +11527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10803,6 +11565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10838,6 +11603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10873,6 +11641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10908,6 +11679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10943,6 +11717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10978,6 +11755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11013,6 +11793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11048,6 +11831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -11083,6 +11869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -11118,6 +11907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11153,6 +11945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -11188,6 +11983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -11223,6 +12021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -11258,6 +12059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -11293,6 +12097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -11328,6 +12135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11363,6 +12173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11398,6 +12211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11433,6 +12249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11468,6 +12287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11503,6 +12325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11538,6 +12363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11573,6 +12401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11608,6 +12439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11643,6 +12477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11678,6 +12515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11713,6 +12553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -11748,6 +12591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11783,6 +12629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11818,6 +12667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11853,6 +12705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11888,6 +12743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11923,6 +12781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11958,6 +12819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11993,6 +12857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12028,6 +12895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12063,6 +12933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12098,6 +12971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -12133,6 +13009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12168,6 +13047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.4.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.2.sarif
@@ -1866,8 +1866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1904,8 +1902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1942,8 +1938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -1980,8 +1974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2018,8 +2010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2056,8 +2046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2094,8 +2082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2132,8 +2118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2170,8 +2154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2208,8 +2190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2246,8 +2226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2284,8 +2262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2322,8 +2298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2360,8 +2334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2398,8 +2370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2436,8 +2406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2474,8 +2442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2512,8 +2478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2550,8 +2514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2588,8 +2550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2626,8 +2586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2664,8 +2622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2702,8 +2658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2740,8 +2694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2778,8 +2730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2816,8 +2766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2854,8 +2802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2892,8 +2838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2930,8 +2874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2968,8 +2910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3006,8 +2946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3044,8 +2982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3082,8 +3018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3120,8 +3054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3158,8 +3090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3196,8 +3126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3234,8 +3162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3272,8 +3198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3310,8 +3234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3348,8 +3270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3386,8 +3306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3424,8 +3342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3462,8 +3378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3500,8 +3414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3538,8 +3450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3576,8 +3486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3614,8 +3522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3652,8 +3558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3690,8 +3594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3728,8 +3630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3766,8 +3666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3804,8 +3702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3842,8 +3738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3880,8 +3774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3918,8 +3810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3956,8 +3846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3994,8 +3882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4032,8 +3918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4070,8 +3954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4108,8 +3990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4146,8 +4026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4184,8 +4062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4222,8 +4098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4260,8 +4134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4298,8 +4170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4336,8 +4206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4374,8 +4242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4412,8 +4278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4450,8 +4314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4488,8 +4350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4526,8 +4386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4564,8 +4422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4602,8 +4458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4640,8 +4494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4678,8 +4530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4716,8 +4566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4754,8 +4602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4792,8 +4638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4830,8 +4674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4868,8 +4710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4906,8 +4746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4944,8 +4782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4982,8 +4818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5020,8 +4854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5058,8 +4890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5096,8 +4926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5134,8 +4962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5172,8 +4998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5210,8 +5034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5248,8 +5070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5286,8 +5106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5324,8 +5142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5362,8 +5178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5400,8 +5214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5438,8 +5250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5476,8 +5286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5514,8 +5322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5552,8 +5358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5590,8 +5394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5628,8 +5430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5666,8 +5466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5704,8 +5502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5742,8 +5538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5780,8 +5574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5818,8 +5610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5856,8 +5646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5894,8 +5682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5932,8 +5718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5970,8 +5754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,8 +5790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6046,8 +5826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6084,8 +5862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6122,8 +5898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6160,8 +5934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6198,8 +5970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6236,8 +6006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6274,8 +6042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6312,8 +6078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6350,8 +6114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6388,8 +6150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6426,8 +6186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6464,8 +6222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6502,8 +6258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6540,8 +6294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6578,8 +6330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6616,8 +6366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6654,8 +6402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6692,8 +6438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6730,8 +6474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6768,8 +6510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6806,8 +6546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6844,8 +6582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6882,8 +6618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6920,8 +6654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6958,8 +6690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6996,8 +6726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7034,8 +6762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7072,8 +6798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7110,8 +6834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7148,8 +6870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7186,8 +6906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7224,8 +6942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7262,8 +6978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7300,8 +7014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7338,8 +7050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7376,8 +7086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7414,8 +7122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7452,8 +7158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7490,8 +7194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7528,8 +7230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7566,8 +7266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7604,8 +7302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7642,8 +7338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7680,8 +7374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7718,8 +7410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7756,8 +7446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7794,8 +7482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7832,8 +7518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7870,8 +7554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7908,8 +7590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7946,8 +7626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7984,8 +7662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -8022,8 +7698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8060,8 +7734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -8098,8 +7770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -8136,8 +7806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -8174,8 +7842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -8212,8 +7878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8250,8 +7914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8288,8 +7950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -8326,8 +7986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -8364,8 +8022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8402,8 +8058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8440,8 +8094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8478,8 +8130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8516,8 +8166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8554,8 +8202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8592,8 +8238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8630,8 +8274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8668,8 +8310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8706,8 +8346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8744,8 +8382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8782,8 +8418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8820,8 +8454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8858,8 +8490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8896,8 +8526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8934,8 +8562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8972,8 +8598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9010,8 +8634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9048,8 +8670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -9086,8 +8706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9124,8 +8742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -9162,8 +8778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9200,8 +8814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -9238,8 +8850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -9276,8 +8886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9314,8 +8922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -9352,8 +8958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9390,8 +8994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -9428,8 +9030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9466,8 +9066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9504,8 +9102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -9542,8 +9138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -9580,8 +9174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -9618,8 +9210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -9656,8 +9246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -9694,8 +9282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -9732,8 +9318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -9770,8 +9354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9808,8 +9390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9846,8 +9426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9884,8 +9462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9922,8 +9498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9960,8 +9534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9998,8 +9570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -10036,8 +9606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -10074,8 +9642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -10112,8 +9678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10150,8 +9714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10188,8 +9750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10226,8 +9786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -10264,8 +9822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10302,8 +9858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10340,8 +9894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10378,8 +9930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10416,8 +9966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10454,8 +10002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10492,8 +10038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10530,8 +10074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10568,8 +10110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10606,8 +10146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10644,8 +10182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10682,8 +10218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10720,8 +10254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10758,8 +10290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10796,8 +10326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10834,8 +10362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10872,8 +10398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10910,8 +10434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10948,8 +10470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10986,8 +10506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11024,8 +10542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11062,8 +10578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11100,8 +10614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -11138,8 +10650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -11176,8 +10686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -11214,8 +10722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -11252,8 +10758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -11290,8 +10794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -11328,8 +10830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11366,8 +10866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -11404,8 +10902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -11442,8 +10938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -11480,8 +10974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11518,8 +11010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -11556,8 +11046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -11594,8 +11082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -11632,8 +11118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -11670,8 +11154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -11708,8 +11190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11746,8 +11226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11784,8 +11262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11822,8 +11298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11860,8 +11334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11898,8 +11370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11936,8 +11406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11974,8 +11442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12012,8 +11478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12050,8 +11514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12088,8 +11550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12126,8 +11586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12164,8 +11622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -12202,8 +11658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12240,8 +11694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12278,8 +11730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12316,8 +11766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -12354,8 +11802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12392,8 +11838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -12430,8 +11874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12468,8 +11910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -12506,8 +11946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -12544,8 +11982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -12582,8 +12018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12620,8 +12054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.4.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.2.sarif
@@ -1866,6 +1866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1902,6 +1904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1938,6 +1942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -1974,6 +1980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2010,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2046,6 +2056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2082,6 +2094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2118,6 +2132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2154,6 +2170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2190,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2226,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2262,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2298,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2334,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2370,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2406,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2442,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2478,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2514,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2550,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2586,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2622,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2658,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2694,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2730,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2766,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2802,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2838,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2874,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2910,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -2946,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2982,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3018,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3054,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3090,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3126,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3162,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3198,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3234,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3270,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3306,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3342,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3378,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3414,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3450,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3486,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3522,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3558,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3594,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3630,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3666,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3702,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3738,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3774,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3810,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3846,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3882,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3918,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -3954,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3990,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4026,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4062,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4098,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4134,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4170,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4206,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4242,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4278,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4314,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4350,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4386,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4422,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4458,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4494,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4530,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4566,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4602,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4638,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4674,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4710,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4746,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4782,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4818,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4854,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4890,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4926,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4962,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4998,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5034,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5070,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5106,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5142,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5178,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5214,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5250,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5286,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5322,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5358,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5394,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5430,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5466,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5502,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5538,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5574,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5610,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5646,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5682,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5718,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5754,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5790,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5826,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5862,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5898,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5934,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -5970,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6006,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6042,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6078,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6114,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6150,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6186,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6222,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6258,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6294,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6330,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6366,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6402,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6438,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6474,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6510,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6546,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6582,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6618,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6654,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6690,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6726,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -6762,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -6798,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -6834,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -6870,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -6906,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -6942,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -6978,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7014,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7050,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7086,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7122,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7158,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7194,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7230,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7266,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7302,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7338,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7374,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7410,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7446,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7482,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7518,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7554,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7590,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7626,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7662,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -7698,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7734,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -7770,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -7806,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -7842,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -7878,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7914,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7950,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -7986,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -8022,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8058,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8094,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8130,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -8166,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8202,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8238,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8274,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8310,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8346,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8382,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8418,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8454,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8490,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8526,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8562,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8598,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8634,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8670,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -8706,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8742,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -8778,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8814,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -8850,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -8886,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8922,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -8958,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8994,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -9030,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9066,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -9102,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -9138,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -9174,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -9210,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -9246,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -9282,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -9318,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -9354,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9390,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9426,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9462,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9498,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9534,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9570,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9606,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9642,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9678,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9714,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9750,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9786,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9822,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9858,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9894,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9930,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9966,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10002,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10038,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -10074,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -10110,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10146,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10182,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10218,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10254,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10290,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10326,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10362,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10398,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10434,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10470,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10506,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10542,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10578,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10614,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10650,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10686,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10722,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10758,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10794,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10830,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -10866,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -10902,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -10938,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -10974,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -11010,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -11046,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -11082,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -11118,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -11154,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -11190,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -11226,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11262,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11298,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11334,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11370,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11406,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11442,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11478,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11514,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11550,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11586,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -11622,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11658,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11694,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11730,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11766,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11802,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11838,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11874,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11910,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11946,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -11982,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -12018,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12054,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.4.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.2.sarif
@@ -1865,6 +1865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1900,6 +1903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -1935,6 +1941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -1970,6 +1979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2005,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2040,6 +2055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2075,6 +2093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2110,6 +2131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2145,6 +2169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2180,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2215,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2250,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2285,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2320,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2355,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2390,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2425,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2460,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2495,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2530,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2565,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2600,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2635,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2670,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2705,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2740,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2775,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2810,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2845,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2880,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -2915,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2950,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -2985,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3020,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3055,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3090,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3125,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3160,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3195,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3230,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3265,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3300,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3335,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3370,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3405,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3440,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3475,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -3510,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3545,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3580,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -3615,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3650,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3685,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -3720,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3755,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -3790,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3825,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3860,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -3895,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3930,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -3965,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4000,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4035,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4070,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4105,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4140,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4175,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -4210,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -4245,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -4280,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -4315,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4350,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -4385,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -4420,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -4455,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4490,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4525,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -4560,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -4595,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -4630,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4665,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4700,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4735,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4770,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4805,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -4840,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4875,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -4910,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -4945,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -4980,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5015,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5050,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5085,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5120,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5155,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -5190,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -5225,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -5260,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -5295,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -5330,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5365,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -5400,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -5435,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -5470,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -5505,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -5540,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -5575,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -5610,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -5645,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5680,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -5715,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -5750,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -5785,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -5820,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -5855,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -5890,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -5925,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5960,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -5995,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6030,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6065,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6100,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6135,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6170,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -6205,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -6240,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -6275,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -6310,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -6345,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -6380,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -6415,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -6450,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -6485,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -6520,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -6555,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -6590,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -6625,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -6660,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -6695,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -6730,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -6765,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -6800,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -6835,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -6870,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -6905,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -6940,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -6975,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7010,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7045,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7080,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7115,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7150,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7185,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -7220,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7255,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7290,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -7325,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -7360,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -7395,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7430,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -7465,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -7500,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -7535,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -7570,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -7605,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -7640,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -7675,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -7710,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7745,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7780,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -7815,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -7850,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7885,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -7920,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -7955,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -7990,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8025,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -8060,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8095,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8130,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8165,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8200,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -8235,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8270,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8305,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8340,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8375,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8410,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8445,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -8480,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -8515,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8550,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -8585,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8620,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -8655,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -8690,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8725,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -8760,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8795,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8830,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8865,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8900,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8935,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8970,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -9005,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -9040,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -9075,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -9110,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -9145,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9180,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9215,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9250,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9285,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9320,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9355,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9390,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9425,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9460,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9495,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9530,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9565,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -9600,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9635,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9670,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9705,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9740,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9775,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9810,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9845,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9880,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9915,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9950,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9985,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -10020,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -10055,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -10090,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -10125,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10160,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10195,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10230,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10265,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10300,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10335,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10370,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10405,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10440,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10475,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10510,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10545,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10580,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -10615,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -10650,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -10685,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -10720,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -10755,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -10790,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -10825,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -10860,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -10895,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -10930,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -10965,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11000,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11035,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11070,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11105,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11140,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11175,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11210,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11245,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11280,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11315,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -11350,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -11385,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11420,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11455,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11490,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -11525,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11560,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -11595,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11630,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -11665,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -11700,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -11735,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11770,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.1.sarif
@@ -1951,6 +1951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1986,6 +1989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2021,6 +2027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2056,6 +2065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2091,6 +2103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2126,6 +2141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2161,6 +2179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2196,6 +2217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2231,6 +2255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2266,6 +2293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2301,6 +2331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2336,6 +2369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2371,6 +2407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2406,6 +2445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2441,6 +2483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2476,6 +2521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2511,6 +2559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2546,6 +2597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2581,6 +2635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2616,6 +2673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2651,6 +2711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2686,6 +2749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2721,6 +2787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2756,6 +2825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2791,6 +2863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2826,6 +2901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2861,6 +2939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2896,6 +2977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2931,6 +3015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2966,6 +3053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3001,6 +3091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3036,6 +3129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3071,6 +3167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3106,6 +3205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3141,6 +3243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3176,6 +3281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3211,6 +3319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3246,6 +3357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3281,6 +3395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3316,6 +3433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3351,6 +3471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3386,6 +3509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3421,6 +3547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3456,6 +3585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3491,6 +3623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3526,6 +3661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3561,6 +3699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3596,6 +3737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3631,6 +3775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3666,6 +3813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3701,6 +3851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3736,6 +3889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3771,6 +3927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3806,6 +3965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3841,6 +4003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3876,6 +4041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3911,6 +4079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3946,6 +4117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -3981,6 +4155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4016,6 +4193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4051,6 +4231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4086,6 +4269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4121,6 +4307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4156,6 +4345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4191,6 +4383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4226,6 +4421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4261,6 +4459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4296,6 +4497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4331,6 +4535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4366,6 +4573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4401,6 +4611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4436,6 +4649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4471,6 +4687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4506,6 +4725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4541,6 +4763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4576,6 +4801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4611,6 +4839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4646,6 +4877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4681,6 +4915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4716,6 +4953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4751,6 +4991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4786,6 +5029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4821,6 +5067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4856,6 +5105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4891,6 +5143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4926,6 +5181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4961,6 +5219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -4996,6 +5257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5031,6 +5295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5066,6 +5333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5101,6 +5371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5136,6 +5409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5171,6 +5447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5206,6 +5485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5241,6 +5523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5276,6 +5561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5311,6 +5599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5346,6 +5637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5381,6 +5675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5416,6 +5713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5451,6 +5751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5486,6 +5789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5521,6 +5827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5556,6 +5865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5591,6 +5903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5626,6 +5941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5661,6 +5979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5696,6 +6017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5731,6 +6055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5766,6 +6093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5801,6 +6131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5836,6 +6169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5871,6 +6207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5906,6 +6245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5941,6 +6283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -5976,6 +6321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6011,6 +6359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6046,6 +6397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6081,6 +6435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6116,6 +6473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6151,6 +6511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6186,6 +6549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6221,6 +6587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6256,6 +6625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6291,6 +6663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6326,6 +6701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6361,6 +6739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6396,6 +6777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6431,6 +6815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6466,6 +6853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6501,6 +6891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6536,6 +6929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6571,6 +6967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6606,6 +7005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6641,6 +7043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6676,6 +7081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6711,6 +7119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6746,6 +7157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6781,6 +7195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6816,6 +7233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6851,6 +7271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6886,6 +7309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6921,6 +7347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6956,6 +7385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6991,6 +7423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7026,6 +7461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7061,6 +7499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7096,6 +7537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7131,6 +7575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7166,6 +7613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7201,6 +7651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7236,6 +7689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7271,6 +7727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7306,6 +7765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7341,6 +7803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7376,6 +7841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7411,6 +7879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7446,6 +7917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7481,6 +7955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7516,6 +7993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7551,6 +8031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7586,6 +8069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7621,6 +8107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7656,6 +8145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7691,6 +8183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7726,6 +8221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7761,6 +8259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7796,6 +8297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7831,6 +8335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7866,6 +8373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -7901,6 +8411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -7936,6 +8449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -7971,6 +8487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8006,6 +8525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8041,6 +8563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8076,6 +8601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8111,6 +8639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8146,6 +8677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8181,6 +8715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8216,6 +8753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8251,6 +8791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8286,6 +8829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8321,6 +8867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8356,6 +8905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8391,6 +8943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8426,6 +8981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8461,6 +9019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8496,6 +9057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8531,6 +9095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8566,6 +9133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8601,6 +9171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8636,6 +9209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8671,6 +9247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8706,6 +9285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8741,6 +9323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8776,6 +9361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -8811,6 +9399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -8846,6 +9437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -8881,6 +9475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -8916,6 +9513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -8951,6 +9551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -8986,6 +9589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9021,6 +9627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9056,6 +9665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9091,6 +9703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9126,6 +9741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9161,6 +9779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9196,6 +9817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9231,6 +9855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9266,6 +9893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9301,6 +9931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9336,6 +9969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9371,6 +10007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9406,6 +10045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9441,6 +10083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9476,6 +10121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9511,6 +10159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9546,6 +10197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9581,6 +10235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9616,6 +10273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9651,6 +10311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9686,6 +10349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9721,6 +10387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9756,6 +10425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9791,6 +10463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9826,6 +10501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9861,6 +10539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9896,6 +10577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9931,6 +10615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9966,6 +10653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10001,6 +10691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10036,6 +10729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10071,6 +10767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10106,6 +10805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10141,6 +10843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10176,6 +10881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10211,6 +10919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10246,6 +10957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10281,6 +10995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10316,6 +11033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10351,6 +11071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10386,6 +11109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10421,6 +11147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10456,6 +11185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10491,6 +11223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10526,6 +11261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10561,6 +11299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10596,6 +11337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10631,6 +11375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10666,6 +11413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10701,6 +11451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10736,6 +11489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10771,6 +11527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10806,6 +11565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10841,6 +11603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10876,6 +11641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10911,6 +11679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10946,6 +11717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10981,6 +11755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11016,6 +11793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11051,6 +11831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11086,6 +11869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11121,6 +11907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11156,6 +11945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11191,6 +11983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11226,6 +12021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11261,6 +12059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11296,6 +12097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11331,6 +12135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11366,6 +12173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11401,6 +12211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11436,6 +12249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11471,6 +12287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11506,6 +12325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11541,6 +12363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11576,6 +12401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11611,6 +12439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11646,6 +12477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11681,6 +12515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11716,6 +12553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11751,6 +12591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11786,6 +12629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11821,6 +12667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11856,6 +12705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11891,6 +12743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11926,6 +12781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11961,6 +12819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -11996,6 +12857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12031,6 +12895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12066,6 +12933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12101,6 +12971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12136,6 +13009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12171,6 +13047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12206,6 +13085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12241,6 +13123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12276,6 +13161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12311,6 +13199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12346,6 +13237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12381,6 +13275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12416,6 +13313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12451,6 +13351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12486,6 +13389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12521,6 +13427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12556,6 +13465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12591,6 +13503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12626,6 +13541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12661,6 +13579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12696,6 +13617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12731,6 +13655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12766,6 +13693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12801,6 +13731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12836,6 +13769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12871,6 +13807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12906,6 +13845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12941,6 +13883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -12976,6 +13921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13011,6 +13959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13046,6 +13997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13081,6 +14035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13116,6 +14073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13151,6 +14111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13186,6 +14149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13221,6 +14187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13256,6 +14225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13291,6 +14263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13326,6 +14301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13361,6 +14339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13396,6 +14377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13431,6 +14415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13466,6 +14453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13501,6 +14491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13536,6 +14529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13571,6 +14567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13606,6 +14605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13641,6 +14643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13676,6 +14681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13711,6 +14719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13746,6 +14757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -13781,6 +14795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13816,6 +14833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -13851,6 +14871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -13886,6 +14909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -13921,6 +14947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13956,6 +14985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -13991,6 +15023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14026,6 +15061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14061,6 +15099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14096,6 +15137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14131,6 +15175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14166,6 +15213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14201,6 +15251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14236,6 +15289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14271,6 +15327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14306,6 +15365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14341,6 +15403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14376,6 +15441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14411,6 +15479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14446,6 +15517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14481,6 +15555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14516,6 +15593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14551,6 +15631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14586,6 +15669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14621,6 +15707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14656,6 +15745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14691,6 +15783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14726,6 +15821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14761,6 +15859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14796,6 +15897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -14831,6 +15935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14866,6 +15973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14901,6 +16011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14936,6 +16049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -14971,6 +16087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15006,6 +16125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15041,6 +16163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15076,6 +16201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15111,6 +16239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15146,6 +16277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15181,6 +16315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15216,6 +16353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15251,6 +16391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15286,6 +16429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15321,6 +16467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15356,6 +16505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15391,6 +16543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15426,6 +16581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15461,6 +16619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15496,6 +16657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15531,6 +16695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15566,6 +16733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15601,6 +16771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15636,6 +16809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15671,6 +16847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15706,6 +16885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15741,6 +16923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15776,6 +16961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15811,6 +16999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15846,6 +17037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15881,6 +17075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15916,6 +17113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15951,6 +17151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -15986,6 +17189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16021,6 +17227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16056,6 +17265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16091,6 +17303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16126,6 +17341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16161,6 +17379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16196,6 +17417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16231,6 +17455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16266,6 +17493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16301,6 +17531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16336,6 +17569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16371,6 +17607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16406,6 +17645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16441,6 +17683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16476,6 +17721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16511,6 +17759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16546,6 +17797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16581,6 +17835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16616,6 +17873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16651,6 +17911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16686,6 +17949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16721,6 +17987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16756,6 +18025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16791,6 +18063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16826,6 +18101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -16861,6 +18139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16896,6 +18177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16931,6 +18215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -16966,6 +18253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17001,6 +18291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17036,6 +18329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17071,6 +18367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17106,6 +18405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17141,6 +18443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17176,6 +18481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17211,6 +18519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17246,6 +18557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17281,6 +18595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17316,6 +18633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17351,6 +18671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17386,6 +18709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17421,6 +18747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17456,6 +18785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17491,6 +18823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17526,6 +18861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17561,6 +18899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17596,6 +18937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17631,6 +18975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17666,6 +19013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17701,6 +19051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17736,6 +19089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17771,6 +19127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17806,6 +19165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17841,6 +19203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17876,6 +19241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -17911,6 +19279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -17946,6 +19317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -17981,6 +19355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18016,6 +19393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18051,6 +19431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18086,6 +19469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18121,6 +19507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18156,6 +19545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18191,6 +19583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18226,6 +19621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18261,6 +19659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18296,6 +19697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18331,6 +19735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18366,6 +19773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18401,6 +19811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18436,6 +19849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18471,6 +19887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18506,6 +19925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18541,6 +19963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18576,6 +20001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18611,6 +20039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18646,6 +20077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18681,6 +20115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18716,6 +20153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18751,6 +20191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18786,6 +20229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18821,6 +20267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18856,6 +20305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18891,6 +20343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18926,6 +20381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18961,6 +20419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -18996,6 +20457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19031,6 +20495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19066,6 +20533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19101,6 +20571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19136,6 +20609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19171,6 +20647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19206,6 +20685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19241,6 +20723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19276,6 +20761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19311,6 +20799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19346,6 +20837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19381,6 +20875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19416,6 +20913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19451,6 +20951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19486,6 +20989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19521,6 +21027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19556,6 +21065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19591,6 +21103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19626,6 +21141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19661,6 +21179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19696,6 +21217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19731,6 +21255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -19766,6 +21293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19801,6 +21331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19836,6 +21369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19871,6 +21407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19906,6 +21445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19941,6 +21483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -19976,6 +21521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20011,6 +21559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20046,6 +21597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20081,6 +21635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20116,6 +21673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20151,6 +21711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20186,6 +21749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20221,6 +21787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20256,6 +21825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20291,6 +21863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20326,6 +21901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20361,6 +21939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20396,6 +21977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20431,6 +22015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20466,6 +22053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20501,6 +22091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20536,6 +22129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20571,6 +22167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20606,6 +22205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20641,6 +22243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20676,6 +22281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20711,6 +22319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20746,6 +22357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20781,6 +22395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20816,6 +22433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20851,6 +22471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -20886,6 +22509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -20921,6 +22547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -20956,6 +22585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -20991,6 +22623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21026,6 +22661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21061,6 +22699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21096,6 +22737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21131,6 +22775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21166,6 +22813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21201,6 +22851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21236,6 +22889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21271,6 +22927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21306,6 +22965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21341,6 +23003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21376,6 +23041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21411,6 +23079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21446,6 +23117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21481,6 +23155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21516,6 +23193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21551,6 +23231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21586,6 +23269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21621,6 +23307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21656,6 +23345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21691,6 +23383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21726,6 +23421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21761,6 +23459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -21796,6 +23497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -21831,6 +23535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -21866,6 +23573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -21901,6 +23611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -21936,6 +23649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -21971,6 +23687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22006,6 +23725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22041,6 +23763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22076,6 +23801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22111,6 +23839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22146,6 +23877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22181,6 +23915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22216,6 +23953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22251,6 +23991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22286,6 +24029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22321,6 +24067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22356,6 +24105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22391,6 +24143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22426,6 +24181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22461,6 +24219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22496,6 +24257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22531,6 +24295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22566,6 +24333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22601,6 +24371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22636,6 +24409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22671,6 +24447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22706,6 +24485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22741,6 +24523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22776,6 +24561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -22811,6 +24599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -22846,6 +24637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -22881,6 +24675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -22916,6 +24713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22951,6 +24751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22986,6 +24789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23021,6 +24827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23056,6 +24865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23091,6 +24903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23126,6 +24941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23161,6 +24979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23196,6 +25017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23231,6 +25055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23266,6 +25093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23301,6 +25131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23336,6 +25169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23371,6 +25207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23406,6 +25245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23441,6 +25283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23476,6 +25321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23511,6 +25359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23546,6 +25397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23581,6 +25435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23616,6 +25473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23651,6 +25511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23686,6 +25549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23721,6 +25587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23756,6 +25625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23791,6 +25663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23826,6 +25701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23861,6 +25739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -23896,6 +25777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23931,6 +25815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23966,6 +25853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24001,6 +25891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24036,6 +25929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24071,6 +25967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24106,6 +26005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24141,6 +26043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24176,6 +26081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24211,6 +26119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24246,6 +26157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24281,6 +26195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24316,6 +26233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.1.sarif
@@ -1952,6 +1952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1988,6 +1990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2024,6 +2028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2060,6 +2066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2096,6 +2104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2132,6 +2142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2168,6 +2180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2204,6 +2218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2240,6 +2256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2276,6 +2294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2312,6 +2332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2348,6 +2370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2384,6 +2408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2420,6 +2446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2456,6 +2484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2492,6 +2522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2528,6 +2560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2564,6 +2598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2600,6 +2636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2636,6 +2674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2672,6 +2712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2708,6 +2750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2744,6 +2788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2780,6 +2826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2816,6 +2864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2852,6 +2902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2888,6 +2940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2924,6 +2978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2960,6 +3016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2996,6 +3054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3032,6 +3092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3068,6 +3130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3104,6 +3168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3140,6 +3206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3176,6 +3244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3212,6 +3282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3248,6 +3320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3284,6 +3358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3320,6 +3396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3356,6 +3434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3392,6 +3472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3428,6 +3510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3464,6 +3548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3500,6 +3586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3536,6 +3624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3572,6 +3662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3608,6 +3700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3644,6 +3738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3680,6 +3776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3716,6 +3814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3752,6 +3852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3788,6 +3890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3824,6 +3928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3860,6 +3966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3896,6 +4004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3932,6 +4042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3968,6 +4080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4004,6 +4118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4040,6 +4156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4076,6 +4194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4112,6 +4232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4148,6 +4270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4184,6 +4308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4220,6 +4346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4256,6 +4384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4292,6 +4422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4328,6 +4460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4364,6 +4498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4400,6 +4536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4436,6 +4574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4472,6 +4612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4508,6 +4650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4544,6 +4688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4580,6 +4726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4616,6 +4764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4652,6 +4802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4688,6 +4840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4724,6 +4878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4760,6 +4916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4796,6 +4954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4832,6 +4992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4868,6 +5030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4904,6 +5068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4940,6 +5106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4976,6 +5144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5012,6 +5182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5048,6 +5220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5084,6 +5258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5120,6 +5296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5156,6 +5334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5192,6 +5372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5228,6 +5410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5264,6 +5448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5300,6 +5486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5336,6 +5524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5372,6 +5562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5408,6 +5600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5444,6 +5638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5480,6 +5676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5516,6 +5714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5552,6 +5752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5588,6 +5790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5624,6 +5828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5660,6 +5866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5696,6 +5904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5732,6 +5942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5768,6 +5980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5804,6 +6018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5840,6 +6056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5876,6 +6094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5912,6 +6132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5948,6 +6170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5984,6 +6208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6020,6 +6246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6056,6 +6284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6092,6 +6322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6128,6 +6360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6164,6 +6398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6200,6 +6436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6236,6 +6474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6272,6 +6512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6308,6 +6550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6344,6 +6588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6380,6 +6626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6416,6 +6664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6452,6 +6702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6488,6 +6740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6524,6 +6778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6560,6 +6816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6596,6 +6854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6632,6 +6892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6668,6 +6930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6704,6 +6968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6740,6 +7006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6776,6 +7044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6812,6 +7082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6848,6 +7120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6884,6 +7158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6920,6 +7196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6956,6 +7234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6992,6 +7272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7028,6 +7310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7064,6 +7348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7100,6 +7386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7136,6 +7424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7172,6 +7462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7208,6 +7500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7244,6 +7538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7280,6 +7576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7316,6 +7614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7352,6 +7652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7388,6 +7690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7424,6 +7728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7460,6 +7766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7496,6 +7804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7532,6 +7842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7568,6 +7880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7604,6 +7918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7640,6 +7956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7676,6 +7994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7712,6 +8032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7748,6 +8070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7784,6 +8108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7820,6 +8146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7856,6 +8184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7892,6 +8222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7928,6 +8260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7964,6 +8298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8000,6 +8336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8036,6 +8374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8072,6 +8412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8108,6 +8450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8144,6 +8488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8180,6 +8526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8216,6 +8564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8252,6 +8602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8288,6 +8640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8324,6 +8678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8360,6 +8716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8396,6 +8754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8432,6 +8792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8468,6 +8830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8504,6 +8868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8540,6 +8906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8576,6 +8944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8612,6 +8982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8648,6 +9020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8684,6 +9058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8720,6 +9096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8756,6 +9134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8792,6 +9172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8828,6 +9210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8864,6 +9248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8900,6 +9286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8936,6 +9324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8972,6 +9362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9008,6 +9400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9044,6 +9438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9080,6 +9476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9116,6 +9514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9152,6 +9552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9188,6 +9590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9224,6 +9628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9260,6 +9666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9296,6 +9704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9332,6 +9742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9368,6 +9780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9404,6 +9818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9440,6 +9856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9476,6 +9894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9512,6 +9932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9548,6 +9970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9584,6 +10008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9620,6 +10046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9656,6 +10084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9692,6 +10122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9728,6 +10160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9764,6 +10198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9800,6 +10236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9836,6 +10274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9872,6 +10312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9908,6 +10350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9944,6 +10388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9980,6 +10426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10016,6 +10464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10052,6 +10502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10088,6 +10540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10124,6 +10578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10160,6 +10616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10196,6 +10654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10232,6 +10692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10268,6 +10730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10304,6 +10768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10340,6 +10806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10376,6 +10844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10412,6 +10882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10448,6 +10920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10484,6 +10958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10520,6 +10996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10556,6 +11034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10592,6 +11072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10628,6 +11110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10664,6 +11148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10700,6 +11186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10736,6 +11224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10772,6 +11262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10808,6 +11300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10844,6 +11338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10880,6 +11376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10916,6 +11414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10952,6 +11452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10988,6 +11490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11024,6 +11528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11060,6 +11566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11096,6 +11604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11132,6 +11642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11168,6 +11680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11204,6 +11718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11240,6 +11756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11276,6 +11794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11312,6 +11832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11348,6 +11870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11384,6 +11908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11420,6 +11946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11456,6 +11984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11492,6 +12022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11528,6 +12060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11564,6 +12098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11600,6 +12136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11636,6 +12174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11672,6 +12212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11708,6 +12250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11744,6 +12288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11780,6 +12326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11816,6 +12364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11852,6 +12402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11888,6 +12440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11924,6 +12478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11960,6 +12516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11996,6 +12554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12032,6 +12592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12068,6 +12630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12104,6 +12668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12140,6 +12706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12176,6 +12744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12212,6 +12782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12248,6 +12820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12284,6 +12858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12320,6 +12896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12356,6 +12934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12392,6 +12972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12428,6 +13010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12464,6 +13048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12500,6 +13086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12536,6 +13124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12572,6 +13162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12608,6 +13200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12644,6 +13238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12680,6 +13276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12716,6 +13314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12752,6 +13352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12788,6 +13390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12824,6 +13428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12860,6 +13466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12896,6 +13504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12932,6 +13542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12968,6 +13580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13004,6 +13618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13040,6 +13656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13076,6 +13694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13112,6 +13732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13148,6 +13770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13184,6 +13808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13220,6 +13846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13256,6 +13884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13292,6 +13922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13328,6 +13960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13364,6 +13998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13400,6 +14036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13436,6 +14074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13472,6 +14112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13508,6 +14150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13544,6 +14188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13580,6 +14226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13616,6 +14264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13652,6 +14302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13688,6 +14340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13724,6 +14378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13760,6 +14416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13796,6 +14454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13832,6 +14492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13868,6 +14530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13904,6 +14568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13940,6 +14606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13976,6 +14644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14012,6 +14682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14048,6 +14720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14084,6 +14758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14120,6 +14796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14156,6 +14834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14192,6 +14872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14228,6 +14910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14264,6 +14948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14300,6 +14986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14336,6 +15024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14372,6 +15062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14408,6 +15100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14444,6 +15138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14480,6 +15176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14516,6 +15214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14552,6 +15252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14588,6 +15290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14624,6 +15328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14660,6 +15366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14696,6 +15404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14732,6 +15442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14768,6 +15480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14804,6 +15518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14840,6 +15556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14876,6 +15594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14912,6 +15632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14948,6 +15670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14984,6 +15708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15020,6 +15746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15056,6 +15784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15092,6 +15822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15128,6 +15860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15164,6 +15898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15200,6 +15936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15236,6 +15974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15272,6 +16012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15308,6 +16050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15344,6 +16088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15380,6 +16126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15416,6 +16164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15452,6 +16202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15488,6 +16240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15524,6 +16278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15560,6 +16316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15596,6 +16354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15632,6 +16392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15668,6 +16430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15704,6 +16468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15740,6 +16506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15776,6 +16544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15812,6 +16582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15848,6 +16620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15884,6 +16658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15920,6 +16696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15956,6 +16734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15992,6 +16772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16028,6 +16810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16064,6 +16848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16100,6 +16886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16136,6 +16924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16172,6 +16962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16208,6 +17000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16244,6 +17038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16280,6 +17076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16316,6 +17114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16352,6 +17152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16388,6 +17190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16424,6 +17228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16460,6 +17266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16496,6 +17304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16532,6 +17342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16568,6 +17380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16604,6 +17418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16640,6 +17456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16676,6 +17494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16712,6 +17532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16748,6 +17570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16784,6 +17608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16820,6 +17646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16856,6 +17684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16892,6 +17722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16928,6 +17760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16964,6 +17798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17000,6 +17836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17036,6 +17874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17072,6 +17912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17108,6 +17950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17144,6 +17988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17180,6 +18026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17216,6 +18064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17252,6 +18102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17288,6 +18140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17324,6 +18178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17360,6 +18216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17396,6 +18254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17432,6 +18292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17468,6 +18330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17504,6 +18368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17540,6 +18406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17576,6 +18444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17612,6 +18482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17648,6 +18520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17684,6 +18558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17720,6 +18596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17756,6 +18634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17792,6 +18672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17828,6 +18710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17864,6 +18748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17900,6 +18786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17936,6 +18824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17972,6 +18862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18008,6 +18900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18044,6 +18938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18080,6 +18976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18116,6 +19014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18152,6 +19052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18188,6 +19090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18224,6 +19128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18260,6 +19166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18296,6 +19204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18332,6 +19242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18368,6 +19280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18404,6 +19318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18440,6 +19356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18476,6 +19394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18512,6 +19432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18548,6 +19470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18584,6 +19508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18620,6 +19546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18656,6 +19584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18692,6 +19622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18728,6 +19660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18764,6 +19698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18800,6 +19736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18836,6 +19774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18872,6 +19812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18908,6 +19850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18944,6 +19888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18980,6 +19926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19016,6 +19964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19052,6 +20002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19088,6 +20040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19124,6 +20078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19160,6 +20116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19196,6 +20154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19232,6 +20192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19268,6 +20230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19304,6 +20268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19340,6 +20306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19376,6 +20344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19412,6 +20382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19448,6 +20420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19484,6 +20458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19520,6 +20496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19556,6 +20534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19592,6 +20572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19628,6 +20610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19664,6 +20648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19700,6 +20686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19736,6 +20724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19772,6 +20762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19808,6 +20800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19844,6 +20838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19880,6 +20876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19916,6 +20914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19952,6 +20952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19988,6 +20990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20024,6 +21028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20060,6 +21066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20096,6 +21104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20132,6 +21142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20168,6 +21180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20204,6 +21218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20240,6 +21256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20276,6 +21294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20312,6 +21332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20348,6 +21370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20384,6 +21408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20420,6 +21446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20456,6 +21484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20492,6 +21522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20528,6 +21560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20564,6 +21598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20600,6 +21636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20636,6 +21674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20672,6 +21712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20708,6 +21750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20744,6 +21788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20780,6 +21826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20816,6 +21864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20852,6 +21902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20888,6 +21940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20924,6 +21978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20960,6 +22016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20996,6 +22054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21032,6 +22092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21068,6 +22130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21104,6 +22168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21140,6 +22206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21176,6 +22244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21212,6 +22282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21248,6 +22320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21284,6 +22358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21320,6 +22396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21356,6 +22434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21392,6 +22472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21428,6 +22510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21464,6 +22548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21500,6 +22586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21536,6 +22624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21572,6 +22662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21608,6 +22700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21644,6 +22738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21680,6 +22776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21716,6 +22814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21752,6 +22852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21788,6 +22890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21824,6 +22928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21860,6 +22966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21896,6 +23004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21932,6 +23042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21968,6 +23080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22004,6 +23118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22040,6 +23156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22076,6 +23194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22112,6 +23232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22148,6 +23270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22184,6 +23308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22220,6 +23346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22256,6 +23384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22292,6 +23422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22328,6 +23460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22364,6 +23498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22400,6 +23536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22436,6 +23574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22472,6 +23612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22508,6 +23650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22544,6 +23688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22580,6 +23726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22616,6 +23764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22652,6 +23802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22688,6 +23840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22724,6 +23878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22760,6 +23916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22796,6 +23954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22832,6 +23992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22868,6 +24030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22904,6 +24068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22940,6 +24106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22976,6 +24144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23012,6 +24182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23048,6 +24220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23084,6 +24258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23120,6 +24296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23156,6 +24334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23192,6 +24372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23228,6 +24410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23264,6 +24448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23300,6 +24486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23336,6 +24524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23372,6 +24562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23408,6 +24600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23444,6 +24638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23480,6 +24676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23516,6 +24714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23552,6 +24752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23588,6 +24790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23624,6 +24828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23660,6 +24866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23696,6 +24904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23732,6 +24942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23768,6 +24980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23804,6 +25018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23840,6 +25056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23876,6 +25094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23912,6 +25132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23948,6 +25170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23984,6 +25208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24020,6 +25246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24056,6 +25284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24092,6 +25322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24128,6 +25360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24164,6 +25398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24200,6 +25436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24236,6 +25474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24272,6 +25512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24308,6 +25550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24344,6 +25588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24380,6 +25626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24416,6 +25664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24452,6 +25702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24488,6 +25740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24524,6 +25778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24560,6 +25816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24596,6 +25854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24632,6 +25892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24668,6 +25930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24704,6 +25968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24740,6 +26006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24776,6 +26044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24812,6 +26082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24848,6 +26120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24884,6 +26158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24920,6 +26196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24956,6 +26234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.1.sarif
@@ -1952,8 +1952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -1990,8 +1988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2028,8 +2024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2066,8 +2060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2104,8 +2096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2142,8 +2132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2180,8 +2168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2218,8 +2204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2256,8 +2240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2294,8 +2276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2332,8 +2312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2370,8 +2348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2408,8 +2384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2446,8 +2420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2484,8 +2456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2522,8 +2492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2560,8 +2528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2598,8 +2564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2636,8 +2600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2674,8 +2636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2712,8 +2672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2750,8 +2708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2788,8 +2744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2826,8 +2780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2864,8 +2816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2902,8 +2852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2940,8 +2888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2978,8 +2924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3016,8 +2960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3054,8 +2996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3092,8 +3032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3130,8 +3068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3168,8 +3104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3206,8 +3140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3244,8 +3176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3282,8 +3212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3320,8 +3248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3358,8 +3284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3396,8 +3320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3434,8 +3356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3472,8 +3392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3510,8 +3428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3548,8 +3464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3586,8 +3500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3624,8 +3536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3662,8 +3572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3700,8 +3608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3738,8 +3644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3776,8 +3680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3814,8 +3716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3852,8 +3752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3890,8 +3788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3928,8 +3824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3966,8 +3860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4004,8 +3896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4042,8 +3932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4080,8 +3968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4118,8 +4004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4156,8 +4040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4194,8 +4076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4232,8 +4112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4270,8 +4148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4308,8 +4184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4346,8 +4220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4384,8 +4256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4422,8 +4292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4460,8 +4328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4498,8 +4364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4536,8 +4400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4574,8 +4436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4612,8 +4472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4650,8 +4508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4688,8 +4544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4726,8 +4580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4764,8 +4616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4802,8 +4652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4840,8 +4688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4878,8 +4724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4916,8 +4760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4954,8 +4796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4992,8 +4832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5030,8 +4868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5068,8 +4904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5106,8 +4940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5144,8 +4976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5182,8 +5012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5220,8 +5048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5258,8 +5084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5296,8 +5120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5334,8 +5156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5372,8 +5192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5410,8 +5228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5448,8 +5264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5486,8 +5300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5524,8 +5336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5562,8 +5372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5600,8 +5408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5638,8 +5444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5676,8 +5480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5714,8 +5516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5752,8 +5552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5790,8 +5588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5828,8 +5624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5866,8 +5660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5904,8 +5696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5942,8 +5732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5980,8 +5768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6018,8 +5804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6056,8 +5840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6094,8 +5876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6132,8 +5912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6170,8 +5948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6208,8 +5984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6246,8 +6020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6284,8 +6056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6322,8 +6092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6360,8 +6128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6398,8 +6164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6436,8 +6200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6474,8 +6236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6512,8 +6272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6550,8 +6308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6588,8 +6344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6626,8 +6380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6664,8 +6416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6702,8 +6452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6740,8 +6488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6778,8 +6524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6816,8 +6560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6854,8 +6596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6892,8 +6632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6930,8 +6668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6968,8 +6704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7006,8 +6740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7044,8 +6776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7082,8 +6812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7120,8 +6848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7158,8 +6884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7196,8 +6920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7234,8 +6956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7272,8 +6992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7310,8 +7028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7348,8 +7064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7386,8 +7100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7424,8 +7136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7462,8 +7172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7500,8 +7208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7538,8 +7244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7576,8 +7280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7614,8 +7316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7652,8 +7352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7690,8 +7388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7728,8 +7424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7766,8 +7460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7804,8 +7496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7842,8 +7532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7880,8 +7568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7918,8 +7604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7956,8 +7640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7994,8 +7676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8032,8 +7712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8070,8 +7748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8108,8 +7784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8146,8 +7820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8184,8 +7856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8222,8 +7892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8260,8 +7928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8298,8 +7964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8336,8 +8000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8374,8 +8036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8412,8 +8072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8450,8 +8108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8488,8 +8144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8526,8 +8180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8564,8 +8216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8602,8 +8252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8640,8 +8288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8678,8 +8324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8716,8 +8360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8754,8 +8396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8792,8 +8432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8830,8 +8468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8868,8 +8504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8906,8 +8540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8944,8 +8576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8982,8 +8612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9020,8 +8648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9058,8 +8684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9096,8 +8720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9134,8 +8756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9172,8 +8792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9210,8 +8828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9248,8 +8864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9286,8 +8900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9324,8 +8936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9362,8 +8972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9400,8 +9008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9438,8 +9044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9476,8 +9080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9514,8 +9116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9552,8 +9152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9590,8 +9188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9628,8 +9224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9666,8 +9260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9704,8 +9296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9742,8 +9332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9780,8 +9368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9818,8 +9404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9856,8 +9440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9894,8 +9476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9932,8 +9512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9970,8 +9548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10008,8 +9584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10046,8 +9620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10084,8 +9656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10122,8 +9692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10160,8 +9728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10198,8 +9764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10236,8 +9800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10274,8 +9836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10312,8 +9872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10350,8 +9908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10388,8 +9944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10426,8 +9980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10464,8 +10016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10502,8 +10052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10540,8 +10088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10578,8 +10124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10616,8 +10160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10654,8 +10196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10692,8 +10232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10730,8 +10268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10768,8 +10304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10806,8 +10340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10844,8 +10376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10882,8 +10412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10920,8 +10448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10958,8 +10484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10996,8 +10520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11034,8 +10556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11072,8 +10592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11110,8 +10628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11148,8 +10664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11186,8 +10700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11224,8 +10736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11262,8 +10772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11300,8 +10808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11338,8 +10844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11376,8 +10880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11414,8 +10916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11452,8 +10952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11490,8 +10988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11528,8 +11024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11566,8 +11060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11604,8 +11096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11642,8 +11132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11680,8 +11168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11718,8 +11204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11756,8 +11240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11794,8 +11276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11832,8 +11312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11870,8 +11348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11908,8 +11384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11946,8 +11420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11984,8 +11456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12022,8 +11492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12060,8 +11528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12098,8 +11564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12136,8 +11600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12174,8 +11636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12212,8 +11672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12250,8 +11708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12288,8 +11744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12326,8 +11780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12364,8 +11816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12402,8 +11852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12440,8 +11888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12478,8 +11924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12516,8 +11960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12554,8 +11996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12592,8 +12032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12630,8 +12068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12668,8 +12104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12706,8 +12140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12744,8 +12176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12782,8 +12212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12820,8 +12248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12858,8 +12284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12896,8 +12320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12934,8 +12356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12972,8 +12392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13010,8 +12428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13048,8 +12464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13086,8 +12500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13124,8 +12536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13162,8 +12572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13200,8 +12608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13238,8 +12644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13276,8 +12680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13314,8 +12716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13352,8 +12752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13390,8 +12788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13428,8 +12824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13466,8 +12860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13504,8 +12896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13542,8 +12932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13580,8 +12968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13618,8 +13004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13656,8 +13040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13694,8 +13076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13732,8 +13112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13770,8 +13148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13808,8 +13184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13846,8 +13220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13884,8 +13256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13922,8 +13292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13960,8 +13328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13998,8 +13364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14036,8 +13400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14074,8 +13436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14112,8 +13472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14150,8 +13508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14188,8 +13544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14226,8 +13580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14264,8 +13616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14302,8 +13652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14340,8 +13688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14378,8 +13724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14416,8 +13760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14454,8 +13796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14492,8 +13832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14530,8 +13868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14568,8 +13904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14606,8 +13940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14644,8 +13976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14682,8 +14012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14720,8 +14048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14758,8 +14084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14796,8 +14120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14834,8 +14156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14872,8 +14192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14910,8 +14228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14948,8 +14264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14986,8 +14300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15024,8 +14336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15062,8 +14372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15100,8 +14408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15138,8 +14444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15176,8 +14480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15214,8 +14516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15252,8 +14552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15290,8 +14588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15328,8 +14624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15366,8 +14660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15404,8 +14696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15442,8 +14732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15480,8 +14768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15518,8 +14804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15556,8 +14840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15594,8 +14876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15632,8 +14912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15670,8 +14948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15708,8 +14984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15746,8 +15020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15784,8 +15056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15822,8 +15092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15860,8 +15128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15898,8 +15164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15936,8 +15200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15974,8 +15236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16012,8 +15272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16050,8 +15308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16088,8 +15344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16126,8 +15380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16164,8 +15416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16202,8 +15452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16240,8 +15488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16278,8 +15524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16316,8 +15560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16354,8 +15596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16392,8 +15632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16430,8 +15668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16468,8 +15704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16506,8 +15740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16544,8 +15776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16582,8 +15812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16620,8 +15848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16658,8 +15884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16696,8 +15920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16734,8 +15956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16772,8 +15992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16810,8 +16028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16848,8 +16064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16886,8 +16100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16924,8 +16136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16962,8 +16172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17000,8 +16208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17038,8 +16244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17076,8 +16280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17114,8 +16316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17152,8 +16352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17190,8 +16388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17228,8 +16424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17266,8 +16460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17304,8 +16496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17342,8 +16532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17380,8 +16568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17418,8 +16604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17456,8 +16640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17494,8 +16676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17532,8 +16712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17570,8 +16748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17608,8 +16784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17646,8 +16820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17684,8 +16856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17722,8 +16892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17760,8 +16928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17798,8 +16964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17836,8 +17000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17874,8 +17036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17912,8 +17072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17950,8 +17108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17988,8 +17144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18026,8 +17180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18064,8 +17216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18102,8 +17252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18140,8 +17288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18178,8 +17324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18216,8 +17360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18254,8 +17396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18292,8 +17432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18330,8 +17468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18368,8 +17504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18406,8 +17540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18444,8 +17576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18482,8 +17612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18520,8 +17648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18558,8 +17684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18596,8 +17720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18634,8 +17756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18672,8 +17792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18710,8 +17828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18748,8 +17864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18786,8 +17900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18824,8 +17936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18862,8 +17972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18900,8 +18008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18938,8 +18044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18976,8 +18080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19014,8 +18116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19052,8 +18152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19090,8 +18188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19128,8 +18224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19166,8 +18260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19204,8 +18296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19242,8 +18332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19280,8 +18368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19318,8 +18404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19356,8 +18440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19394,8 +18476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19432,8 +18512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19470,8 +18548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19508,8 +18584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19546,8 +18620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19584,8 +18656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19622,8 +18692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19660,8 +18728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19698,8 +18764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19736,8 +18800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19774,8 +18836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19812,8 +18872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19850,8 +18908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19888,8 +18944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19926,8 +18980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19964,8 +19016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20002,8 +19052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20040,8 +19088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20078,8 +19124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20116,8 +19160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20154,8 +19196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20192,8 +19232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20230,8 +19268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20268,8 +19304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20306,8 +19340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20344,8 +19376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20382,8 +19412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20420,8 +19448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20458,8 +19484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20496,8 +19520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20534,8 +19556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20572,8 +19592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20610,8 +19628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20648,8 +19664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20686,8 +19700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20724,8 +19736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20762,8 +19772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20800,8 +19808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20838,8 +19844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20876,8 +19880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20914,8 +19916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20952,8 +19952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20990,8 +19988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21028,8 +20024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21066,8 +20060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21104,8 +20096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21142,8 +20132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21180,8 +20168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21218,8 +20204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21256,8 +20240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21294,8 +20276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21332,8 +20312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21370,8 +20348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21408,8 +20384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21446,8 +20420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21484,8 +20456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21522,8 +20492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21560,8 +20528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21598,8 +20564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21636,8 +20600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21674,8 +20636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21712,8 +20672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21750,8 +20708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21788,8 +20744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21826,8 +20780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21864,8 +20816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21902,8 +20852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21940,8 +20888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21978,8 +20924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22016,8 +20960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22054,8 +20996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22092,8 +21032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22130,8 +21068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22168,8 +21104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22206,8 +21140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22244,8 +21176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22282,8 +21212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22320,8 +21248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22358,8 +21284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22396,8 +21320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22434,8 +21356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22472,8 +21392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22510,8 +21428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22548,8 +21464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22586,8 +21500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22624,8 +21536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22662,8 +21572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22700,8 +21608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22738,8 +21644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22776,8 +21680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22814,8 +21716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22852,8 +21752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22890,8 +21788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22928,8 +21824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22966,8 +21860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23004,8 +21896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23042,8 +21932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23080,8 +21968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23118,8 +22004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23156,8 +22040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23194,8 +22076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23232,8 +22112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23270,8 +22148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23308,8 +22184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23346,8 +22220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23384,8 +22256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23422,8 +22292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23460,8 +22328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23498,8 +22364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23536,8 +22400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23574,8 +22436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23612,8 +22472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23650,8 +22508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23688,8 +22544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23726,8 +22580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23764,8 +22616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23802,8 +22652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23840,8 +22688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23878,8 +22724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23916,8 +22760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23954,8 +22796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23992,8 +22832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24030,8 +22868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24068,8 +22904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24106,8 +22940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24144,8 +22976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24182,8 +23012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24220,8 +23048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24258,8 +23084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24296,8 +23120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24334,8 +23156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24372,8 +23192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24410,8 +23228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24448,8 +23264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24486,8 +23300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24524,8 +23336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24562,8 +23372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24600,8 +23408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24638,8 +23444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24676,8 +23480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24714,8 +23516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24752,8 +23552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24790,8 +23588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24828,8 +23624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24866,8 +23660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24904,8 +23696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24942,8 +23732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24980,8 +23768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25018,8 +23804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25056,8 +23840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25094,8 +23876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25132,8 +23912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25170,8 +23948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25208,8 +23984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25246,8 +24020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25284,8 +24056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25322,8 +24092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25360,8 +24128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25398,8 +24164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25436,8 +24200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25474,8 +24236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25512,8 +24272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25550,8 +24308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25588,8 +24344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25626,8 +24380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25664,8 +24416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25702,8 +24452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25740,8 +24488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25778,8 +24524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25816,8 +24560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25854,8 +24596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25892,8 +24632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25930,8 +24668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25968,8 +24704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26006,8 +24740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26044,8 +24776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26082,8 +24812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26120,8 +24848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26158,8 +24884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26196,8 +24920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26234,8 +24956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.2.sarif
@@ -1980,8 +1980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2018,8 +2016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2056,8 +2052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2094,8 +2088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2132,8 +2124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2170,8 +2160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2208,8 +2196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2246,8 +2232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2284,8 +2268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2322,8 +2304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2360,8 +2340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2398,8 +2376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2436,8 +2412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2474,8 +2448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2512,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2550,8 +2520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2588,8 +2556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2626,8 +2592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2664,8 +2628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2702,8 +2664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2740,8 +2700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2778,8 +2736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2816,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2854,8 +2808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2892,8 +2844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2930,8 +2880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2968,8 +2916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3006,8 +2952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3044,8 +2988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3082,8 +3024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3120,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3158,8 +3096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3196,8 +3132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3234,8 +3168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3272,8 +3204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3310,8 +3240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3348,8 +3276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3386,8 +3312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3424,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3462,8 +3384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3500,8 +3420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3538,8 +3456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3576,8 +3492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3614,8 +3528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3652,8 +3564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3690,8 +3600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3728,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3766,8 +3672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3804,8 +3708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3842,8 +3744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3880,8 +3780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3918,8 +3816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3956,8 +3852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3994,8 +3888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4032,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4070,8 +3960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4108,8 +3996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4146,8 +4032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4184,8 +4068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4222,8 +4104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4260,8 +4140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4298,8 +4176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4336,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4374,8 +4248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4412,8 +4284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4450,8 +4320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4488,8 +4356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4526,8 +4392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4564,8 +4428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4602,8 +4464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4640,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4678,8 +4536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4716,8 +4572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4754,8 +4608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4792,8 +4644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4830,8 +4680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4868,8 +4716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4906,8 +4752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4944,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4982,8 +4824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5020,8 +4860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5058,8 +4896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5096,8 +4932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5134,8 +4968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5172,8 +5004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5210,8 +5040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5248,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5286,8 +5112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5324,8 +5148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5362,8 +5184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5400,8 +5220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5438,8 +5256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5476,8 +5292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5514,8 +5328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5552,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5590,8 +5400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5628,8 +5436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5666,8 +5472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5704,8 +5508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5742,8 +5544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5780,8 +5580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5818,8 +5616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5856,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5894,8 +5688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5932,8 +5724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5970,8 +5760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,8 +5796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6046,8 +5832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6084,8 +5868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6122,8 +5904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6160,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6198,8 +5976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6236,8 +6012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6274,8 +6048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6312,8 +6084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6350,8 +6120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6388,8 +6156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6426,8 +6192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6464,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6502,8 +6264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6540,8 +6300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6578,8 +6336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6616,8 +6372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6654,8 +6408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6692,8 +6444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6730,8 +6480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6768,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6806,8 +6552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6844,8 +6588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6882,8 +6624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6920,8 +6660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6958,8 +6696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6996,8 +6732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7034,8 +6768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7072,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7110,8 +6840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7148,8 +6876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7186,8 +6912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7224,8 +6948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7262,8 +6984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7300,8 +7020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7338,8 +7056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7376,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7414,8 +7128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7452,8 +7164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7490,8 +7200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7528,8 +7236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7566,8 +7272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7604,8 +7308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7642,8 +7344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7680,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,8 +7416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7756,8 +7452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7794,8 +7488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7832,8 +7524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7870,8 +7560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7908,8 +7596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7946,8 +7632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7984,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8022,8 +7704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8060,8 +7740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8098,8 +7776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8136,8 +7812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8174,8 +7848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8212,8 +7884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8250,8 +7920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8288,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8326,8 +7992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8364,8 +8028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8402,8 +8064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8440,8 +8100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8478,8 +8136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8516,8 +8172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8554,8 +8208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8592,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8630,8 +8280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8668,8 +8316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8706,8 +8352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8744,8 +8388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8782,8 +8424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8820,8 +8460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8858,8 +8496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8896,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8934,8 +8568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8972,8 +8604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9010,8 +8640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9048,8 +8676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9086,8 +8712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9124,8 +8748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9162,8 +8784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9200,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9238,8 +8856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9276,8 +8892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9314,8 +8928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9352,8 +8964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9390,8 +9000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9428,8 +9036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9466,8 +9072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9504,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9542,8 +9144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9580,8 +9180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9618,8 +9216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9656,8 +9252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9694,8 +9288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9732,8 +9324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9770,8 +9360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9808,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9846,8 +9432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9884,8 +9468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9922,8 +9504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9960,8 +9540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9998,8 +9576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10036,8 +9612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10074,8 +9648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10112,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10150,8 +9720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10188,8 +9756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10226,8 +9792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10264,8 +9828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10302,8 +9864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10340,8 +9900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10378,8 +9936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10416,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10454,8 +10008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10492,8 +10044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10530,8 +10080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10568,8 +10116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10606,8 +10152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10644,8 +10188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10682,8 +10224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10720,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10758,8 +10296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10796,8 +10332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10834,8 +10368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10872,8 +10404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10910,8 +10440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10948,8 +10476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10986,8 +10512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11024,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11062,8 +10584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11100,8 +10620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11138,8 +10656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11176,8 +10692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11214,8 +10728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11252,8 +10764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11290,8 +10800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11328,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11366,8 +10872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11404,8 +10908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11442,8 +10944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11480,8 +10980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11518,8 +11016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11556,8 +11052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11594,8 +11088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11632,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11670,8 +11160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11708,8 +11196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11746,8 +11232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11784,8 +11268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11822,8 +11304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11860,8 +11340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11898,8 +11376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11936,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11974,8 +11448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12012,8 +11484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12050,8 +11520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12088,8 +11556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12126,8 +11592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12164,8 +11628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12202,8 +11664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12240,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12278,8 +11736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12316,8 +11772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12354,8 +11808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12392,8 +11844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12430,8 +11880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12468,8 +11916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12506,8 +11952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12544,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12582,8 +12024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12620,8 +12060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12658,8 +12096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12696,8 +12132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12734,8 +12168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12772,8 +12204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12810,8 +12240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12848,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12886,8 +12312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12924,8 +12348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12962,8 +12384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13000,8 +12420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13038,8 +12456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13076,8 +12492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13114,8 +12528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13152,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13190,8 +12600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13228,8 +12636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13266,8 +12672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13304,8 +12708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13342,8 +12744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13380,8 +12780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13418,8 +12816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13456,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13494,8 +12888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13532,8 +12924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13570,8 +12960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13608,8 +12996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13646,8 +13032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13684,8 +13068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13722,8 +13104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13760,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13798,8 +13176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13836,8 +13212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13874,8 +13248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13912,8 +13284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13950,8 +13320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13988,8 +13356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14026,8 +13392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14064,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14102,8 +13464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14140,8 +13500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14178,8 +13536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14216,8 +13572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14254,8 +13608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14292,8 +13644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14330,8 +13680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14368,8 +13716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14406,8 +13752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14444,8 +13788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14482,8 +13824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14520,8 +13860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14558,8 +13896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14596,8 +13932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14634,8 +13968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14672,8 +14004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14710,8 +14040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14748,8 +14076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14786,8 +14112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14824,8 +14148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14862,8 +14184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14900,8 +14220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14938,8 +14256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14976,8 +14292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15014,8 +14328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15052,8 +14364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15090,8 +14400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15128,8 +14436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15166,8 +14472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15204,8 +14508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15242,8 +14544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15280,8 +14580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15318,8 +14616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15356,8 +14652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15394,8 +14688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15432,8 +14724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15470,8 +14760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15508,8 +14796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15546,8 +14832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15584,8 +14868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15622,8 +14904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15660,8 +14940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15698,8 +14976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15736,8 +15012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15774,8 +15048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15812,8 +15084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15850,8 +15120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15888,8 +15156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15926,8 +15192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15964,8 +15228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16002,8 +15264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16040,8 +15300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16078,8 +15336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16116,8 +15372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16154,8 +15408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16192,8 +15444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16230,8 +15480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16268,8 +15516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16306,8 +15552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16344,8 +15588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16382,8 +15624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16420,8 +15660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16458,8 +15696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16496,8 +15732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16534,8 +15768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16572,8 +15804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16610,8 +15840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16648,8 +15876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16686,8 +15912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16724,8 +15948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16762,8 +15984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16800,8 +16020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16838,8 +16056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16876,8 +16092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16914,8 +16128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16952,8 +16164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16990,8 +16200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17028,8 +16236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17066,8 +16272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17104,8 +16308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17142,8 +16344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17180,8 +16380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17218,8 +16416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17256,8 +16452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17294,8 +16488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17332,8 +16524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17370,8 +16560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17408,8 +16596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17446,8 +16632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17484,8 +16668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17522,8 +16704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17560,8 +16740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17598,8 +16776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17636,8 +16812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17674,8 +16848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17712,8 +16884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17750,8 +16920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17788,8 +16956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17826,8 +16992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17864,8 +17028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17902,8 +17064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17940,8 +17100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17978,8 +17136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18016,8 +17172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18054,8 +17208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18092,8 +17244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18130,8 +17280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18168,8 +17316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18206,8 +17352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18244,8 +17388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18282,8 +17424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18320,8 +17460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18358,8 +17496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18396,8 +17532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18434,8 +17568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18472,8 +17604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18510,8 +17640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18548,8 +17676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18586,8 +17712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18624,8 +17748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18662,8 +17784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18700,8 +17820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18738,8 +17856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18776,8 +17892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18814,8 +17928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18852,8 +17964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18890,8 +18000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18928,8 +18036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18966,8 +18072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19004,8 +18108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19042,8 +18144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19080,8 +18180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19118,8 +18216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19156,8 +18252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19194,8 +18288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19232,8 +18324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19270,8 +18360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19308,8 +18396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19346,8 +18432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19384,8 +18468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19422,8 +18504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19460,8 +18540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19498,8 +18576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19536,8 +18612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19574,8 +18648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19612,8 +18684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19650,8 +18720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19688,8 +18756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19726,8 +18792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19764,8 +18828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19802,8 +18864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19840,8 +18900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19878,8 +18936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19916,8 +18972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19954,8 +19008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19992,8 +19044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20030,8 +19080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20068,8 +19116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20106,8 +19152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20144,8 +19188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20182,8 +19224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20220,8 +19260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20258,8 +19296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20296,8 +19332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20334,8 +19368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20372,8 +19404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20410,8 +19440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20448,8 +19476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20486,8 +19512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20524,8 +19548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20562,8 +19584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20600,8 +19620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20638,8 +19656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20676,8 +19692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20714,8 +19728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20752,8 +19764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20790,8 +19800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20828,8 +19836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20866,8 +19872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20904,8 +19908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20942,8 +19944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20980,8 +19980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21018,8 +20016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21056,8 +20052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21094,8 +20088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21132,8 +20124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21170,8 +20160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21208,8 +20196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21246,8 +20232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21284,8 +20268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21322,8 +20304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21360,8 +20340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21398,8 +20376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21436,8 +20412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21474,8 +20448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21512,8 +20484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21550,8 +20520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21588,8 +20556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21626,8 +20592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21664,8 +20628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21702,8 +20664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21740,8 +20700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21778,8 +20736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21816,8 +20772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21854,8 +20808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21892,8 +20844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21930,8 +20880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21968,8 +20916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22006,8 +20952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22044,8 +20988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22082,8 +21024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22120,8 +21060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22158,8 +21096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22196,8 +21132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22234,8 +21168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22272,8 +21204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22310,8 +21240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22348,8 +21276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22386,8 +21312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22424,8 +21348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22462,8 +21384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22500,8 +21420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22538,8 +21456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22576,8 +21492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22614,8 +21528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22652,8 +21564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22690,8 +21600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22728,8 +21636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22766,8 +21672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22804,8 +21708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22842,8 +21744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22880,8 +21780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22918,8 +21816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22956,8 +21852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22994,8 +21888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23032,8 +21924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23070,8 +21960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23108,8 +21996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23146,8 +22032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23184,8 +22068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23222,8 +22104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23260,8 +22140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23298,8 +22176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23336,8 +22212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23374,8 +22248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23412,8 +22284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23450,8 +22320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23488,8 +22356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23526,8 +22392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23564,8 +22428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23602,8 +22464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23640,8 +22500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23678,8 +22536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23716,8 +22572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23754,8 +22608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23792,8 +22644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23830,8 +22680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23868,8 +22716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23906,8 +22752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23944,8 +22788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23982,8 +22824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24020,8 +22860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24058,8 +22896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24096,8 +22932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24134,8 +22968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24172,8 +23004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24210,8 +23040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24248,8 +23076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24286,8 +23112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24324,8 +23148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24362,8 +23184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24400,8 +23220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24438,8 +23256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24476,8 +23292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24514,8 +23328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24552,8 +23364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24590,8 +23400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24628,8 +23436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24666,8 +23472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24704,8 +23508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24742,8 +23544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24780,8 +23580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24818,8 +23616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24856,8 +23652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24894,8 +23688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24932,8 +23724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24970,8 +23760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25008,8 +23796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25046,8 +23832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25084,8 +23868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25122,8 +23904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25160,8 +23940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25198,8 +23976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25236,8 +24012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25274,8 +24048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25312,8 +24084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25350,8 +24120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25388,8 +24156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25426,8 +24192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25464,8 +24228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25502,8 +24264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25540,8 +24300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25578,8 +24336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25616,8 +24372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25654,8 +24408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25692,8 +24444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25730,8 +24480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25768,8 +24516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25806,8 +24552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25844,8 +24588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25882,8 +24624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25920,8 +24660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25958,8 +24696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25996,8 +24732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26034,8 +24768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26072,8 +24804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26110,8 +24840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26148,8 +24876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,8 +24912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26224,8 +24948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26262,8 +24984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.2.sarif
@@ -1979,6 +1979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2014,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2049,6 +2055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2084,6 +2093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2119,6 +2131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2154,6 +2169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2189,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2224,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2259,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2294,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2329,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2364,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2399,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2434,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2469,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2504,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2539,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2574,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2609,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2644,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2679,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2714,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2749,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2784,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2819,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2854,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2889,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2924,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2959,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2994,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3029,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3064,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3099,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3134,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3169,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3204,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3239,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3274,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3309,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3344,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3379,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3414,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3449,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3484,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3519,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3554,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3589,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3624,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3659,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3694,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3729,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3764,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3799,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3834,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3869,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3904,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3939,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3974,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4009,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4044,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4079,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4114,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4149,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4184,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4219,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4254,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4289,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4324,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4359,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4394,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4429,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4499,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4534,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4569,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4604,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4639,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4674,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4709,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4744,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4779,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4814,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4849,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4884,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4919,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4954,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4989,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5024,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5059,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5094,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5129,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5164,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5199,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5234,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5269,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5304,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5339,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5374,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5409,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5444,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5479,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5514,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5549,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5584,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5619,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5654,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5689,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5759,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5794,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5829,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5864,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5899,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5934,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5969,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6004,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6039,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6074,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6109,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6144,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6179,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6214,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6249,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6284,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6319,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6354,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6389,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6424,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6459,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6494,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6529,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6564,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6599,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6634,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6669,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6704,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6739,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6774,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6809,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6844,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6879,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6914,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6949,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6984,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7019,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7054,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7089,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7124,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7159,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7194,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7229,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7264,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7299,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7334,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7369,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7404,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7439,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7474,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7509,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7544,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7579,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7614,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7649,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7684,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7719,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7754,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7789,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7824,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7859,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7894,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -7929,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -7964,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -7999,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8034,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8069,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8104,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8139,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8174,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8209,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8244,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8279,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8314,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8349,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8384,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8419,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8454,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8489,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8524,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8559,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8594,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8629,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8664,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8699,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8734,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8769,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8804,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -8839,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -8874,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -8909,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -8944,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -8979,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9014,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9049,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9084,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9119,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9154,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9189,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9224,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9259,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9294,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9329,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9364,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9399,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9434,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9469,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9504,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9539,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9574,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9609,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9644,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9679,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9714,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9749,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9784,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9819,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9854,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9889,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9924,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9959,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9994,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10029,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10064,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10099,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10134,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10169,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10204,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10239,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10274,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10309,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10344,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10379,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10414,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10449,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10484,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10519,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10554,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10589,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10624,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10659,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10694,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10729,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10764,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10799,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10834,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10869,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10904,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10939,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10974,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11009,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11044,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11079,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11114,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11149,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11184,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11219,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11254,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11289,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11324,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11359,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11394,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11429,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11464,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11499,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11534,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11569,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11604,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11639,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11674,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11709,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11744,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11779,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11814,6 +12657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11849,6 +12695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11884,6 +12733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11919,6 +12771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11954,6 +12809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11989,6 +12847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12024,6 +12885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12059,6 +12923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12094,6 +12961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12129,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12164,6 +13037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12199,6 +13075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12234,6 +13113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12269,6 +13151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12304,6 +13189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12339,6 +13227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12374,6 +13265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12409,6 +13303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12444,6 +13341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12479,6 +13379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12514,6 +13417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12549,6 +13455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12584,6 +13493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12619,6 +13531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12654,6 +13569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12689,6 +13607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12724,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12759,6 +13683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12794,6 +13721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12829,6 +13759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12864,6 +13797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12899,6 +13835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12934,6 +13873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12969,6 +13911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13004,6 +13949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13039,6 +13987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13074,6 +14025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13109,6 +14063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13144,6 +14101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13179,6 +14139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13214,6 +14177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13249,6 +14215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13284,6 +14253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13319,6 +14291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13354,6 +14329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13389,6 +14367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13424,6 +14405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13459,6 +14443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13494,6 +14481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13529,6 +14519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13564,6 +14557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13599,6 +14595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13634,6 +14633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13669,6 +14671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13704,6 +14709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13739,6 +14747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13774,6 +14785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -13809,6 +14823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13844,6 +14861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -13879,6 +14899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -13914,6 +14937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -13949,6 +14975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13984,6 +15013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14019,6 +15051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14054,6 +15089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14089,6 +15127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14124,6 +15165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14159,6 +15203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14194,6 +15241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14229,6 +15279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14264,6 +15317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14299,6 +15355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14334,6 +15393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14369,6 +15431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14404,6 +15469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14439,6 +15507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14474,6 +15545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14509,6 +15583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14544,6 +15621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14579,6 +15659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14614,6 +15697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14649,6 +15735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14684,6 +15773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14719,6 +15811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14754,6 +15849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14789,6 +15887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14824,6 +15925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -14859,6 +15963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14894,6 +16001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14929,6 +16039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14964,6 +16077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -14999,6 +16115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15034,6 +16153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15069,6 +16191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15104,6 +16229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15139,6 +16267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15174,6 +16305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15209,6 +16343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15244,6 +16381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15279,6 +16419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15314,6 +16457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15349,6 +16495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15384,6 +16533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15419,6 +16571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15454,6 +16609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15489,6 +16647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15524,6 +16685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15559,6 +16723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15594,6 +16761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15629,6 +16799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15664,6 +16837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15699,6 +16875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15734,6 +16913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15769,6 +16951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15804,6 +16989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15839,6 +17027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15874,6 +17065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15909,6 +17103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15944,6 +17141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15979,6 +17179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16014,6 +17217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16049,6 +17255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16084,6 +17293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16119,6 +17331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16154,6 +17369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16189,6 +17407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16224,6 +17445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16259,6 +17483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16294,6 +17521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16329,6 +17559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16364,6 +17597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16399,6 +17635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16434,6 +17673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16469,6 +17711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16504,6 +17749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16539,6 +17787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16574,6 +17825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16609,6 +17863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16644,6 +17901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16679,6 +17939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16714,6 +17977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16749,6 +18015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16784,6 +18053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16819,6 +18091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16854,6 +18129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -16889,6 +18167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16924,6 +18205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16959,6 +18243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -16994,6 +18281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17029,6 +18319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17064,6 +18357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17099,6 +18395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17134,6 +18433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17169,6 +18471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17204,6 +18509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17239,6 +18547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17274,6 +18585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17309,6 +18623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17344,6 +18661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17379,6 +18699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17414,6 +18737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17449,6 +18775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17484,6 +18813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17519,6 +18851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17554,6 +18889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17589,6 +18927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17624,6 +18965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17659,6 +19003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17694,6 +19041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17729,6 +19079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17764,6 +19117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17799,6 +19155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17834,6 +19193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17869,6 +19231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17904,6 +19269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -17939,6 +19307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -17974,6 +19345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18009,6 +19383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18044,6 +19421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18079,6 +19459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18114,6 +19497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18149,6 +19535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18184,6 +19573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18219,6 +19611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18254,6 +19649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18289,6 +19687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18324,6 +19725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18359,6 +19763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18394,6 +19801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18429,6 +19839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18464,6 +19877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18499,6 +19915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18534,6 +19953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18569,6 +19991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18604,6 +20029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18639,6 +20067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18674,6 +20105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18709,6 +20143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18744,6 +20181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18779,6 +20219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18814,6 +20257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18849,6 +20295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18884,6 +20333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18919,6 +20371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18954,6 +20409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18989,6 +20447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19024,6 +20485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19059,6 +20523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19094,6 +20561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19129,6 +20599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19164,6 +20637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19199,6 +20675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19234,6 +20713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19269,6 +20751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19304,6 +20789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19339,6 +20827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19374,6 +20865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19409,6 +20903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19444,6 +20941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19479,6 +20979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19514,6 +21017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19549,6 +21055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19584,6 +21093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19619,6 +21131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19654,6 +21169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19689,6 +21207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19724,6 +21245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19759,6 +21283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -19794,6 +21321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19829,6 +21359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19864,6 +21397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19899,6 +21435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19934,6 +21473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19969,6 +21511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20004,6 +21549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20039,6 +21587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20074,6 +21625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20109,6 +21663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20144,6 +21701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20179,6 +21739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20214,6 +21777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20249,6 +21815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20284,6 +21853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20319,6 +21891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20354,6 +21929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20389,6 +21967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20424,6 +22005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20459,6 +22043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20494,6 +22081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20529,6 +22119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20564,6 +22157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20599,6 +22195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20634,6 +22233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20669,6 +22271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20704,6 +22309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20739,6 +22347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20774,6 +22385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20809,6 +22423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20844,6 +22461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20879,6 +22499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -20914,6 +22537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -20949,6 +22575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -20984,6 +22613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21019,6 +22651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21054,6 +22689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21089,6 +22727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21124,6 +22765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21159,6 +22803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21194,6 +22841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21229,6 +22879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21264,6 +22917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21299,6 +22955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21334,6 +22993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21369,6 +23031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21404,6 +23069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21439,6 +23107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21474,6 +23145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21509,6 +23183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21544,6 +23221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21579,6 +23259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21614,6 +23297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21649,6 +23335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21684,6 +23373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21719,6 +23411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21754,6 +23449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21789,6 +23487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -21824,6 +23525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -21859,6 +23563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -21894,6 +23601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -21929,6 +23639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -21964,6 +23677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -21999,6 +23715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22034,6 +23753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22069,6 +23791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22104,6 +23829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22139,6 +23867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22174,6 +23905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22209,6 +23943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22244,6 +23981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22279,6 +24019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22314,6 +24057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22349,6 +24095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22384,6 +24133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22419,6 +24171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22454,6 +24209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22489,6 +24247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22524,6 +24285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22559,6 +24323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22594,6 +24361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22629,6 +24399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22664,6 +24437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22699,6 +24475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22734,6 +24513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22769,6 +24551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22804,6 +24589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -22839,6 +24627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -22874,6 +24665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -22909,6 +24703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -22944,6 +24741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22979,6 +24779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23014,6 +24817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23049,6 +24855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23084,6 +24893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23119,6 +24931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23154,6 +24969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23189,6 +25007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23224,6 +25045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23259,6 +25083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23294,6 +25121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23329,6 +25159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23364,6 +25197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23399,6 +25235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23434,6 +25273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23469,6 +25311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23504,6 +25349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23539,6 +25387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23574,6 +25425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23609,6 +25463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23644,6 +25501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23679,6 +25539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23714,6 +25577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23749,6 +25615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23784,6 +25653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23819,6 +25691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23854,6 +25729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23889,6 +25767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -23924,6 +25805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23959,6 +25843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23994,6 +25881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24029,6 +25919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24064,6 +25957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24099,6 +25995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24134,6 +26033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24169,6 +26071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24204,6 +26109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24239,6 +26147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24274,6 +26185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24309,6 +26223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24344,6 +26261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.2.sarif
@@ -1980,6 +1980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2016,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2052,6 +2056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2088,6 +2094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2124,6 +2132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2160,6 +2170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2196,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2232,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2268,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2304,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2340,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2376,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2412,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2448,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2484,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2520,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2556,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2592,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2628,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2664,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2700,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2736,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2772,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2808,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2844,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2880,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2916,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2952,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2988,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3024,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3060,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3096,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3132,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3168,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3204,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3240,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3276,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3312,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3348,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3384,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3420,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3456,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3492,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3528,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3564,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3600,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3636,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3672,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3708,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3744,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3780,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3816,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3852,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3888,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3924,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3960,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3996,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4032,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4068,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4104,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4140,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4176,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4212,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4248,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4284,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4320,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4356,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4392,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4428,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4500,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4536,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4572,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4608,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4644,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4680,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4716,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4752,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4788,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4824,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4860,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4896,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4932,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4968,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5004,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5040,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5076,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5112,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5148,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5184,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5220,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5256,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5292,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5328,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5364,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5400,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5436,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5472,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5508,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5544,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5580,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5616,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5652,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5688,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5760,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5796,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5832,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5868,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5904,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5940,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5976,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6012,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6048,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6084,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6120,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6156,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6192,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6228,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6264,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6300,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6336,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6372,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6408,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6444,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6480,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6516,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6552,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6588,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6624,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6660,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6696,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6732,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6768,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6804,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6840,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6876,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6912,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6948,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6984,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7020,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7056,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7092,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7128,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7164,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7200,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7236,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7272,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7308,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7344,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7380,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7416,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7452,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7488,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7524,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7560,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7596,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7632,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7668,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7704,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7740,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7776,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7812,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7848,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7884,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7920,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7956,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7992,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8028,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8064,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8100,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8136,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8172,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8208,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8244,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8280,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8316,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8352,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8388,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8424,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8460,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8496,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8532,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8568,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8604,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8640,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8676,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8712,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8748,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8784,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8820,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8856,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8892,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8928,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8964,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9000,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9036,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9072,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9108,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9144,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9180,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9216,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9252,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9288,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9324,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9360,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9396,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9432,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9468,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9504,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9540,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9576,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9612,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9648,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9684,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9720,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9756,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9792,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9828,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9864,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9900,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9936,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9972,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10008,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10044,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10080,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10116,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10152,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10188,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10224,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10260,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10296,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10332,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10368,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10404,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10440,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10476,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10512,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10548,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10584,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10620,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10656,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10692,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10728,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10764,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10800,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10836,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10872,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10908,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10944,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10980,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11016,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11052,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11088,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11124,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11160,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11196,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11232,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11268,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11304,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11340,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11376,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11412,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11448,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11484,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11520,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11556,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11592,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11628,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11664,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11700,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11736,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11772,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11808,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11844,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11880,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11916,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11952,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11988,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12024,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12060,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12096,6 +12658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12132,6 +12696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12168,6 +12734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12204,6 +12772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12240,6 +12810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12276,6 +12848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12312,6 +12886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12348,6 +12924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12384,6 +12962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12420,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12456,6 +13038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12492,6 +13076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12528,6 +13114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12564,6 +13152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12600,6 +13190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12636,6 +13228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12672,6 +13266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12708,6 +13304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12744,6 +13342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12780,6 +13380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12852,6 +13456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12888,6 +13494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12924,6 +13532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12960,6 +13570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12996,6 +13608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13032,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13068,6 +13684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13104,6 +13722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13140,6 +13760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13176,6 +13798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13212,6 +13836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13248,6 +13874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13284,6 +13912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13320,6 +13950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13356,6 +13988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13392,6 +14026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13428,6 +14064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13464,6 +14102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13500,6 +14140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13536,6 +14178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13572,6 +14216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13608,6 +14254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13644,6 +14292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13680,6 +14330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13716,6 +14368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13752,6 +14406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13788,6 +14444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13824,6 +14482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13860,6 +14520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13896,6 +14558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13932,6 +14596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13968,6 +14634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14004,6 +14672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14040,6 +14710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14076,6 +14748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14112,6 +14786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14148,6 +14824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14184,6 +14862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14220,6 +14900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14256,6 +14938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14292,6 +14976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14328,6 +15014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14364,6 +15052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14400,6 +15090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14436,6 +15128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14472,6 +15166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14508,6 +15204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14544,6 +15242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14580,6 +15280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14616,6 +15318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14652,6 +15356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14688,6 +15394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14724,6 +15432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14760,6 +15470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14796,6 +15508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14832,6 +15546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14868,6 +15584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14904,6 +15622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14940,6 +15660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14976,6 +15698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15012,6 +15736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15048,6 +15774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15084,6 +15812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15120,6 +15850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15156,6 +15888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15192,6 +15926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15228,6 +15964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15264,6 +16002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15300,6 +16040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15336,6 +16078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15372,6 +16116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15408,6 +16154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15444,6 +16192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15480,6 +16230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15516,6 +16268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15552,6 +16306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15588,6 +16344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15624,6 +16382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15660,6 +16420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15696,6 +16458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15732,6 +16496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15768,6 +16534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15804,6 +16572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15840,6 +16610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15876,6 +16648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15912,6 +16686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15948,6 +16724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15984,6 +16762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16020,6 +16800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16056,6 +16838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16092,6 +16876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16128,6 +16914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16164,6 +16952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16200,6 +16990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16236,6 +17028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16272,6 +17066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16308,6 +17104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16344,6 +17142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16380,6 +17180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16416,6 +17218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16452,6 +17256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16488,6 +17294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16524,6 +17332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16560,6 +17370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16596,6 +17408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16632,6 +17446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16668,6 +17484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16704,6 +17522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16740,6 +17560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16776,6 +17598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16812,6 +17636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16848,6 +17674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16884,6 +17712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16920,6 +17750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16956,6 +17788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16992,6 +17826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17028,6 +17864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17064,6 +17902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17100,6 +17940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17136,6 +17978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17172,6 +18016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17208,6 +18054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17244,6 +18092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17280,6 +18130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17316,6 +18168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17352,6 +18206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17388,6 +18244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17424,6 +18282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17460,6 +18320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17496,6 +18358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17532,6 +18396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17568,6 +18434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17604,6 +18472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17640,6 +18510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17676,6 +18548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17712,6 +18586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17748,6 +18624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17784,6 +18662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17820,6 +18700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17856,6 +18738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17892,6 +18776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17928,6 +18814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17964,6 +18852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18000,6 +18890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18036,6 +18928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18072,6 +18966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18108,6 +19004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18144,6 +19042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18180,6 +19080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18216,6 +19118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18252,6 +19156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18288,6 +19194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18324,6 +19232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18360,6 +19270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18396,6 +19308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18432,6 +19346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18468,6 +19384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18504,6 +19422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18540,6 +19460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18576,6 +19498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18612,6 +19536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18648,6 +19574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18684,6 +19612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18720,6 +19650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18756,6 +19688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18792,6 +19726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18828,6 +19764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18864,6 +19802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18900,6 +19840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18936,6 +19878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18972,6 +19916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19008,6 +19954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19044,6 +19992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19080,6 +20030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19116,6 +20068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19152,6 +20106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19188,6 +20144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19224,6 +20182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19260,6 +20220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19296,6 +20258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19332,6 +20296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19368,6 +20334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19404,6 +20372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19440,6 +20410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19476,6 +20448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19512,6 +20486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19548,6 +20524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19584,6 +20562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19620,6 +20600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19656,6 +20638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19692,6 +20676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19728,6 +20714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19764,6 +20752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19800,6 +20790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19836,6 +20828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19872,6 +20866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19908,6 +20904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19944,6 +20942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19980,6 +20980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20016,6 +21018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20052,6 +21056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20088,6 +21094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20124,6 +21132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20160,6 +21170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20196,6 +21208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20232,6 +21246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20268,6 +21284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20304,6 +21322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20340,6 +21360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20376,6 +21398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20412,6 +21436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20448,6 +21474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20484,6 +21512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20520,6 +21550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20556,6 +21588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20592,6 +21626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20628,6 +21664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20664,6 +21702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20700,6 +21740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20736,6 +21778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20772,6 +21816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20808,6 +21854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20844,6 +21892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20880,6 +21930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20916,6 +21968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20952,6 +22006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20988,6 +22044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21024,6 +22082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21060,6 +22120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21096,6 +22158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21132,6 +22196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21168,6 +22234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21204,6 +22272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21240,6 +22310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21276,6 +22348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21312,6 +22386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21348,6 +22424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21384,6 +22462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21420,6 +22500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21456,6 +22538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21492,6 +22576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21528,6 +22614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21564,6 +22652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21600,6 +22690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21636,6 +22728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21672,6 +22766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21708,6 +22804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21744,6 +22842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21780,6 +22880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21816,6 +22918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21852,6 +22956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21888,6 +22994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21924,6 +23032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21960,6 +23070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21996,6 +23108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22032,6 +23146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22068,6 +23184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22104,6 +23222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22140,6 +23260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22176,6 +23298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22212,6 +23336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22248,6 +23374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22284,6 +23412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22320,6 +23450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22356,6 +23488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22392,6 +23526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22428,6 +23564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22464,6 +23602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22500,6 +23640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22536,6 +23678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22572,6 +23716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22608,6 +23754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22644,6 +23792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22680,6 +23830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22716,6 +23868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22752,6 +23906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22788,6 +23944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22824,6 +23982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22860,6 +24020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22896,6 +24058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22932,6 +24096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22968,6 +24134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23004,6 +24172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23040,6 +24210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23076,6 +24248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23112,6 +24286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23148,6 +24324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23184,6 +24362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23220,6 +24400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23256,6 +24438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23292,6 +24476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23328,6 +24514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23364,6 +24552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23400,6 +24590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23436,6 +24628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23472,6 +24666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23508,6 +24704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23544,6 +24742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23580,6 +24780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23616,6 +24818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23652,6 +24856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23688,6 +24894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23724,6 +24932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23760,6 +24970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23796,6 +25008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23832,6 +25046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23868,6 +25084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23904,6 +25122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23940,6 +25160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23976,6 +25198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24012,6 +25236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24048,6 +25274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24084,6 +25312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24120,6 +25350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24156,6 +25388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24192,6 +25426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24228,6 +25464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24264,6 +25502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24300,6 +25540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24336,6 +25578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24372,6 +25616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24408,6 +25654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24444,6 +25692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24480,6 +25730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24516,6 +25768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24552,6 +25806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24588,6 +25844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24624,6 +25882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24660,6 +25920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24696,6 +25958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24732,6 +25996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24768,6 +26034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24804,6 +26072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24840,6 +26110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24876,6 +26148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24912,6 +26186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24948,6 +26224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24984,6 +26262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.3.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.3.sarif
@@ -1980,8 +1980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2018,8 +2016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2056,8 +2052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2094,8 +2088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2132,8 +2124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2170,8 +2160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2208,8 +2196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2246,8 +2232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2284,8 +2268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2322,8 +2304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2360,8 +2340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2398,8 +2376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2436,8 +2412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2474,8 +2448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2512,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2550,8 +2520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2588,8 +2556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2626,8 +2592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2664,8 +2628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2702,8 +2664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2740,8 +2700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2778,8 +2736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2816,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2854,8 +2808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2892,8 +2844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2930,8 +2880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2968,8 +2916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3006,8 +2952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3044,8 +2988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3082,8 +3024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3120,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3158,8 +3096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3196,8 +3132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3234,8 +3168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3272,8 +3204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3310,8 +3240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3348,8 +3276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3386,8 +3312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3424,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3462,8 +3384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3500,8 +3420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3538,8 +3456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3576,8 +3492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3614,8 +3528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3652,8 +3564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3690,8 +3600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3728,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3766,8 +3672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3804,8 +3708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3842,8 +3744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3880,8 +3780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3918,8 +3816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3956,8 +3852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3994,8 +3888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4032,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4070,8 +3960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4108,8 +3996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4146,8 +4032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4184,8 +4068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4222,8 +4104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4260,8 +4140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4298,8 +4176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4336,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4374,8 +4248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4412,8 +4284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4450,8 +4320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4488,8 +4356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4526,8 +4392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4564,8 +4428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4602,8 +4464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4640,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4678,8 +4536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4716,8 +4572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4754,8 +4608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4792,8 +4644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4830,8 +4680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4868,8 +4716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4906,8 +4752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4944,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4982,8 +4824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5020,8 +4860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5058,8 +4896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5096,8 +4932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5134,8 +4968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5172,8 +5004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5210,8 +5040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5248,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5286,8 +5112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5324,8 +5148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5362,8 +5184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5400,8 +5220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5438,8 +5256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5476,8 +5292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5514,8 +5328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5552,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5590,8 +5400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5628,8 +5436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5666,8 +5472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5704,8 +5508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5742,8 +5544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5780,8 +5580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5818,8 +5616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5856,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5894,8 +5688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5932,8 +5724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5970,8 +5760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,8 +5796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6046,8 +5832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6084,8 +5868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6122,8 +5904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6160,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6198,8 +5976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6236,8 +6012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6274,8 +6048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6312,8 +6084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6350,8 +6120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6388,8 +6156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6426,8 +6192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6464,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6502,8 +6264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6540,8 +6300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6578,8 +6336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6616,8 +6372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6654,8 +6408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6692,8 +6444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6730,8 +6480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6768,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6806,8 +6552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6844,8 +6588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6882,8 +6624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6920,8 +6660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6958,8 +6696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6996,8 +6732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7034,8 +6768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7072,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7110,8 +6840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7148,8 +6876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7186,8 +6912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7224,8 +6948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7262,8 +6984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7300,8 +7020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7338,8 +7056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7376,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7414,8 +7128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7452,8 +7164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7490,8 +7200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7528,8 +7236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7566,8 +7272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7604,8 +7308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7642,8 +7344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7680,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,8 +7416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7756,8 +7452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7794,8 +7488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7832,8 +7524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7870,8 +7560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7908,8 +7596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7946,8 +7632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7984,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8022,8 +7704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8060,8 +7740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8098,8 +7776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8136,8 +7812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8174,8 +7848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8212,8 +7884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8250,8 +7920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8288,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8326,8 +7992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8364,8 +8028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8402,8 +8064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8440,8 +8100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8478,8 +8136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8516,8 +8172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8554,8 +8208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8592,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8630,8 +8280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8668,8 +8316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8706,8 +8352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8744,8 +8388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8782,8 +8424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8820,8 +8460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8858,8 +8496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8896,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8934,8 +8568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8972,8 +8604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9010,8 +8640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9048,8 +8676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9086,8 +8712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9124,8 +8748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9162,8 +8784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9200,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9238,8 +8856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9276,8 +8892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9314,8 +8928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9352,8 +8964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9390,8 +9000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9428,8 +9036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9466,8 +9072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9504,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9542,8 +9144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9580,8 +9180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9618,8 +9216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9656,8 +9252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9694,8 +9288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9732,8 +9324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9770,8 +9360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9808,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9846,8 +9432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9884,8 +9468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9922,8 +9504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9960,8 +9540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9998,8 +9576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10036,8 +9612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10074,8 +9648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10112,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10150,8 +9720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10188,8 +9756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10226,8 +9792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10264,8 +9828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10302,8 +9864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10340,8 +9900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10378,8 +9936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10416,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10454,8 +10008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10492,8 +10044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10530,8 +10080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10568,8 +10116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10606,8 +10152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10644,8 +10188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10682,8 +10224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10720,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10758,8 +10296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10796,8 +10332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10834,8 +10368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10872,8 +10404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10910,8 +10440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10948,8 +10476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10986,8 +10512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11024,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11062,8 +10584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11100,8 +10620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11138,8 +10656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11176,8 +10692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11214,8 +10728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11252,8 +10764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11290,8 +10800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11328,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11366,8 +10872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11404,8 +10908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11442,8 +10944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11480,8 +10980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11518,8 +11016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11556,8 +11052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11594,8 +11088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11632,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11670,8 +11160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11708,8 +11196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11746,8 +11232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11784,8 +11268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11822,8 +11304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11860,8 +11340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11898,8 +11376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11936,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11974,8 +11448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12012,8 +11484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12050,8 +11520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12088,8 +11556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12126,8 +11592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12164,8 +11628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12202,8 +11664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12240,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12278,8 +11736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12316,8 +11772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12354,8 +11808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12392,8 +11844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12430,8 +11880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12468,8 +11916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12506,8 +11952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12544,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12582,8 +12024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12620,8 +12060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12658,8 +12096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12696,8 +12132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12734,8 +12168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12772,8 +12204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12810,8 +12240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12848,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12886,8 +12312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12924,8 +12348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12962,8 +12384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13000,8 +12420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13038,8 +12456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13076,8 +12492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13114,8 +12528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13152,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13190,8 +12600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13228,8 +12636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13266,8 +12672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13304,8 +12708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13342,8 +12744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13380,8 +12780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13418,8 +12816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13456,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13494,8 +12888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13532,8 +12924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13570,8 +12960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13608,8 +12996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13646,8 +13032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13684,8 +13068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13722,8 +13104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13760,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13798,8 +13176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13836,8 +13212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13874,8 +13248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13912,8 +13284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13950,8 +13320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13988,8 +13356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14026,8 +13392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14064,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14102,8 +13464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14140,8 +13500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14178,8 +13536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14216,8 +13572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14254,8 +13608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14292,8 +13644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14330,8 +13680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14368,8 +13716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14406,8 +13752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14444,8 +13788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14482,8 +13824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14520,8 +13860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14558,8 +13896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14596,8 +13932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14634,8 +13968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14672,8 +14004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14710,8 +14040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14748,8 +14076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14786,8 +14112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14824,8 +14148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14862,8 +14184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14900,8 +14220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14938,8 +14256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14976,8 +14292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15014,8 +14328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15052,8 +14364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15090,8 +14400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15128,8 +14436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15166,8 +14472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15204,8 +14508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15242,8 +14544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15280,8 +14580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15318,8 +14616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15356,8 +14652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15394,8 +14688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15432,8 +14724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15470,8 +14760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15508,8 +14796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15546,8 +14832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15584,8 +14868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15622,8 +14904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15660,8 +14940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15698,8 +14976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15736,8 +15012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15774,8 +15048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15812,8 +15084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15850,8 +15120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15888,8 +15156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15926,8 +15192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15964,8 +15228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16002,8 +15264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16040,8 +15300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16078,8 +15336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16116,8 +15372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16154,8 +15408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16192,8 +15444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16230,8 +15480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16268,8 +15516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16306,8 +15552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16344,8 +15588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16382,8 +15624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16420,8 +15660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16458,8 +15696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16496,8 +15732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16534,8 +15768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16572,8 +15804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16610,8 +15840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16648,8 +15876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16686,8 +15912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16724,8 +15948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16762,8 +15984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16800,8 +16020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16838,8 +16056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16876,8 +16092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16914,8 +16128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16952,8 +16164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16990,8 +16200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17028,8 +16236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17066,8 +16272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17104,8 +16308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17142,8 +16344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17180,8 +16380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17218,8 +16416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17256,8 +16452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17294,8 +16488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17332,8 +16524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17370,8 +16560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17408,8 +16596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17446,8 +16632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17484,8 +16668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17522,8 +16704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17560,8 +16740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17598,8 +16776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17636,8 +16812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17674,8 +16848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17712,8 +16884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17750,8 +16920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17788,8 +16956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17826,8 +16992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17864,8 +17028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17902,8 +17064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17940,8 +17100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17978,8 +17136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18016,8 +17172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18054,8 +17208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18092,8 +17244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18130,8 +17280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18168,8 +17316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18206,8 +17352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18244,8 +17388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18282,8 +17424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18320,8 +17460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18358,8 +17496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18396,8 +17532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18434,8 +17568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18472,8 +17604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18510,8 +17640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18548,8 +17676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18586,8 +17712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18624,8 +17748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18662,8 +17784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18700,8 +17820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18738,8 +17856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18776,8 +17892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18814,8 +17928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18852,8 +17964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18890,8 +18000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18928,8 +18036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18966,8 +18072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19004,8 +18108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19042,8 +18144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19080,8 +18180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19118,8 +18216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19156,8 +18252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19194,8 +18288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19232,8 +18324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19270,8 +18360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19308,8 +18396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19346,8 +18432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19384,8 +18468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19422,8 +18504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19460,8 +18540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19498,8 +18576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19536,8 +18612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19574,8 +18648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19612,8 +18684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19650,8 +18720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19688,8 +18756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19726,8 +18792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19764,8 +18828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19802,8 +18864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19840,8 +18900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19878,8 +18936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19916,8 +18972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19954,8 +19008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19992,8 +19044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20030,8 +19080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20068,8 +19116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20106,8 +19152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20144,8 +19188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20182,8 +19224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20220,8 +19260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20258,8 +19296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20296,8 +19332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20334,8 +19368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20372,8 +19404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20410,8 +19440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20448,8 +19476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20486,8 +19512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20524,8 +19548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20562,8 +19584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20600,8 +19620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20638,8 +19656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20676,8 +19692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20714,8 +19728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20752,8 +19764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20790,8 +19800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20828,8 +19836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20866,8 +19872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20904,8 +19908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20942,8 +19944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20980,8 +19980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21018,8 +20016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21056,8 +20052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21094,8 +20088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21132,8 +20124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21170,8 +20160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21208,8 +20196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21246,8 +20232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21284,8 +20268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21322,8 +20304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21360,8 +20340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21398,8 +20376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21436,8 +20412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21474,8 +20448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21512,8 +20484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21550,8 +20520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21588,8 +20556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21626,8 +20592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21664,8 +20628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21702,8 +20664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21740,8 +20700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21778,8 +20736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21816,8 +20772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21854,8 +20808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21892,8 +20844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21930,8 +20880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21968,8 +20916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22006,8 +20952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22044,8 +20988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22082,8 +21024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22120,8 +21060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22158,8 +21096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22196,8 +21132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22234,8 +21168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22272,8 +21204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22310,8 +21240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22348,8 +21276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22386,8 +21312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22424,8 +21348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22462,8 +21384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22500,8 +21420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22538,8 +21456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22576,8 +21492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22614,8 +21528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22652,8 +21564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22690,8 +21600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22728,8 +21636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22766,8 +21672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22804,8 +21708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22842,8 +21744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22880,8 +21780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22918,8 +21816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22956,8 +21852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22994,8 +21888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23032,8 +21924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23070,8 +21960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23108,8 +21996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23146,8 +22032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23184,8 +22068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23222,8 +22104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23260,8 +22140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23298,8 +22176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23336,8 +22212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23374,8 +22248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23412,8 +22284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23450,8 +22320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23488,8 +22356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23526,8 +22392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23564,8 +22428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23602,8 +22464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23640,8 +22500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23678,8 +22536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23716,8 +22572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23754,8 +22608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23792,8 +22644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23830,8 +22680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23868,8 +22716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23906,8 +22752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23944,8 +22788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23982,8 +22824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24020,8 +22860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24058,8 +22896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24096,8 +22932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24134,8 +22968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24172,8 +23004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24210,8 +23040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24248,8 +23076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24286,8 +23112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24324,8 +23148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24362,8 +23184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24400,8 +23220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24438,8 +23256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24476,8 +23292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24514,8 +23328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24552,8 +23364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24590,8 +23400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24628,8 +23436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24666,8 +23472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24704,8 +23508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24742,8 +23544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24780,8 +23580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24818,8 +23616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24856,8 +23652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24894,8 +23688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24932,8 +23724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24970,8 +23760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25008,8 +23796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25046,8 +23832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25084,8 +23868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25122,8 +23904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25160,8 +23940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25198,8 +23976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25236,8 +24012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25274,8 +24048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25312,8 +24084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25350,8 +24120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25388,8 +24156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25426,8 +24192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25464,8 +24228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25502,8 +24264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25540,8 +24300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25578,8 +24336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25616,8 +24372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25654,8 +24408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25692,8 +24444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25730,8 +24480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25768,8 +24516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25806,8 +24552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25844,8 +24588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25882,8 +24624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25920,8 +24660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25958,8 +24696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25996,8 +24732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26034,8 +24768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26072,8 +24804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26110,8 +24840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26148,8 +24876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,8 +24912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26224,8 +24948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26262,8 +24984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.3.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.3.sarif
@@ -1979,6 +1979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2014,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2049,6 +2055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2084,6 +2093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2119,6 +2131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2154,6 +2169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2189,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2224,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2259,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2294,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2329,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2364,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2399,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2434,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2469,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2504,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2539,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2574,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2609,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2644,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2679,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2714,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2749,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2784,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2819,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2854,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2889,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2924,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2959,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2994,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3029,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3064,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3099,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3134,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3169,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3204,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3239,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3274,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3309,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3344,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3379,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3414,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3449,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3484,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3519,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3554,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3589,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3624,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3659,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3694,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3729,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3764,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3799,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3834,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3869,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3904,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3939,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3974,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4009,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4044,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4079,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4114,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4149,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4184,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4219,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4254,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4289,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4324,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4359,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4394,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4429,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4499,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4534,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4569,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4604,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4639,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4674,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4709,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4744,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4779,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4814,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4849,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4884,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4919,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4954,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4989,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5024,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5059,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5094,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5129,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5164,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5199,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5234,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5269,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5304,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5339,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5374,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5409,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5444,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5479,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5514,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5549,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5584,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5619,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5654,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5689,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5759,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5794,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5829,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5864,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5899,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5934,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5969,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6004,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6039,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6074,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6109,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6144,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6179,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6214,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6249,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6284,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6319,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6354,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6389,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6424,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6459,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6494,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6529,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6564,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6599,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6634,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6669,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6704,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6739,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6774,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6809,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6844,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6879,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6914,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6949,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6984,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7019,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7054,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7089,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7124,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7159,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7194,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7229,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7264,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7299,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7334,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7369,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7404,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7439,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7474,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7509,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7544,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7579,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7614,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7649,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7684,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7719,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7754,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7789,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7824,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7859,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7894,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -7929,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -7964,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -7999,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8034,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8069,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8104,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8139,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8174,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8209,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8244,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8279,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8314,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8349,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8384,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8419,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8454,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8489,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8524,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8559,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8594,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8629,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8664,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8699,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8734,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8769,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8804,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -8839,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -8874,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -8909,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -8944,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -8979,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9014,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9049,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9084,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9119,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9154,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9189,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9224,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9259,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9294,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9329,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9364,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9399,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9434,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9469,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9504,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9539,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9574,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9609,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9644,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9679,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9714,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9749,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9784,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9819,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9854,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9889,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9924,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9959,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9994,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10029,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10064,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10099,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10134,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10169,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10204,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10239,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10274,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10309,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10344,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10379,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10414,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10449,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10484,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10519,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10554,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10589,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10624,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10659,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10694,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10729,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10764,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10799,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10834,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10869,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10904,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10939,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10974,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11009,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11044,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11079,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11114,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11149,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11184,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11219,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11254,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11289,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11324,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11359,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11394,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11429,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11464,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11499,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11534,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11569,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11604,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11639,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11674,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11709,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11744,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11779,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11814,6 +12657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11849,6 +12695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11884,6 +12733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11919,6 +12771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11954,6 +12809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11989,6 +12847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12024,6 +12885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12059,6 +12923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12094,6 +12961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12129,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12164,6 +13037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12199,6 +13075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12234,6 +13113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12269,6 +13151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12304,6 +13189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12339,6 +13227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12374,6 +13265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12409,6 +13303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12444,6 +13341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12479,6 +13379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12514,6 +13417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12549,6 +13455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12584,6 +13493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12619,6 +13531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12654,6 +13569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12689,6 +13607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12724,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12759,6 +13683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12794,6 +13721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12829,6 +13759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12864,6 +13797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12899,6 +13835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12934,6 +13873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12969,6 +13911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13004,6 +13949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13039,6 +13987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13074,6 +14025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13109,6 +14063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13144,6 +14101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13179,6 +14139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13214,6 +14177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13249,6 +14215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13284,6 +14253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13319,6 +14291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13354,6 +14329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13389,6 +14367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13424,6 +14405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13459,6 +14443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13494,6 +14481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13529,6 +14519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13564,6 +14557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13599,6 +14595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13634,6 +14633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13669,6 +14671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13704,6 +14709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13739,6 +14747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13774,6 +14785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -13809,6 +14823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13844,6 +14861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -13879,6 +14899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -13914,6 +14937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -13949,6 +14975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13984,6 +15013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14019,6 +15051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14054,6 +15089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14089,6 +15127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14124,6 +15165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14159,6 +15203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14194,6 +15241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14229,6 +15279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14264,6 +15317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14299,6 +15355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14334,6 +15393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14369,6 +15431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14404,6 +15469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14439,6 +15507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14474,6 +15545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14509,6 +15583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14544,6 +15621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14579,6 +15659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14614,6 +15697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14649,6 +15735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14684,6 +15773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14719,6 +15811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14754,6 +15849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14789,6 +15887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14824,6 +15925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -14859,6 +15963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14894,6 +16001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14929,6 +16039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14964,6 +16077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -14999,6 +16115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15034,6 +16153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15069,6 +16191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15104,6 +16229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15139,6 +16267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15174,6 +16305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15209,6 +16343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15244,6 +16381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15279,6 +16419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15314,6 +16457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15349,6 +16495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15384,6 +16533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15419,6 +16571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15454,6 +16609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15489,6 +16647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15524,6 +16685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15559,6 +16723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15594,6 +16761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15629,6 +16799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15664,6 +16837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15699,6 +16875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15734,6 +16913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15769,6 +16951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15804,6 +16989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15839,6 +17027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15874,6 +17065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15909,6 +17103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15944,6 +17141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15979,6 +17179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16014,6 +17217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16049,6 +17255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16084,6 +17293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16119,6 +17331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16154,6 +17369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16189,6 +17407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16224,6 +17445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16259,6 +17483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16294,6 +17521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16329,6 +17559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16364,6 +17597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16399,6 +17635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16434,6 +17673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16469,6 +17711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16504,6 +17749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16539,6 +17787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16574,6 +17825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16609,6 +17863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16644,6 +17901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16679,6 +17939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16714,6 +17977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16749,6 +18015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16784,6 +18053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16819,6 +18091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16854,6 +18129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -16889,6 +18167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16924,6 +18205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16959,6 +18243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -16994,6 +18281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17029,6 +18319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17064,6 +18357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17099,6 +18395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17134,6 +18433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17169,6 +18471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17204,6 +18509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17239,6 +18547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17274,6 +18585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17309,6 +18623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17344,6 +18661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17379,6 +18699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17414,6 +18737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17449,6 +18775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17484,6 +18813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17519,6 +18851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17554,6 +18889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17589,6 +18927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17624,6 +18965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17659,6 +19003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17694,6 +19041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17729,6 +19079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17764,6 +19117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17799,6 +19155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17834,6 +19193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17869,6 +19231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17904,6 +19269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -17939,6 +19307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -17974,6 +19345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18009,6 +19383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18044,6 +19421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18079,6 +19459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18114,6 +19497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18149,6 +19535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18184,6 +19573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18219,6 +19611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18254,6 +19649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18289,6 +19687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18324,6 +19725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18359,6 +19763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18394,6 +19801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18429,6 +19839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18464,6 +19877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18499,6 +19915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18534,6 +19953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18569,6 +19991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18604,6 +20029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18639,6 +20067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18674,6 +20105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18709,6 +20143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18744,6 +20181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18779,6 +20219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18814,6 +20257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18849,6 +20295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18884,6 +20333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18919,6 +20371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18954,6 +20409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18989,6 +20447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19024,6 +20485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19059,6 +20523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19094,6 +20561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19129,6 +20599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19164,6 +20637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19199,6 +20675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19234,6 +20713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19269,6 +20751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19304,6 +20789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19339,6 +20827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19374,6 +20865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19409,6 +20903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19444,6 +20941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19479,6 +20979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19514,6 +21017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19549,6 +21055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19584,6 +21093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19619,6 +21131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19654,6 +21169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19689,6 +21207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19724,6 +21245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19759,6 +21283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -19794,6 +21321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19829,6 +21359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19864,6 +21397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19899,6 +21435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19934,6 +21473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19969,6 +21511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20004,6 +21549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20039,6 +21587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20074,6 +21625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20109,6 +21663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20144,6 +21701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20179,6 +21739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20214,6 +21777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20249,6 +21815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20284,6 +21853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20319,6 +21891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20354,6 +21929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20389,6 +21967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20424,6 +22005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20459,6 +22043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20494,6 +22081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20529,6 +22119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20564,6 +22157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20599,6 +22195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20634,6 +22233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20669,6 +22271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20704,6 +22309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20739,6 +22347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20774,6 +22385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20809,6 +22423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20844,6 +22461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20879,6 +22499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -20914,6 +22537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -20949,6 +22575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -20984,6 +22613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21019,6 +22651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21054,6 +22689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21089,6 +22727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21124,6 +22765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21159,6 +22803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21194,6 +22841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21229,6 +22879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21264,6 +22917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21299,6 +22955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21334,6 +22993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21369,6 +23031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21404,6 +23069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21439,6 +23107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21474,6 +23145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21509,6 +23183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21544,6 +23221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21579,6 +23259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21614,6 +23297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21649,6 +23335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21684,6 +23373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21719,6 +23411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21754,6 +23449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21789,6 +23487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -21824,6 +23525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -21859,6 +23563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -21894,6 +23601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -21929,6 +23639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -21964,6 +23677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -21999,6 +23715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22034,6 +23753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22069,6 +23791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22104,6 +23829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22139,6 +23867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22174,6 +23905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22209,6 +23943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22244,6 +23981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22279,6 +24019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22314,6 +24057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22349,6 +24095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22384,6 +24133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22419,6 +24171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22454,6 +24209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22489,6 +24247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22524,6 +24285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22559,6 +24323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22594,6 +24361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22629,6 +24399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22664,6 +24437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22699,6 +24475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22734,6 +24513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22769,6 +24551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22804,6 +24589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -22839,6 +24627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -22874,6 +24665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -22909,6 +24703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -22944,6 +24741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22979,6 +24779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23014,6 +24817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23049,6 +24855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23084,6 +24893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23119,6 +24931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23154,6 +24969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23189,6 +25007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23224,6 +25045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23259,6 +25083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23294,6 +25121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23329,6 +25159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23364,6 +25197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23399,6 +25235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23434,6 +25273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23469,6 +25311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23504,6 +25349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23539,6 +25387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23574,6 +25425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23609,6 +25463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23644,6 +25501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23679,6 +25539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23714,6 +25577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23749,6 +25615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23784,6 +25653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23819,6 +25691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23854,6 +25729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23889,6 +25767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -23924,6 +25805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23959,6 +25843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23994,6 +25881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24029,6 +25919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24064,6 +25957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24099,6 +25995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24134,6 +26033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24169,6 +26071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24204,6 +26109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24239,6 +26147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24274,6 +26185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24309,6 +26223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24344,6 +26261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.3.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.3.sarif
@@ -1980,6 +1980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2016,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2052,6 +2056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2088,6 +2094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2124,6 +2132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2160,6 +2170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2196,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2232,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2268,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2304,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2340,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2376,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2412,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2448,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2484,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2520,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2556,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2592,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2628,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2664,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2700,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2736,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2772,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2808,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2844,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2880,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2916,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2952,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2988,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3024,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3060,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3096,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3132,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3168,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3204,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3240,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3276,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3312,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3348,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3384,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3420,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3456,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3492,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3528,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3564,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3600,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3636,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3672,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3708,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3744,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3780,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3816,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3852,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3888,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3924,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3960,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3996,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4032,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4068,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4104,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4140,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4176,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4212,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4248,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4284,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4320,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4356,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4392,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4428,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4500,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4536,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4572,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4608,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4644,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4680,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4716,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4752,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4788,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4824,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4860,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4896,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4932,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4968,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5004,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5040,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5076,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5112,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5148,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5184,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5220,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5256,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5292,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5328,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5364,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5400,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5436,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5472,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5508,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5544,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5580,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5616,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5652,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5688,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5760,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5796,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5832,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5868,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5904,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5940,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5976,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6012,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6048,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6084,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6120,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6156,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6192,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6228,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6264,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6300,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6336,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6372,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6408,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6444,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6480,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6516,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6552,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6588,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6624,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6660,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6696,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6732,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6768,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6804,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6840,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6876,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6912,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6948,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6984,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7020,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7056,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7092,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7128,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7164,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7200,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7236,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7272,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7308,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7344,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7380,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7416,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7452,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7488,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7524,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7560,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7596,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7632,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7668,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7704,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7740,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7776,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7812,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7848,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7884,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7920,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7956,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7992,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8028,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8064,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8100,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8136,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8172,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8208,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8244,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8280,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8316,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8352,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8388,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8424,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8460,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8496,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8532,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8568,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8604,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8640,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8676,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8712,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8748,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8784,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8820,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8856,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8892,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8928,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8964,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9000,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9036,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9072,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9108,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9144,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9180,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9216,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9252,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9288,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9324,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9360,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9396,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9432,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9468,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9504,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9540,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9576,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9612,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9648,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9684,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9720,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9756,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9792,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9828,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9864,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9900,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9936,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9972,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10008,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10044,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10080,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10116,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10152,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10188,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10224,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10260,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10296,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10332,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10368,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10404,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10440,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10476,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10512,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10548,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10584,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10620,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10656,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10692,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10728,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10764,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10800,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10836,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10872,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10908,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10944,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10980,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11016,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11052,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11088,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11124,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11160,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11196,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11232,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11268,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11304,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11340,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11376,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11412,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11448,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11484,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11520,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11556,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11592,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11628,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11664,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11700,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11736,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11772,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11808,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11844,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11880,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11916,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11952,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11988,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12024,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12060,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12096,6 +12658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12132,6 +12696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12168,6 +12734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12204,6 +12772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12240,6 +12810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12276,6 +12848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12312,6 +12886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12348,6 +12924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12384,6 +12962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12420,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12456,6 +13038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12492,6 +13076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12528,6 +13114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12564,6 +13152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12600,6 +13190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12636,6 +13228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12672,6 +13266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12708,6 +13304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12744,6 +13342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12780,6 +13380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12852,6 +13456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12888,6 +13494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12924,6 +13532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12960,6 +13570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12996,6 +13608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13032,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13068,6 +13684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13104,6 +13722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13140,6 +13760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13176,6 +13798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13212,6 +13836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13248,6 +13874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13284,6 +13912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13320,6 +13950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13356,6 +13988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13392,6 +14026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13428,6 +14064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13464,6 +14102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13500,6 +14140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13536,6 +14178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13572,6 +14216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13608,6 +14254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13644,6 +14292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13680,6 +14330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13716,6 +14368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13752,6 +14406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13788,6 +14444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13824,6 +14482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13860,6 +14520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13896,6 +14558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13932,6 +14596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13968,6 +14634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14004,6 +14672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14040,6 +14710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14076,6 +14748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14112,6 +14786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14148,6 +14824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14184,6 +14862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14220,6 +14900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14256,6 +14938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14292,6 +14976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14328,6 +15014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14364,6 +15052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14400,6 +15090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14436,6 +15128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14472,6 +15166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14508,6 +15204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14544,6 +15242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14580,6 +15280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14616,6 +15318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14652,6 +15356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14688,6 +15394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14724,6 +15432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14760,6 +15470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14796,6 +15508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14832,6 +15546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14868,6 +15584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14904,6 +15622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14940,6 +15660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14976,6 +15698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15012,6 +15736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15048,6 +15774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15084,6 +15812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15120,6 +15850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15156,6 +15888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15192,6 +15926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15228,6 +15964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15264,6 +16002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15300,6 +16040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15336,6 +16078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15372,6 +16116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15408,6 +16154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15444,6 +16192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15480,6 +16230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15516,6 +16268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15552,6 +16306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15588,6 +16344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15624,6 +16382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15660,6 +16420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15696,6 +16458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15732,6 +16496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15768,6 +16534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15804,6 +16572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15840,6 +16610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15876,6 +16648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15912,6 +16686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15948,6 +16724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15984,6 +16762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16020,6 +16800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16056,6 +16838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16092,6 +16876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16128,6 +16914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16164,6 +16952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16200,6 +16990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16236,6 +17028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16272,6 +17066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16308,6 +17104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16344,6 +17142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16380,6 +17180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16416,6 +17218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16452,6 +17256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16488,6 +17294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16524,6 +17332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16560,6 +17370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16596,6 +17408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16632,6 +17446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16668,6 +17484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16704,6 +17522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16740,6 +17560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16776,6 +17598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16812,6 +17636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16848,6 +17674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16884,6 +17712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16920,6 +17750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16956,6 +17788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16992,6 +17826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17028,6 +17864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17064,6 +17902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17100,6 +17940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17136,6 +17978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17172,6 +18016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17208,6 +18054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17244,6 +18092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17280,6 +18130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17316,6 +18168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17352,6 +18206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17388,6 +18244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17424,6 +18282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17460,6 +18320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17496,6 +18358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17532,6 +18396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17568,6 +18434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17604,6 +18472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17640,6 +18510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17676,6 +18548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17712,6 +18586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17748,6 +18624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17784,6 +18662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17820,6 +18700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17856,6 +18738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17892,6 +18776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17928,6 +18814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17964,6 +18852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18000,6 +18890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18036,6 +18928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18072,6 +18966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18108,6 +19004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18144,6 +19042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18180,6 +19080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18216,6 +19118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18252,6 +19156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18288,6 +19194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18324,6 +19232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18360,6 +19270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18396,6 +19308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18432,6 +19346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18468,6 +19384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18504,6 +19422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18540,6 +19460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18576,6 +19498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18612,6 +19536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18648,6 +19574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18684,6 +19612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18720,6 +19650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18756,6 +19688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18792,6 +19726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18828,6 +19764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18864,6 +19802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18900,6 +19840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18936,6 +19878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18972,6 +19916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19008,6 +19954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19044,6 +19992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19080,6 +20030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19116,6 +20068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19152,6 +20106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19188,6 +20144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19224,6 +20182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19260,6 +20220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19296,6 +20258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19332,6 +20296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19368,6 +20334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19404,6 +20372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19440,6 +20410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19476,6 +20448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19512,6 +20486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19548,6 +20524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19584,6 +20562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19620,6 +20600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19656,6 +20638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19692,6 +20676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19728,6 +20714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19764,6 +20752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19800,6 +20790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19836,6 +20828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19872,6 +20866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19908,6 +20904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19944,6 +20942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19980,6 +20980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20016,6 +21018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20052,6 +21056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20088,6 +21094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20124,6 +21132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20160,6 +21170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20196,6 +21208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20232,6 +21246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20268,6 +21284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20304,6 +21322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20340,6 +21360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20376,6 +21398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20412,6 +21436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20448,6 +21474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20484,6 +21512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20520,6 +21550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20556,6 +21588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20592,6 +21626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20628,6 +21664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20664,6 +21702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20700,6 +21740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20736,6 +21778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20772,6 +21816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20808,6 +21854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20844,6 +21892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20880,6 +21930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20916,6 +21968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20952,6 +22006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20988,6 +22044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21024,6 +22082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21060,6 +22120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21096,6 +22158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21132,6 +22196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21168,6 +22234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21204,6 +22272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21240,6 +22310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21276,6 +22348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21312,6 +22386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21348,6 +22424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21384,6 +22462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21420,6 +22500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21456,6 +22538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21492,6 +22576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21528,6 +22614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21564,6 +22652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21600,6 +22690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21636,6 +22728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21672,6 +22766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21708,6 +22804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21744,6 +22842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21780,6 +22880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21816,6 +22918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21852,6 +22956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21888,6 +22994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21924,6 +23032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21960,6 +23070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21996,6 +23108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22032,6 +23146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22068,6 +23184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22104,6 +23222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22140,6 +23260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22176,6 +23298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22212,6 +23336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22248,6 +23374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22284,6 +23412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22320,6 +23450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22356,6 +23488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22392,6 +23526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22428,6 +23564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22464,6 +23602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22500,6 +23640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22536,6 +23678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22572,6 +23716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22608,6 +23754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22644,6 +23792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22680,6 +23830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22716,6 +23868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22752,6 +23906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22788,6 +23944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22824,6 +23982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22860,6 +24020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22896,6 +24058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22932,6 +24096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22968,6 +24134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23004,6 +24172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23040,6 +24210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23076,6 +24248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23112,6 +24286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23148,6 +24324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23184,6 +24362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23220,6 +24400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23256,6 +24438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23292,6 +24476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23328,6 +24514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23364,6 +24552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23400,6 +24590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23436,6 +24628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23472,6 +24666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23508,6 +24704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23544,6 +24742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23580,6 +24780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23616,6 +24818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23652,6 +24856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23688,6 +24894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23724,6 +24932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23760,6 +24970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23796,6 +25008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23832,6 +25046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23868,6 +25084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23904,6 +25122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23940,6 +25160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23976,6 +25198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24012,6 +25236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24048,6 +25274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24084,6 +25312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24120,6 +25350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24156,6 +25388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24192,6 +25426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24228,6 +25464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24264,6 +25502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24300,6 +25540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24336,6 +25578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24372,6 +25616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24408,6 +25654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24444,6 +25692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24480,6 +25730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24516,6 +25768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24552,6 +25806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24588,6 +25844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24624,6 +25882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24660,6 +25920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24696,6 +25958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24732,6 +25996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24768,6 +26034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24804,6 +26072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24840,6 +26110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24876,6 +26148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24912,6 +26186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24948,6 +26224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24984,6 +26262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.4.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.4.sarif
@@ -1980,8 +1980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2018,8 +2016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2056,8 +2052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2094,8 +2088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2132,8 +2124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2170,8 +2160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2208,8 +2196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2246,8 +2232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2284,8 +2268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2322,8 +2304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2360,8 +2340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2398,8 +2376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2436,8 +2412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2474,8 +2448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2512,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2550,8 +2520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2588,8 +2556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2626,8 +2592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2664,8 +2628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2702,8 +2664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2740,8 +2700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2778,8 +2736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2816,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2854,8 +2808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2892,8 +2844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2930,8 +2880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2968,8 +2916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3006,8 +2952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3044,8 +2988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3082,8 +3024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3120,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3158,8 +3096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3196,8 +3132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3234,8 +3168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3272,8 +3204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3310,8 +3240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3348,8 +3276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3386,8 +3312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3424,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3462,8 +3384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3500,8 +3420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3538,8 +3456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3576,8 +3492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3614,8 +3528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3652,8 +3564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3690,8 +3600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3728,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3766,8 +3672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3804,8 +3708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3842,8 +3744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3880,8 +3780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3918,8 +3816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3956,8 +3852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3994,8 +3888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4032,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4070,8 +3960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4108,8 +3996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4146,8 +4032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4184,8 +4068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4222,8 +4104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4260,8 +4140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4298,8 +4176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4336,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4374,8 +4248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4412,8 +4284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4450,8 +4320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4488,8 +4356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4526,8 +4392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4564,8 +4428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4602,8 +4464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4640,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4678,8 +4536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4716,8 +4572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4754,8 +4608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4792,8 +4644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4830,8 +4680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4868,8 +4716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4906,8 +4752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4944,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4982,8 +4824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5020,8 +4860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5058,8 +4896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5096,8 +4932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5134,8 +4968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5172,8 +5004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5210,8 +5040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5248,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5286,8 +5112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5324,8 +5148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5362,8 +5184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5400,8 +5220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5438,8 +5256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5476,8 +5292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5514,8 +5328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5552,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5590,8 +5400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5628,8 +5436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5666,8 +5472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5704,8 +5508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5742,8 +5544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5780,8 +5580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5818,8 +5616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5856,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5894,8 +5688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5932,8 +5724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5970,8 +5760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,8 +5796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6046,8 +5832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6084,8 +5868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6122,8 +5904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6160,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6198,8 +5976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6236,8 +6012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6274,8 +6048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6312,8 +6084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6350,8 +6120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6388,8 +6156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6426,8 +6192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6464,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6502,8 +6264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6540,8 +6300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6578,8 +6336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6616,8 +6372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6654,8 +6408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6692,8 +6444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6730,8 +6480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6768,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6806,8 +6552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6844,8 +6588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6882,8 +6624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6920,8 +6660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6958,8 +6696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6996,8 +6732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7034,8 +6768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7072,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7110,8 +6840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7148,8 +6876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7186,8 +6912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7224,8 +6948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7262,8 +6984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7300,8 +7020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7338,8 +7056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7376,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7414,8 +7128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7452,8 +7164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7490,8 +7200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7528,8 +7236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7566,8 +7272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7604,8 +7308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7642,8 +7344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7680,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,8 +7416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7756,8 +7452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7794,8 +7488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7832,8 +7524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7870,8 +7560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7908,8 +7596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7946,8 +7632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7984,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8022,8 +7704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8060,8 +7740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8098,8 +7776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8136,8 +7812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8174,8 +7848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8212,8 +7884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8250,8 +7920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8288,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8326,8 +7992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8364,8 +8028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8402,8 +8064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8440,8 +8100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8478,8 +8136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8516,8 +8172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8554,8 +8208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8592,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8630,8 +8280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8668,8 +8316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8706,8 +8352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8744,8 +8388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8782,8 +8424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8820,8 +8460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8858,8 +8496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8896,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8934,8 +8568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8972,8 +8604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9010,8 +8640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9048,8 +8676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9086,8 +8712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9124,8 +8748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9162,8 +8784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9200,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9238,8 +8856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9276,8 +8892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9314,8 +8928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9352,8 +8964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9390,8 +9000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9428,8 +9036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9466,8 +9072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9504,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9542,8 +9144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9580,8 +9180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9618,8 +9216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9656,8 +9252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9694,8 +9288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9732,8 +9324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9770,8 +9360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9808,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9846,8 +9432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9884,8 +9468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9922,8 +9504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9960,8 +9540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9998,8 +9576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10036,8 +9612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10074,8 +9648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10112,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10150,8 +9720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10188,8 +9756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10226,8 +9792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10264,8 +9828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10302,8 +9864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10340,8 +9900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10378,8 +9936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10416,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10454,8 +10008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10492,8 +10044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10530,8 +10080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10568,8 +10116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10606,8 +10152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10644,8 +10188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10682,8 +10224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10720,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10758,8 +10296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10796,8 +10332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10834,8 +10368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10872,8 +10404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10910,8 +10440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10948,8 +10476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10986,8 +10512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11024,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11062,8 +10584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11100,8 +10620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11138,8 +10656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11176,8 +10692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11214,8 +10728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11252,8 +10764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11290,8 +10800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11328,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11366,8 +10872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11404,8 +10908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11442,8 +10944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11480,8 +10980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11518,8 +11016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11556,8 +11052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11594,8 +11088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11632,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11670,8 +11160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11708,8 +11196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11746,8 +11232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11784,8 +11268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11822,8 +11304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11860,8 +11340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11898,8 +11376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11936,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11974,8 +11448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12012,8 +11484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12050,8 +11520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12088,8 +11556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12126,8 +11592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12164,8 +11628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12202,8 +11664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12240,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12278,8 +11736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12316,8 +11772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12354,8 +11808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12392,8 +11844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12430,8 +11880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12468,8 +11916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12506,8 +11952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12544,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12582,8 +12024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12620,8 +12060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12658,8 +12096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12696,8 +12132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12734,8 +12168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12772,8 +12204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12810,8 +12240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12848,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12886,8 +12312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12924,8 +12348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12962,8 +12384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13000,8 +12420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13038,8 +12456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13076,8 +12492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13114,8 +12528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13152,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13190,8 +12600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13228,8 +12636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13266,8 +12672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13304,8 +12708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13342,8 +12744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13380,8 +12780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13418,8 +12816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13456,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13494,8 +12888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13532,8 +12924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13570,8 +12960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13608,8 +12996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13646,8 +13032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13684,8 +13068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13722,8 +13104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13760,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13798,8 +13176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13836,8 +13212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13874,8 +13248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13912,8 +13284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13950,8 +13320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13988,8 +13356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14026,8 +13392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14064,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14102,8 +13464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14140,8 +13500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14178,8 +13536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14216,8 +13572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14254,8 +13608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14292,8 +13644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14330,8 +13680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14368,8 +13716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14406,8 +13752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14444,8 +13788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14482,8 +13824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14520,8 +13860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14558,8 +13896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14596,8 +13932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14634,8 +13968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14672,8 +14004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14710,8 +14040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14748,8 +14076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14786,8 +14112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14824,8 +14148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14862,8 +14184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14900,8 +14220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14938,8 +14256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14976,8 +14292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15014,8 +14328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15052,8 +14364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15090,8 +14400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15128,8 +14436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15166,8 +14472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15204,8 +14508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15242,8 +14544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15280,8 +14580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15318,8 +14616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15356,8 +14652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15394,8 +14688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15432,8 +14724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15470,8 +14760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15508,8 +14796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15546,8 +14832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15584,8 +14868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15622,8 +14904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15660,8 +14940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15698,8 +14976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15736,8 +15012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15774,8 +15048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15812,8 +15084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15850,8 +15120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15888,8 +15156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15926,8 +15192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15964,8 +15228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16002,8 +15264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16040,8 +15300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16078,8 +15336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16116,8 +15372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16154,8 +15408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16192,8 +15444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16230,8 +15480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16268,8 +15516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16306,8 +15552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16344,8 +15588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16382,8 +15624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16420,8 +15660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16458,8 +15696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16496,8 +15732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16534,8 +15768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16572,8 +15804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16610,8 +15840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16648,8 +15876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16686,8 +15912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16724,8 +15948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16762,8 +15984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16800,8 +16020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16838,8 +16056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16876,8 +16092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16914,8 +16128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16952,8 +16164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16990,8 +16200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17028,8 +16236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17066,8 +16272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17104,8 +16308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17142,8 +16344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17180,8 +16380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17218,8 +16416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17256,8 +16452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17294,8 +16488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17332,8 +16524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17370,8 +16560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17408,8 +16596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17446,8 +16632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17484,8 +16668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17522,8 +16704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17560,8 +16740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17598,8 +16776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17636,8 +16812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17674,8 +16848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17712,8 +16884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17750,8 +16920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17788,8 +16956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17826,8 +16992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17864,8 +17028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17902,8 +17064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17940,8 +17100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17978,8 +17136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18016,8 +17172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18054,8 +17208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18092,8 +17244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18130,8 +17280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18168,8 +17316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18206,8 +17352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18244,8 +17388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18282,8 +17424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18320,8 +17460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18358,8 +17496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18396,8 +17532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18434,8 +17568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18472,8 +17604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18510,8 +17640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18548,8 +17676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18586,8 +17712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18624,8 +17748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18662,8 +17784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18700,8 +17820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18738,8 +17856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18776,8 +17892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18814,8 +17928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18852,8 +17964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18890,8 +18000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18928,8 +18036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18966,8 +18072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19004,8 +18108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19042,8 +18144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19080,8 +18180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19118,8 +18216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19156,8 +18252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19194,8 +18288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19232,8 +18324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19270,8 +18360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19308,8 +18396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19346,8 +18432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19384,8 +18468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19422,8 +18504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19460,8 +18540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19498,8 +18576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19536,8 +18612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19574,8 +18648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19612,8 +18684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19650,8 +18720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19688,8 +18756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19726,8 +18792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19764,8 +18828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19802,8 +18864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19840,8 +18900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19878,8 +18936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19916,8 +18972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19954,8 +19008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19992,8 +19044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20030,8 +19080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20068,8 +19116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20106,8 +19152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20144,8 +19188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20182,8 +19224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20220,8 +19260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20258,8 +19296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20296,8 +19332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20334,8 +19368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20372,8 +19404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20410,8 +19440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20448,8 +19476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20486,8 +19512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20524,8 +19548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20562,8 +19584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20600,8 +19620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20638,8 +19656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20676,8 +19692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20714,8 +19728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20752,8 +19764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20790,8 +19800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20828,8 +19836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20866,8 +19872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20904,8 +19908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20942,8 +19944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20980,8 +19980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21018,8 +20016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21056,8 +20052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21094,8 +20088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21132,8 +20124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21170,8 +20160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21208,8 +20196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21246,8 +20232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21284,8 +20268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21322,8 +20304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21360,8 +20340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21398,8 +20376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21436,8 +20412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21474,8 +20448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21512,8 +20484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21550,8 +20520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21588,8 +20556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21626,8 +20592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21664,8 +20628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21702,8 +20664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21740,8 +20700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21778,8 +20736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21816,8 +20772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21854,8 +20808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21892,8 +20844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21930,8 +20880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21968,8 +20916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22006,8 +20952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22044,8 +20988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22082,8 +21024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22120,8 +21060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22158,8 +21096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22196,8 +21132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22234,8 +21168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22272,8 +21204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22310,8 +21240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22348,8 +21276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22386,8 +21312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22424,8 +21348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22462,8 +21384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22500,8 +21420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22538,8 +21456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22576,8 +21492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22614,8 +21528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22652,8 +21564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22690,8 +21600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22728,8 +21636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22766,8 +21672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22804,8 +21708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22842,8 +21744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22880,8 +21780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22918,8 +21816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22956,8 +21852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22994,8 +21888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23032,8 +21924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23070,8 +21960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23108,8 +21996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23146,8 +22032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23184,8 +22068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23222,8 +22104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23260,8 +22140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23298,8 +22176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23336,8 +22212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23374,8 +22248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23412,8 +22284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23450,8 +22320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23488,8 +22356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23526,8 +22392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23564,8 +22428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23602,8 +22464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23640,8 +22500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23678,8 +22536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23716,8 +22572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23754,8 +22608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23792,8 +22644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23830,8 +22680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23868,8 +22716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23906,8 +22752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23944,8 +22788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23982,8 +22824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24020,8 +22860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24058,8 +22896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24096,8 +22932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24134,8 +22968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24172,8 +23004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24210,8 +23040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24248,8 +23076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24286,8 +23112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24324,8 +23148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24362,8 +23184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24400,8 +23220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24438,8 +23256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24476,8 +23292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24514,8 +23328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24552,8 +23364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24590,8 +23400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24628,8 +23436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24666,8 +23472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24704,8 +23508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24742,8 +23544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24780,8 +23580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24818,8 +23616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24856,8 +23652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24894,8 +23688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24932,8 +23724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24970,8 +23760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25008,8 +23796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25046,8 +23832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25084,8 +23868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25122,8 +23904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25160,8 +23940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25198,8 +23976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25236,8 +24012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25274,8 +24048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25312,8 +24084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25350,8 +24120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25388,8 +24156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25426,8 +24192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25464,8 +24228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25502,8 +24264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25540,8 +24300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25578,8 +24336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25616,8 +24372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25654,8 +24408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25692,8 +24444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25730,8 +24480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25768,8 +24516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25806,8 +24552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25844,8 +24588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25882,8 +24624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25920,8 +24660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25958,8 +24696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25996,8 +24732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26034,8 +24768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26072,8 +24804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26110,8 +24840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26148,8 +24876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,8 +24912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26224,8 +24948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26262,8 +24984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.4.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.4.sarif
@@ -1979,6 +1979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2014,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2049,6 +2055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2084,6 +2093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2119,6 +2131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2154,6 +2169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2189,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2224,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2259,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2294,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2329,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2364,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2399,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2434,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2469,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2504,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2539,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2574,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2609,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2644,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2679,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2714,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2749,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2784,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2819,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2854,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2889,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2924,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2959,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2994,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3029,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3064,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3099,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3134,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3169,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3204,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3239,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3274,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3309,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3344,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3379,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3414,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3449,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3484,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3519,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3554,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3589,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3624,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3659,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3694,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3729,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3764,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3799,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3834,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3869,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3904,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3939,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3974,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4009,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4044,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4079,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4114,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4149,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4184,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4219,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4254,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4289,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4324,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4359,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4394,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4429,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4499,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4534,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4569,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4604,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4639,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4674,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4709,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4744,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4779,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4814,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4849,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4884,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4919,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4954,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4989,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5024,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5059,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5094,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5129,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5164,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5199,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5234,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5269,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5304,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5339,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5374,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5409,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5444,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5479,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5514,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5549,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5584,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5619,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5654,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5689,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5759,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5794,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5829,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5864,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5899,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5934,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5969,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6004,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6039,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6074,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6109,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6144,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6179,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6214,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6249,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6284,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6319,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6354,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6389,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6424,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6459,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6494,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6529,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6564,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6599,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6634,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6669,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6704,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6739,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6774,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6809,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6844,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6879,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6914,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6949,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6984,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7019,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7054,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7089,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7124,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7159,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7194,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7229,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7264,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7299,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7334,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7369,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7404,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7439,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7474,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7509,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7544,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7579,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7614,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7649,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7684,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7719,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7754,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7789,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7824,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7859,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7894,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -7929,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -7964,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -7999,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8034,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8069,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8104,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8139,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8174,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8209,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8244,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8279,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8314,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8349,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8384,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8419,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8454,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8489,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8524,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8559,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8594,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8629,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8664,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8699,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8734,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8769,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8804,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -8839,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -8874,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -8909,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -8944,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -8979,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9014,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9049,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9084,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9119,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9154,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9189,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9224,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9259,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9294,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9329,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9364,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9399,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9434,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9469,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9504,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9539,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9574,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9609,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9644,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9679,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9714,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9749,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9784,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9819,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9854,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9889,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9924,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9959,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9994,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10029,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10064,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10099,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10134,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10169,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10204,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10239,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10274,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10309,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10344,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10379,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10414,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10449,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10484,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10519,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10554,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10589,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10624,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10659,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10694,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10729,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10764,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10799,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10834,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10869,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10904,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10939,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10974,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11009,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11044,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11079,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11114,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11149,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11184,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11219,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11254,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11289,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11324,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11359,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11394,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11429,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11464,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11499,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11534,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11569,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11604,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11639,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11674,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11709,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11744,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11779,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11814,6 +12657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11849,6 +12695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11884,6 +12733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11919,6 +12771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11954,6 +12809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11989,6 +12847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12024,6 +12885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12059,6 +12923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12094,6 +12961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12129,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12164,6 +13037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12199,6 +13075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12234,6 +13113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12269,6 +13151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12304,6 +13189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12339,6 +13227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12374,6 +13265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12409,6 +13303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12444,6 +13341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12479,6 +13379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12514,6 +13417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12549,6 +13455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12584,6 +13493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12619,6 +13531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12654,6 +13569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12689,6 +13607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12724,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12759,6 +13683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12794,6 +13721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12829,6 +13759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12864,6 +13797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12899,6 +13835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12934,6 +13873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12969,6 +13911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13004,6 +13949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13039,6 +13987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13074,6 +14025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13109,6 +14063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13144,6 +14101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13179,6 +14139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13214,6 +14177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13249,6 +14215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13284,6 +14253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13319,6 +14291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13354,6 +14329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13389,6 +14367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13424,6 +14405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13459,6 +14443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13494,6 +14481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13529,6 +14519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13564,6 +14557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13599,6 +14595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13634,6 +14633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13669,6 +14671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13704,6 +14709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13739,6 +14747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13774,6 +14785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -13809,6 +14823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13844,6 +14861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -13879,6 +14899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -13914,6 +14937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -13949,6 +14975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13984,6 +15013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14019,6 +15051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14054,6 +15089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14089,6 +15127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14124,6 +15165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14159,6 +15203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14194,6 +15241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14229,6 +15279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14264,6 +15317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14299,6 +15355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14334,6 +15393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14369,6 +15431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14404,6 +15469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14439,6 +15507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14474,6 +15545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14509,6 +15583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14544,6 +15621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14579,6 +15659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14614,6 +15697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14649,6 +15735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14684,6 +15773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14719,6 +15811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14754,6 +15849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14789,6 +15887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14824,6 +15925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -14859,6 +15963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14894,6 +16001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14929,6 +16039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14964,6 +16077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -14999,6 +16115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15034,6 +16153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15069,6 +16191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15104,6 +16229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15139,6 +16267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15174,6 +16305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15209,6 +16343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15244,6 +16381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15279,6 +16419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15314,6 +16457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15349,6 +16495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15384,6 +16533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15419,6 +16571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15454,6 +16609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15489,6 +16647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15524,6 +16685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15559,6 +16723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15594,6 +16761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15629,6 +16799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15664,6 +16837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15699,6 +16875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15734,6 +16913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15769,6 +16951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15804,6 +16989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15839,6 +17027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15874,6 +17065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15909,6 +17103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15944,6 +17141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15979,6 +17179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16014,6 +17217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16049,6 +17255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16084,6 +17293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16119,6 +17331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16154,6 +17369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16189,6 +17407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16224,6 +17445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16259,6 +17483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16294,6 +17521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16329,6 +17559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16364,6 +17597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16399,6 +17635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16434,6 +17673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16469,6 +17711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16504,6 +17749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16539,6 +17787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16574,6 +17825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16609,6 +17863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16644,6 +17901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16679,6 +17939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16714,6 +17977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16749,6 +18015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16784,6 +18053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16819,6 +18091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16854,6 +18129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -16889,6 +18167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16924,6 +18205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16959,6 +18243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -16994,6 +18281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17029,6 +18319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17064,6 +18357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17099,6 +18395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17134,6 +18433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17169,6 +18471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17204,6 +18509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17239,6 +18547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17274,6 +18585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17309,6 +18623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17344,6 +18661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17379,6 +18699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17414,6 +18737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17449,6 +18775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17484,6 +18813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17519,6 +18851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17554,6 +18889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17589,6 +18927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17624,6 +18965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17659,6 +19003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17694,6 +19041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17729,6 +19079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17764,6 +19117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17799,6 +19155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17834,6 +19193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17869,6 +19231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17904,6 +19269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -17939,6 +19307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -17974,6 +19345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18009,6 +19383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18044,6 +19421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18079,6 +19459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18114,6 +19497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18149,6 +19535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18184,6 +19573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18219,6 +19611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18254,6 +19649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18289,6 +19687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18324,6 +19725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18359,6 +19763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18394,6 +19801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18429,6 +19839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18464,6 +19877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18499,6 +19915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18534,6 +19953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18569,6 +19991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18604,6 +20029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18639,6 +20067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18674,6 +20105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18709,6 +20143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18744,6 +20181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18779,6 +20219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18814,6 +20257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18849,6 +20295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18884,6 +20333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18919,6 +20371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18954,6 +20409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18989,6 +20447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19024,6 +20485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19059,6 +20523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19094,6 +20561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19129,6 +20599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19164,6 +20637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19199,6 +20675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19234,6 +20713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19269,6 +20751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19304,6 +20789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19339,6 +20827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19374,6 +20865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19409,6 +20903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19444,6 +20941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19479,6 +20979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19514,6 +21017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19549,6 +21055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19584,6 +21093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19619,6 +21131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19654,6 +21169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19689,6 +21207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19724,6 +21245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19759,6 +21283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -19794,6 +21321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19829,6 +21359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19864,6 +21397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19899,6 +21435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19934,6 +21473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19969,6 +21511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20004,6 +21549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20039,6 +21587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20074,6 +21625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20109,6 +21663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20144,6 +21701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20179,6 +21739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20214,6 +21777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20249,6 +21815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20284,6 +21853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20319,6 +21891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20354,6 +21929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20389,6 +21967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20424,6 +22005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20459,6 +22043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20494,6 +22081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20529,6 +22119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20564,6 +22157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20599,6 +22195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20634,6 +22233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20669,6 +22271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20704,6 +22309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20739,6 +22347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20774,6 +22385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20809,6 +22423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20844,6 +22461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20879,6 +22499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -20914,6 +22537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -20949,6 +22575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -20984,6 +22613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21019,6 +22651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21054,6 +22689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21089,6 +22727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21124,6 +22765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21159,6 +22803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21194,6 +22841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21229,6 +22879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21264,6 +22917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21299,6 +22955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21334,6 +22993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21369,6 +23031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21404,6 +23069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21439,6 +23107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21474,6 +23145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21509,6 +23183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21544,6 +23221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21579,6 +23259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21614,6 +23297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21649,6 +23335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21684,6 +23373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21719,6 +23411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21754,6 +23449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21789,6 +23487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -21824,6 +23525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -21859,6 +23563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -21894,6 +23601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -21929,6 +23639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -21964,6 +23677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -21999,6 +23715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22034,6 +23753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22069,6 +23791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22104,6 +23829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22139,6 +23867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22174,6 +23905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22209,6 +23943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22244,6 +23981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22279,6 +24019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22314,6 +24057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22349,6 +24095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22384,6 +24133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22419,6 +24171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22454,6 +24209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22489,6 +24247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22524,6 +24285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22559,6 +24323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22594,6 +24361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22629,6 +24399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22664,6 +24437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22699,6 +24475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22734,6 +24513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22769,6 +24551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22804,6 +24589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -22839,6 +24627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -22874,6 +24665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -22909,6 +24703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -22944,6 +24741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22979,6 +24779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23014,6 +24817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23049,6 +24855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23084,6 +24893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23119,6 +24931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23154,6 +24969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23189,6 +25007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23224,6 +25045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23259,6 +25083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23294,6 +25121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23329,6 +25159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23364,6 +25197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23399,6 +25235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23434,6 +25273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23469,6 +25311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23504,6 +25349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23539,6 +25387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23574,6 +25425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23609,6 +25463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23644,6 +25501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23679,6 +25539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23714,6 +25577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23749,6 +25615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23784,6 +25653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23819,6 +25691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23854,6 +25729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23889,6 +25767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -23924,6 +25805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23959,6 +25843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23994,6 +25881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24029,6 +25919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24064,6 +25957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24099,6 +25995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24134,6 +26033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24169,6 +26071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24204,6 +26109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24239,6 +26147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24274,6 +26185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24309,6 +26223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24344,6 +26261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.4.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.4.sarif
@@ -1980,6 +1980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2016,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2052,6 +2056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2088,6 +2094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2124,6 +2132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2160,6 +2170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2196,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2232,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2268,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2304,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2340,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2376,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2412,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2448,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2484,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2520,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2556,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2592,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2628,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2664,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2700,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2736,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2772,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2808,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2844,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2880,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2916,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2952,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2988,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3024,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3060,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3096,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3132,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3168,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3204,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3240,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3276,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3312,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3348,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3384,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3420,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3456,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3492,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3528,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3564,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3600,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3636,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3672,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3708,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3744,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3780,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3816,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3852,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3888,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3924,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3960,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3996,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4032,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4068,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4104,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4140,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4176,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4212,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4248,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4284,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4320,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4356,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4392,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4428,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4500,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4536,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4572,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4608,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4644,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4680,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4716,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4752,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4788,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4824,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4860,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4896,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4932,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4968,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5004,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5040,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5076,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5112,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5148,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5184,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5220,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5256,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5292,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5328,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5364,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5400,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5436,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5472,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5508,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5544,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5580,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5616,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5652,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5688,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5760,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5796,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5832,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5868,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5904,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5940,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5976,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6012,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6048,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6084,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6120,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6156,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6192,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6228,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6264,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6300,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6336,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6372,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6408,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6444,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6480,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6516,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6552,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6588,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6624,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6660,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6696,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6732,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6768,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6804,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6840,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6876,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6912,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6948,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6984,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7020,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7056,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7092,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7128,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7164,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7200,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7236,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7272,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7308,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7344,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7380,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7416,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7452,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7488,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7524,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7560,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7596,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7632,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7668,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7704,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7740,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7776,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7812,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7848,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7884,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7920,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7956,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7992,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8028,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8064,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8100,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8136,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8172,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8208,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8244,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8280,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8316,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8352,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8388,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8424,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8460,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8496,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8532,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8568,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8604,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8640,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8676,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8712,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8748,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8784,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8820,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8856,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8892,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8928,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8964,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9000,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9036,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9072,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9108,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9144,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9180,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9216,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9252,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9288,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9324,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9360,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9396,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9432,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9468,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9504,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9540,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9576,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9612,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9648,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9684,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9720,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9756,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9792,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9828,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9864,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9900,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9936,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9972,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10008,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10044,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10080,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10116,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10152,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10188,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10224,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10260,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10296,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10332,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10368,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10404,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10440,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10476,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10512,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10548,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10584,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10620,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10656,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10692,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10728,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10764,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10800,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10836,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10872,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10908,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10944,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10980,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11016,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11052,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11088,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11124,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11160,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11196,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11232,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11268,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11304,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11340,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11376,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11412,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11448,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11484,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11520,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11556,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11592,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11628,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11664,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11700,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11736,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11772,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11808,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11844,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11880,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11916,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11952,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11988,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12024,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12060,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12096,6 +12658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12132,6 +12696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12168,6 +12734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12204,6 +12772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12240,6 +12810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12276,6 +12848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12312,6 +12886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12348,6 +12924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12384,6 +12962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12420,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12456,6 +13038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12492,6 +13076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12528,6 +13114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12564,6 +13152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12600,6 +13190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12636,6 +13228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12672,6 +13266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12708,6 +13304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12744,6 +13342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12780,6 +13380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12852,6 +13456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12888,6 +13494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12924,6 +13532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12960,6 +13570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12996,6 +13608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13032,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13068,6 +13684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13104,6 +13722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13140,6 +13760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13176,6 +13798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13212,6 +13836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13248,6 +13874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13284,6 +13912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13320,6 +13950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13356,6 +13988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13392,6 +14026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13428,6 +14064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13464,6 +14102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13500,6 +14140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13536,6 +14178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13572,6 +14216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13608,6 +14254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13644,6 +14292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13680,6 +14330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13716,6 +14368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13752,6 +14406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13788,6 +14444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13824,6 +14482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13860,6 +14520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13896,6 +14558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13932,6 +14596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13968,6 +14634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14004,6 +14672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14040,6 +14710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14076,6 +14748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14112,6 +14786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14148,6 +14824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14184,6 +14862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14220,6 +14900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14256,6 +14938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14292,6 +14976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14328,6 +15014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14364,6 +15052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14400,6 +15090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14436,6 +15128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14472,6 +15166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14508,6 +15204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14544,6 +15242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14580,6 +15280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14616,6 +15318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14652,6 +15356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14688,6 +15394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14724,6 +15432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14760,6 +15470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14796,6 +15508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14832,6 +15546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14868,6 +15584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14904,6 +15622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14940,6 +15660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14976,6 +15698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15012,6 +15736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15048,6 +15774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15084,6 +15812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15120,6 +15850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15156,6 +15888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15192,6 +15926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15228,6 +15964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15264,6 +16002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15300,6 +16040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15336,6 +16078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15372,6 +16116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15408,6 +16154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15444,6 +16192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15480,6 +16230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15516,6 +16268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15552,6 +16306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15588,6 +16344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15624,6 +16382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15660,6 +16420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15696,6 +16458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15732,6 +16496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15768,6 +16534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15804,6 +16572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15840,6 +16610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15876,6 +16648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15912,6 +16686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15948,6 +16724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15984,6 +16762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16020,6 +16800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16056,6 +16838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16092,6 +16876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16128,6 +16914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16164,6 +16952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16200,6 +16990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16236,6 +17028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16272,6 +17066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16308,6 +17104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16344,6 +17142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16380,6 +17180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16416,6 +17218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16452,6 +17256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16488,6 +17294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16524,6 +17332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16560,6 +17370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16596,6 +17408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16632,6 +17446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16668,6 +17484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16704,6 +17522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16740,6 +17560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16776,6 +17598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16812,6 +17636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16848,6 +17674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16884,6 +17712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16920,6 +17750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16956,6 +17788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16992,6 +17826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17028,6 +17864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17064,6 +17902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17100,6 +17940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17136,6 +17978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17172,6 +18016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17208,6 +18054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17244,6 +18092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17280,6 +18130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17316,6 +18168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17352,6 +18206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17388,6 +18244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17424,6 +18282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17460,6 +18320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17496,6 +18358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17532,6 +18396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17568,6 +18434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17604,6 +18472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17640,6 +18510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17676,6 +18548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17712,6 +18586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17748,6 +18624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17784,6 +18662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17820,6 +18700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17856,6 +18738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17892,6 +18776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17928,6 +18814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17964,6 +18852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18000,6 +18890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18036,6 +18928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18072,6 +18966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18108,6 +19004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18144,6 +19042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18180,6 +19080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18216,6 +19118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18252,6 +19156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18288,6 +19194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18324,6 +19232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18360,6 +19270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18396,6 +19308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18432,6 +19346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18468,6 +19384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18504,6 +19422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18540,6 +19460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18576,6 +19498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18612,6 +19536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18648,6 +19574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18684,6 +19612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18720,6 +19650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18756,6 +19688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18792,6 +19726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18828,6 +19764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18864,6 +19802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18900,6 +19840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18936,6 +19878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18972,6 +19916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19008,6 +19954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19044,6 +19992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19080,6 +20030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19116,6 +20068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19152,6 +20106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19188,6 +20144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19224,6 +20182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19260,6 +20220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19296,6 +20258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19332,6 +20296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19368,6 +20334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19404,6 +20372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19440,6 +20410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19476,6 +20448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19512,6 +20486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19548,6 +20524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19584,6 +20562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19620,6 +20600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19656,6 +20638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19692,6 +20676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19728,6 +20714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19764,6 +20752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19800,6 +20790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19836,6 +20828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19872,6 +20866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19908,6 +20904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19944,6 +20942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19980,6 +20980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20016,6 +21018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20052,6 +21056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20088,6 +21094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20124,6 +21132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20160,6 +21170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20196,6 +21208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20232,6 +21246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20268,6 +21284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20304,6 +21322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20340,6 +21360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20376,6 +21398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20412,6 +21436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20448,6 +21474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20484,6 +21512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20520,6 +21550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20556,6 +21588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20592,6 +21626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20628,6 +21664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20664,6 +21702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20700,6 +21740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20736,6 +21778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20772,6 +21816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20808,6 +21854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20844,6 +21892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20880,6 +21930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20916,6 +21968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20952,6 +22006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20988,6 +22044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21024,6 +22082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21060,6 +22120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21096,6 +22158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21132,6 +22196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21168,6 +22234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21204,6 +22272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21240,6 +22310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21276,6 +22348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21312,6 +22386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21348,6 +22424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21384,6 +22462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21420,6 +22500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21456,6 +22538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21492,6 +22576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21528,6 +22614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21564,6 +22652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21600,6 +22690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21636,6 +22728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21672,6 +22766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21708,6 +22804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21744,6 +22842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21780,6 +22880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21816,6 +22918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21852,6 +22956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21888,6 +22994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21924,6 +23032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21960,6 +23070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21996,6 +23108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22032,6 +23146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22068,6 +23184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22104,6 +23222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22140,6 +23260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22176,6 +23298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22212,6 +23336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22248,6 +23374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22284,6 +23412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22320,6 +23450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22356,6 +23488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22392,6 +23526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22428,6 +23564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22464,6 +23602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22500,6 +23640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22536,6 +23678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22572,6 +23716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22608,6 +23754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22644,6 +23792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22680,6 +23830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22716,6 +23868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22752,6 +23906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22788,6 +23944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22824,6 +23982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22860,6 +24020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22896,6 +24058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22932,6 +24096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22968,6 +24134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23004,6 +24172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23040,6 +24210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23076,6 +24248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23112,6 +24286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23148,6 +24324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23184,6 +24362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23220,6 +24400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23256,6 +24438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23292,6 +24476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23328,6 +24514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23364,6 +24552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23400,6 +24590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23436,6 +24628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23472,6 +24666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23508,6 +24704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23544,6 +24742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23580,6 +24780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23616,6 +24818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23652,6 +24856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23688,6 +24894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23724,6 +24932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23760,6 +24970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23796,6 +25008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23832,6 +25046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23868,6 +25084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23904,6 +25122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23940,6 +25160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23976,6 +25198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24012,6 +25236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24048,6 +25274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24084,6 +25312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24120,6 +25350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24156,6 +25388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24192,6 +25426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24228,6 +25464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24264,6 +25502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24300,6 +25540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24336,6 +25578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24372,6 +25616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24408,6 +25654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24444,6 +25692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24480,6 +25730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24516,6 +25768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24552,6 +25806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24588,6 +25844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24624,6 +25882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24660,6 +25920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24696,6 +25958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24732,6 +25996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24768,6 +26034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24804,6 +26072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24840,6 +26110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24876,6 +26148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24912,6 +26186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24948,6 +26224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24984,6 +26262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.5.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.5.sarif
@@ -1980,8 +1980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2018,8 +2016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2056,8 +2052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2094,8 +2088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2132,8 +2124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2170,8 +2160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2208,8 +2196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2246,8 +2232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2284,8 +2268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2322,8 +2304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2360,8 +2340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2398,8 +2376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2436,8 +2412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2474,8 +2448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2512,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2550,8 +2520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2588,8 +2556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2626,8 +2592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2664,8 +2628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2702,8 +2664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2740,8 +2700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2778,8 +2736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2816,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2854,8 +2808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2892,8 +2844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2930,8 +2880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2968,8 +2916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3006,8 +2952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3044,8 +2988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3082,8 +3024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3120,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3158,8 +3096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3196,8 +3132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3234,8 +3168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3272,8 +3204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3310,8 +3240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3348,8 +3276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3386,8 +3312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3424,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3462,8 +3384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3500,8 +3420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3538,8 +3456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3576,8 +3492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3614,8 +3528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3652,8 +3564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3690,8 +3600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3728,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3766,8 +3672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3804,8 +3708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3842,8 +3744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3880,8 +3780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3918,8 +3816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3956,8 +3852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3994,8 +3888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4032,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4070,8 +3960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4108,8 +3996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4146,8 +4032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4184,8 +4068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4222,8 +4104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4260,8 +4140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4298,8 +4176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4336,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4374,8 +4248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4412,8 +4284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4450,8 +4320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4488,8 +4356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4526,8 +4392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4564,8 +4428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4602,8 +4464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4640,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4678,8 +4536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4716,8 +4572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4754,8 +4608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4792,8 +4644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4830,8 +4680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4868,8 +4716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4906,8 +4752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4944,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4982,8 +4824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5020,8 +4860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5058,8 +4896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5096,8 +4932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5134,8 +4968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5172,8 +5004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5210,8 +5040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5248,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5286,8 +5112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5324,8 +5148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5362,8 +5184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5400,8 +5220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5438,8 +5256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5476,8 +5292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5514,8 +5328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5552,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5590,8 +5400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5628,8 +5436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5666,8 +5472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5704,8 +5508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5742,8 +5544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5780,8 +5580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5818,8 +5616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5856,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5894,8 +5688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5932,8 +5724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5970,8 +5760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,8 +5796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6046,8 +5832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6084,8 +5868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6122,8 +5904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6160,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6198,8 +5976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6236,8 +6012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6274,8 +6048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6312,8 +6084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6350,8 +6120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6388,8 +6156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6426,8 +6192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6464,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6502,8 +6264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6540,8 +6300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6578,8 +6336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6616,8 +6372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6654,8 +6408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6692,8 +6444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6730,8 +6480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6768,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6806,8 +6552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6844,8 +6588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6882,8 +6624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6920,8 +6660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6958,8 +6696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6996,8 +6732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7034,8 +6768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7072,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7110,8 +6840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7148,8 +6876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7186,8 +6912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7224,8 +6948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7262,8 +6984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7300,8 +7020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7338,8 +7056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7376,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7414,8 +7128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7452,8 +7164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7490,8 +7200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7528,8 +7236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7566,8 +7272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7604,8 +7308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7642,8 +7344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7680,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,8 +7416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7756,8 +7452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7794,8 +7488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7832,8 +7524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7870,8 +7560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7908,8 +7596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7946,8 +7632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7984,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8022,8 +7704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8060,8 +7740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8098,8 +7776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8136,8 +7812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8174,8 +7848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8212,8 +7884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8250,8 +7920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8288,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8326,8 +7992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8364,8 +8028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8402,8 +8064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8440,8 +8100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8478,8 +8136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8516,8 +8172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8554,8 +8208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8592,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8630,8 +8280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8668,8 +8316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8706,8 +8352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8744,8 +8388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8782,8 +8424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8820,8 +8460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8858,8 +8496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8896,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8934,8 +8568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8972,8 +8604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9010,8 +8640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9048,8 +8676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9086,8 +8712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9124,8 +8748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9162,8 +8784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9200,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9238,8 +8856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9276,8 +8892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9314,8 +8928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9352,8 +8964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9390,8 +9000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9428,8 +9036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9466,8 +9072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9504,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9542,8 +9144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9580,8 +9180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9618,8 +9216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9656,8 +9252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9694,8 +9288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9732,8 +9324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9770,8 +9360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9808,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9846,8 +9432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9884,8 +9468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9922,8 +9504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9960,8 +9540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9998,8 +9576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10036,8 +9612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10074,8 +9648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10112,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10150,8 +9720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10188,8 +9756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10226,8 +9792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10264,8 +9828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10302,8 +9864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10340,8 +9900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10378,8 +9936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10416,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10454,8 +10008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10492,8 +10044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10530,8 +10080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10568,8 +10116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10606,8 +10152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10644,8 +10188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10682,8 +10224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10720,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10758,8 +10296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10796,8 +10332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10834,8 +10368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10872,8 +10404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10910,8 +10440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10948,8 +10476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10986,8 +10512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11024,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11062,8 +10584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11100,8 +10620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11138,8 +10656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11176,8 +10692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11214,8 +10728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11252,8 +10764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11290,8 +10800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11328,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11366,8 +10872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11404,8 +10908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11442,8 +10944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11480,8 +10980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11518,8 +11016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11556,8 +11052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11594,8 +11088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11632,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11670,8 +11160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11708,8 +11196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11746,8 +11232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11784,8 +11268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11822,8 +11304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11860,8 +11340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11898,8 +11376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11936,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11974,8 +11448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12012,8 +11484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12050,8 +11520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12088,8 +11556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12126,8 +11592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12164,8 +11628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12202,8 +11664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12240,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12278,8 +11736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12316,8 +11772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12354,8 +11808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12392,8 +11844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12430,8 +11880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12468,8 +11916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12506,8 +11952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12544,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12582,8 +12024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12620,8 +12060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12658,8 +12096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12696,8 +12132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12734,8 +12168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12772,8 +12204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12810,8 +12240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12848,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12886,8 +12312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12924,8 +12348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12962,8 +12384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13000,8 +12420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13038,8 +12456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13076,8 +12492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13114,8 +12528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13152,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13190,8 +12600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13228,8 +12636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13266,8 +12672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13304,8 +12708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13342,8 +12744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13380,8 +12780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13418,8 +12816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13456,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13494,8 +12888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13532,8 +12924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13570,8 +12960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13608,8 +12996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13646,8 +13032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13684,8 +13068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13722,8 +13104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13760,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13798,8 +13176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13836,8 +13212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13874,8 +13248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13912,8 +13284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13950,8 +13320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13988,8 +13356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14026,8 +13392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14064,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14102,8 +13464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14140,8 +13500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14178,8 +13536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14216,8 +13572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14254,8 +13608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14292,8 +13644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14330,8 +13680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14368,8 +13716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14406,8 +13752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14444,8 +13788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14482,8 +13824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14520,8 +13860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14558,8 +13896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14596,8 +13932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14634,8 +13968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14672,8 +14004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14710,8 +14040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14748,8 +14076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14786,8 +14112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14824,8 +14148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14862,8 +14184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14900,8 +14220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14938,8 +14256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14976,8 +14292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15014,8 +14328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15052,8 +14364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15090,8 +14400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15128,8 +14436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15166,8 +14472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15204,8 +14508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15242,8 +14544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15280,8 +14580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15318,8 +14616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15356,8 +14652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15394,8 +14688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15432,8 +14724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15470,8 +14760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15508,8 +14796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15546,8 +14832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15584,8 +14868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15622,8 +14904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15660,8 +14940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15698,8 +14976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15736,8 +15012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15774,8 +15048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15812,8 +15084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15850,8 +15120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15888,8 +15156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15926,8 +15192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15964,8 +15228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16002,8 +15264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16040,8 +15300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16078,8 +15336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16116,8 +15372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16154,8 +15408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16192,8 +15444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16230,8 +15480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16268,8 +15516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16306,8 +15552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16344,8 +15588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16382,8 +15624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16420,8 +15660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16458,8 +15696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16496,8 +15732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16534,8 +15768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16572,8 +15804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16610,8 +15840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16648,8 +15876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16686,8 +15912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16724,8 +15948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16762,8 +15984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16800,8 +16020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16838,8 +16056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16876,8 +16092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16914,8 +16128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16952,8 +16164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16990,8 +16200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17028,8 +16236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17066,8 +16272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17104,8 +16308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17142,8 +16344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17180,8 +16380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17218,8 +16416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17256,8 +16452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17294,8 +16488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17332,8 +16524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17370,8 +16560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17408,8 +16596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17446,8 +16632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17484,8 +16668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17522,8 +16704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17560,8 +16740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17598,8 +16776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17636,8 +16812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17674,8 +16848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17712,8 +16884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17750,8 +16920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17788,8 +16956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17826,8 +16992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17864,8 +17028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17902,8 +17064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17940,8 +17100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17978,8 +17136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18016,8 +17172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18054,8 +17208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18092,8 +17244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18130,8 +17280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18168,8 +17316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18206,8 +17352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18244,8 +17388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18282,8 +17424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18320,8 +17460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18358,8 +17496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18396,8 +17532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18434,8 +17568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18472,8 +17604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18510,8 +17640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18548,8 +17676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18586,8 +17712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18624,8 +17748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18662,8 +17784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18700,8 +17820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18738,8 +17856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18776,8 +17892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18814,8 +17928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18852,8 +17964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18890,8 +18000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18928,8 +18036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18966,8 +18072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19004,8 +18108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19042,8 +18144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19080,8 +18180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19118,8 +18216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19156,8 +18252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19194,8 +18288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19232,8 +18324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19270,8 +18360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19308,8 +18396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19346,8 +18432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19384,8 +18468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19422,8 +18504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19460,8 +18540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19498,8 +18576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19536,8 +18612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19574,8 +18648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19612,8 +18684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19650,8 +18720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19688,8 +18756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19726,8 +18792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19764,8 +18828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19802,8 +18864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19840,8 +18900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19878,8 +18936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19916,8 +18972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19954,8 +19008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19992,8 +19044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20030,8 +19080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20068,8 +19116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20106,8 +19152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20144,8 +19188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20182,8 +19224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20220,8 +19260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20258,8 +19296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20296,8 +19332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20334,8 +19368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20372,8 +19404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20410,8 +19440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20448,8 +19476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20486,8 +19512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20524,8 +19548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20562,8 +19584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20600,8 +19620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20638,8 +19656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20676,8 +19692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20714,8 +19728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20752,8 +19764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20790,8 +19800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20828,8 +19836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20866,8 +19872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20904,8 +19908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20942,8 +19944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20980,8 +19980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21018,8 +20016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21056,8 +20052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21094,8 +20088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21132,8 +20124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21170,8 +20160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21208,8 +20196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21246,8 +20232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21284,8 +20268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21322,8 +20304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21360,8 +20340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21398,8 +20376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21436,8 +20412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21474,8 +20448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21512,8 +20484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21550,8 +20520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21588,8 +20556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21626,8 +20592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21664,8 +20628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21702,8 +20664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21740,8 +20700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21778,8 +20736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21816,8 +20772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21854,8 +20808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21892,8 +20844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21930,8 +20880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21968,8 +20916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22006,8 +20952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22044,8 +20988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22082,8 +21024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22120,8 +21060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22158,8 +21096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22196,8 +21132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22234,8 +21168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22272,8 +21204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22310,8 +21240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22348,8 +21276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22386,8 +21312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22424,8 +21348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22462,8 +21384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22500,8 +21420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22538,8 +21456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22576,8 +21492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22614,8 +21528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22652,8 +21564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22690,8 +21600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22728,8 +21636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22766,8 +21672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22804,8 +21708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22842,8 +21744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22880,8 +21780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22918,8 +21816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22956,8 +21852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22994,8 +21888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23032,8 +21924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23070,8 +21960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23108,8 +21996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23146,8 +22032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23184,8 +22068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23222,8 +22104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23260,8 +22140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23298,8 +22176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23336,8 +22212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23374,8 +22248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23412,8 +22284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23450,8 +22320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23488,8 +22356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23526,8 +22392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23564,8 +22428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23602,8 +22464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23640,8 +22500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23678,8 +22536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23716,8 +22572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23754,8 +22608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23792,8 +22644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23830,8 +22680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23868,8 +22716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23906,8 +22752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23944,8 +22788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23982,8 +22824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24020,8 +22860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24058,8 +22896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24096,8 +22932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24134,8 +22968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24172,8 +23004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24210,8 +23040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24248,8 +23076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24286,8 +23112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24324,8 +23148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24362,8 +23184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24400,8 +23220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24438,8 +23256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24476,8 +23292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24514,8 +23328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24552,8 +23364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24590,8 +23400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24628,8 +23436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24666,8 +23472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24704,8 +23508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24742,8 +23544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24780,8 +23580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24818,8 +23616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24856,8 +23652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24894,8 +23688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24932,8 +23724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24970,8 +23760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25008,8 +23796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25046,8 +23832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25084,8 +23868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25122,8 +23904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25160,8 +23940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25198,8 +23976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25236,8 +24012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25274,8 +24048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25312,8 +24084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25350,8 +24120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25388,8 +24156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25426,8 +24192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25464,8 +24228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25502,8 +24264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25540,8 +24300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25578,8 +24336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25616,8 +24372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25654,8 +24408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25692,8 +24444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25730,8 +24480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25768,8 +24516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25806,8 +24552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25844,8 +24588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25882,8 +24624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25920,8 +24660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25958,8 +24696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25996,8 +24732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26034,8 +24768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26072,8 +24804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26110,8 +24840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26148,8 +24876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,8 +24912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26224,8 +24948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26262,8 +24984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.5.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.5.sarif
@@ -1979,6 +1979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2014,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2049,6 +2055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2084,6 +2093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2119,6 +2131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2154,6 +2169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2189,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2224,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2259,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2294,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2329,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2364,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2399,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2434,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2469,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2504,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2539,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2574,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2609,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2644,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2679,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2714,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2749,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2784,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2819,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2854,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2889,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2924,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2959,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2994,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3029,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3064,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3099,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3134,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3169,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3204,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3239,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3274,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3309,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3344,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3379,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3414,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3449,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3484,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3519,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3554,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3589,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3624,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3659,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3694,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3729,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3764,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3799,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3834,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3869,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3904,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3939,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3974,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4009,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4044,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4079,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4114,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4149,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4184,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4219,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4254,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4289,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4324,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4359,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4394,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4429,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4499,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4534,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4569,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4604,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4639,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4674,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4709,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4744,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4779,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4814,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4849,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4884,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4919,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4954,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4989,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5024,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5059,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5094,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5129,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5164,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5199,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5234,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5269,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5304,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5339,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5374,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5409,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5444,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5479,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5514,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5549,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5584,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5619,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5654,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5689,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5759,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5794,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5829,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5864,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5899,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5934,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5969,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6004,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6039,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6074,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6109,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6144,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6179,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6214,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6249,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6284,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6319,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6354,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6389,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6424,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6459,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6494,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6529,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6564,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6599,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6634,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6669,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6704,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6739,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6774,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6809,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6844,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6879,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6914,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6949,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6984,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7019,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7054,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7089,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7124,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7159,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7194,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7229,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7264,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7299,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7334,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7369,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7404,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7439,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7474,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7509,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7544,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7579,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7614,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7649,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7684,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7719,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7754,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7789,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7824,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7859,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7894,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -7929,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -7964,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -7999,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8034,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8069,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8104,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8139,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8174,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8209,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8244,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8279,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8314,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8349,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8384,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8419,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8454,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8489,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8524,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8559,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8594,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8629,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8664,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8699,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8734,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8769,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8804,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -8839,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -8874,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -8909,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -8944,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -8979,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9014,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9049,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9084,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9119,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9154,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9189,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9224,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9259,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9294,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9329,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9364,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9399,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9434,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9469,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9504,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9539,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9574,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9609,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9644,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9679,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9714,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9749,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9784,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9819,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9854,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9889,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9924,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9959,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9994,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10029,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10064,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10099,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10134,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10169,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10204,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10239,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10274,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10309,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10344,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10379,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10414,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10449,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10484,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10519,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10554,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10589,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10624,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10659,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10694,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10729,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10764,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10799,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10834,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10869,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10904,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10939,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10974,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11009,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11044,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11079,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11114,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11149,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11184,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11219,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11254,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11289,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11324,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11359,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11394,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11429,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11464,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11499,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11534,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11569,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11604,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11639,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11674,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11709,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11744,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11779,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11814,6 +12657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11849,6 +12695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11884,6 +12733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11919,6 +12771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11954,6 +12809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11989,6 +12847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12024,6 +12885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12059,6 +12923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12094,6 +12961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12129,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12164,6 +13037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12199,6 +13075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12234,6 +13113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12269,6 +13151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12304,6 +13189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12339,6 +13227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12374,6 +13265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12409,6 +13303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12444,6 +13341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12479,6 +13379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12514,6 +13417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12549,6 +13455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12584,6 +13493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12619,6 +13531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12654,6 +13569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12689,6 +13607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12724,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12759,6 +13683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12794,6 +13721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12829,6 +13759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12864,6 +13797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12899,6 +13835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12934,6 +13873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12969,6 +13911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13004,6 +13949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13039,6 +13987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13074,6 +14025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13109,6 +14063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13144,6 +14101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13179,6 +14139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13214,6 +14177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13249,6 +14215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13284,6 +14253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13319,6 +14291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13354,6 +14329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13389,6 +14367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13424,6 +14405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13459,6 +14443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13494,6 +14481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13529,6 +14519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13564,6 +14557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13599,6 +14595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13634,6 +14633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13669,6 +14671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13704,6 +14709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13739,6 +14747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13774,6 +14785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -13809,6 +14823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13844,6 +14861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -13879,6 +14899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -13914,6 +14937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -13949,6 +14975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13984,6 +15013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14019,6 +15051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14054,6 +15089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14089,6 +15127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14124,6 +15165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14159,6 +15203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14194,6 +15241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14229,6 +15279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14264,6 +15317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14299,6 +15355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14334,6 +15393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14369,6 +15431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14404,6 +15469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14439,6 +15507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14474,6 +15545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14509,6 +15583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14544,6 +15621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14579,6 +15659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14614,6 +15697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14649,6 +15735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14684,6 +15773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14719,6 +15811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14754,6 +15849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14789,6 +15887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14824,6 +15925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -14859,6 +15963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14894,6 +16001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14929,6 +16039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14964,6 +16077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -14999,6 +16115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15034,6 +16153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15069,6 +16191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15104,6 +16229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15139,6 +16267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15174,6 +16305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15209,6 +16343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15244,6 +16381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15279,6 +16419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15314,6 +16457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15349,6 +16495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15384,6 +16533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15419,6 +16571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15454,6 +16609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15489,6 +16647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15524,6 +16685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15559,6 +16723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15594,6 +16761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15629,6 +16799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15664,6 +16837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15699,6 +16875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15734,6 +16913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15769,6 +16951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15804,6 +16989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15839,6 +17027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15874,6 +17065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15909,6 +17103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15944,6 +17141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15979,6 +17179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16014,6 +17217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16049,6 +17255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16084,6 +17293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16119,6 +17331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16154,6 +17369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16189,6 +17407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16224,6 +17445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16259,6 +17483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16294,6 +17521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16329,6 +17559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16364,6 +17597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16399,6 +17635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16434,6 +17673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16469,6 +17711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16504,6 +17749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16539,6 +17787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16574,6 +17825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16609,6 +17863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16644,6 +17901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16679,6 +17939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16714,6 +17977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16749,6 +18015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16784,6 +18053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16819,6 +18091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16854,6 +18129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -16889,6 +18167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16924,6 +18205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16959,6 +18243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -16994,6 +18281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17029,6 +18319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17064,6 +18357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17099,6 +18395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17134,6 +18433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17169,6 +18471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17204,6 +18509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17239,6 +18547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17274,6 +18585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17309,6 +18623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17344,6 +18661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17379,6 +18699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17414,6 +18737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17449,6 +18775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17484,6 +18813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17519,6 +18851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17554,6 +18889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17589,6 +18927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17624,6 +18965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17659,6 +19003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17694,6 +19041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17729,6 +19079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17764,6 +19117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17799,6 +19155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17834,6 +19193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17869,6 +19231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17904,6 +19269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -17939,6 +19307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -17974,6 +19345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18009,6 +19383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18044,6 +19421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18079,6 +19459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18114,6 +19497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18149,6 +19535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18184,6 +19573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18219,6 +19611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18254,6 +19649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18289,6 +19687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18324,6 +19725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18359,6 +19763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18394,6 +19801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18429,6 +19839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18464,6 +19877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18499,6 +19915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18534,6 +19953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18569,6 +19991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18604,6 +20029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18639,6 +20067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18674,6 +20105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18709,6 +20143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18744,6 +20181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18779,6 +20219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18814,6 +20257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18849,6 +20295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18884,6 +20333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18919,6 +20371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18954,6 +20409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18989,6 +20447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19024,6 +20485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19059,6 +20523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19094,6 +20561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19129,6 +20599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19164,6 +20637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19199,6 +20675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19234,6 +20713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19269,6 +20751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19304,6 +20789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19339,6 +20827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19374,6 +20865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19409,6 +20903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19444,6 +20941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19479,6 +20979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19514,6 +21017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19549,6 +21055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19584,6 +21093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19619,6 +21131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19654,6 +21169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19689,6 +21207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19724,6 +21245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19759,6 +21283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -19794,6 +21321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19829,6 +21359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19864,6 +21397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19899,6 +21435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19934,6 +21473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19969,6 +21511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20004,6 +21549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20039,6 +21587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20074,6 +21625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20109,6 +21663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20144,6 +21701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20179,6 +21739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20214,6 +21777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20249,6 +21815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20284,6 +21853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20319,6 +21891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20354,6 +21929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20389,6 +21967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20424,6 +22005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20459,6 +22043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20494,6 +22081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20529,6 +22119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20564,6 +22157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20599,6 +22195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20634,6 +22233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20669,6 +22271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20704,6 +22309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20739,6 +22347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20774,6 +22385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20809,6 +22423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20844,6 +22461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20879,6 +22499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -20914,6 +22537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -20949,6 +22575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -20984,6 +22613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21019,6 +22651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21054,6 +22689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21089,6 +22727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21124,6 +22765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21159,6 +22803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21194,6 +22841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21229,6 +22879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21264,6 +22917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21299,6 +22955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21334,6 +22993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21369,6 +23031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21404,6 +23069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21439,6 +23107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21474,6 +23145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21509,6 +23183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21544,6 +23221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21579,6 +23259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21614,6 +23297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21649,6 +23335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21684,6 +23373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21719,6 +23411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21754,6 +23449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21789,6 +23487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -21824,6 +23525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -21859,6 +23563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -21894,6 +23601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -21929,6 +23639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -21964,6 +23677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -21999,6 +23715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22034,6 +23753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22069,6 +23791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22104,6 +23829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22139,6 +23867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22174,6 +23905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22209,6 +23943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22244,6 +23981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22279,6 +24019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22314,6 +24057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22349,6 +24095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22384,6 +24133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22419,6 +24171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22454,6 +24209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22489,6 +24247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22524,6 +24285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22559,6 +24323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22594,6 +24361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22629,6 +24399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22664,6 +24437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22699,6 +24475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22734,6 +24513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22769,6 +24551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22804,6 +24589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -22839,6 +24627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -22874,6 +24665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -22909,6 +24703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -22944,6 +24741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22979,6 +24779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23014,6 +24817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23049,6 +24855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23084,6 +24893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23119,6 +24931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23154,6 +24969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23189,6 +25007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23224,6 +25045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23259,6 +25083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23294,6 +25121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23329,6 +25159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23364,6 +25197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23399,6 +25235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23434,6 +25273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23469,6 +25311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23504,6 +25349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23539,6 +25387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23574,6 +25425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23609,6 +25463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23644,6 +25501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23679,6 +25539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23714,6 +25577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23749,6 +25615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23784,6 +25653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23819,6 +25691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23854,6 +25729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23889,6 +25767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -23924,6 +25805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23959,6 +25843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23994,6 +25881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24029,6 +25919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24064,6 +25957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24099,6 +25995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24134,6 +26033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24169,6 +26071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24204,6 +26109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24239,6 +26147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24274,6 +26185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24309,6 +26223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24344,6 +26261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v3.5.5.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.5.sarif
@@ -1980,6 +1980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2016,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2052,6 +2056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2088,6 +2094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2124,6 +2132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2160,6 +2170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2196,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2232,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2268,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2304,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2340,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2376,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2412,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2448,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2484,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2520,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2556,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2592,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2628,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2664,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2700,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2736,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2772,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2808,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2844,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2880,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2916,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2952,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2988,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3024,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3060,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3096,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3132,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3168,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3204,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3240,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3276,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3312,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3348,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3384,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3420,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3456,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3492,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3528,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3564,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3600,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3636,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3672,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3708,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3744,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3780,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3816,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3852,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3888,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3924,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3960,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3996,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4032,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4068,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4104,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4140,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4176,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4212,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4248,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4284,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4320,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4356,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4392,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4428,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4500,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4536,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4572,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4608,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4644,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4680,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4716,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4752,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4788,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4824,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4860,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4896,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4932,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4968,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5004,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5040,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5076,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5112,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5148,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5184,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5220,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5256,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5292,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5328,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5364,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5400,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5436,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5472,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5508,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5544,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5580,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5616,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5652,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5688,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5760,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5796,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5832,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5868,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5904,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5940,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5976,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6012,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6048,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6084,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6120,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6156,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6192,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6228,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6264,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6300,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6336,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6372,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6408,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6444,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6480,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6516,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6552,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6588,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6624,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6660,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6696,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6732,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6768,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6804,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6840,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6876,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6912,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6948,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6984,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7020,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7056,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7092,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7128,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7164,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7200,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7236,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7272,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7308,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7344,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7380,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7416,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7452,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7488,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7524,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7560,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7596,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7632,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7668,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7704,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7740,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7776,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7812,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7848,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7884,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7920,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7956,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7992,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8028,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8064,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8100,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8136,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8172,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8208,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8244,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8280,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8316,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8352,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8388,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8424,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8460,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8496,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8532,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8568,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8604,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8640,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8676,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8712,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8748,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8784,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8820,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8856,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8892,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8928,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8964,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9000,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9036,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9072,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9108,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9144,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9180,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9216,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9252,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9288,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9324,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9360,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9396,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9432,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9468,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9504,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9540,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9576,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9612,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9648,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9684,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9720,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9756,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9792,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9828,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9864,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9900,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9936,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9972,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10008,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10044,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10080,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10116,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10152,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10188,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10224,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10260,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10296,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10332,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10368,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10404,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10440,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10476,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10512,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10548,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10584,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10620,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10656,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10692,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10728,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10764,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10800,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10836,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10872,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10908,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10944,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10980,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11016,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11052,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11088,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11124,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11160,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11196,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11232,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11268,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11304,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11340,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11376,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11412,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11448,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11484,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11520,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11556,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11592,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11628,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11664,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11700,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11736,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11772,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11808,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11844,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11880,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11916,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11952,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11988,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12024,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12060,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12096,6 +12658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12132,6 +12696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12168,6 +12734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12204,6 +12772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12240,6 +12810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12276,6 +12848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12312,6 +12886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12348,6 +12924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12384,6 +12962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12420,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12456,6 +13038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12492,6 +13076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12528,6 +13114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12564,6 +13152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12600,6 +13190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12636,6 +13228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12672,6 +13266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12708,6 +13304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12744,6 +13342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12780,6 +13380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12852,6 +13456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12888,6 +13494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12924,6 +13532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12960,6 +13570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12996,6 +13608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13032,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13068,6 +13684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13104,6 +13722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13140,6 +13760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13176,6 +13798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13212,6 +13836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13248,6 +13874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13284,6 +13912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13320,6 +13950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13356,6 +13988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13392,6 +14026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13428,6 +14064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13464,6 +14102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13500,6 +14140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13536,6 +14178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13572,6 +14216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13608,6 +14254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13644,6 +14292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13680,6 +14330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13716,6 +14368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13752,6 +14406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13788,6 +14444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13824,6 +14482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13860,6 +14520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13896,6 +14558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13932,6 +14596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13968,6 +14634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14004,6 +14672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14040,6 +14710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14076,6 +14748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14112,6 +14786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14148,6 +14824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14184,6 +14862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14220,6 +14900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14256,6 +14938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14292,6 +14976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14328,6 +15014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14364,6 +15052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14400,6 +15090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14436,6 +15128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14472,6 +15166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14508,6 +15204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14544,6 +15242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14580,6 +15280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14616,6 +15318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14652,6 +15356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14688,6 +15394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14724,6 +15432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14760,6 +15470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14796,6 +15508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14832,6 +15546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14868,6 +15584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14904,6 +15622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14940,6 +15660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14976,6 +15698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15012,6 +15736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15048,6 +15774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15084,6 +15812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15120,6 +15850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15156,6 +15888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15192,6 +15926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15228,6 +15964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15264,6 +16002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15300,6 +16040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15336,6 +16078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15372,6 +16116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15408,6 +16154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15444,6 +16192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15480,6 +16230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15516,6 +16268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15552,6 +16306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15588,6 +16344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15624,6 +16382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15660,6 +16420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15696,6 +16458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15732,6 +16496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15768,6 +16534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15804,6 +16572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15840,6 +16610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15876,6 +16648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15912,6 +16686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15948,6 +16724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15984,6 +16762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16020,6 +16800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16056,6 +16838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16092,6 +16876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16128,6 +16914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16164,6 +16952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16200,6 +16990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16236,6 +17028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16272,6 +17066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16308,6 +17104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16344,6 +17142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16380,6 +17180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16416,6 +17218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16452,6 +17256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16488,6 +17294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16524,6 +17332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16560,6 +17370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16596,6 +17408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16632,6 +17446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16668,6 +17484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16704,6 +17522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16740,6 +17560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16776,6 +17598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16812,6 +17636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16848,6 +17674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16884,6 +17712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16920,6 +17750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16956,6 +17788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16992,6 +17826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17028,6 +17864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17064,6 +17902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17100,6 +17940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17136,6 +17978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17172,6 +18016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17208,6 +18054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17244,6 +18092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17280,6 +18130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17316,6 +18168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17352,6 +18206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17388,6 +18244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17424,6 +18282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17460,6 +18320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17496,6 +18358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17532,6 +18396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17568,6 +18434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17604,6 +18472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17640,6 +18510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17676,6 +18548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17712,6 +18586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17748,6 +18624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17784,6 +18662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17820,6 +18700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17856,6 +18738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17892,6 +18776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17928,6 +18814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17964,6 +18852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18000,6 +18890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18036,6 +18928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18072,6 +18966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18108,6 +19004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18144,6 +19042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18180,6 +19080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18216,6 +19118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18252,6 +19156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18288,6 +19194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18324,6 +19232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18360,6 +19270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18396,6 +19308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18432,6 +19346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18468,6 +19384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18504,6 +19422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18540,6 +19460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18576,6 +19498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18612,6 +19536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18648,6 +19574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18684,6 +19612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18720,6 +19650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18756,6 +19688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18792,6 +19726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18828,6 +19764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18864,6 +19802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18900,6 +19840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18936,6 +19878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18972,6 +19916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19008,6 +19954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19044,6 +19992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19080,6 +20030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19116,6 +20068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19152,6 +20106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19188,6 +20144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19224,6 +20182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19260,6 +20220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19296,6 +20258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19332,6 +20296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19368,6 +20334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19404,6 +20372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19440,6 +20410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19476,6 +20448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19512,6 +20486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19548,6 +20524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19584,6 +20562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19620,6 +20600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19656,6 +20638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19692,6 +20676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19728,6 +20714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19764,6 +20752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19800,6 +20790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19836,6 +20828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19872,6 +20866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19908,6 +20904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19944,6 +20942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19980,6 +20980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20016,6 +21018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20052,6 +21056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20088,6 +21094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20124,6 +21132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20160,6 +21170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20196,6 +21208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20232,6 +21246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20268,6 +21284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20304,6 +21322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20340,6 +21360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20376,6 +21398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20412,6 +21436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20448,6 +21474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20484,6 +21512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20520,6 +21550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20556,6 +21588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20592,6 +21626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20628,6 +21664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20664,6 +21702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20700,6 +21740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20736,6 +21778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20772,6 +21816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20808,6 +21854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20844,6 +21892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20880,6 +21930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20916,6 +21968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20952,6 +22006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20988,6 +22044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21024,6 +22082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21060,6 +22120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21096,6 +22158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21132,6 +22196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21168,6 +22234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21204,6 +22272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21240,6 +22310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21276,6 +22348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21312,6 +22386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21348,6 +22424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21384,6 +22462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21420,6 +22500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21456,6 +22538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21492,6 +22576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21528,6 +22614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21564,6 +22652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21600,6 +22690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21636,6 +22728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21672,6 +22766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21708,6 +22804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21744,6 +22842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21780,6 +22880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21816,6 +22918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21852,6 +22956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21888,6 +22994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21924,6 +23032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21960,6 +23070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21996,6 +23108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22032,6 +23146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22068,6 +23184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22104,6 +23222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22140,6 +23260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22176,6 +23298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22212,6 +23336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22248,6 +23374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22284,6 +23412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22320,6 +23450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22356,6 +23488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22392,6 +23526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22428,6 +23564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22464,6 +23602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22500,6 +23640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22536,6 +23678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22572,6 +23716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22608,6 +23754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22644,6 +23792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22680,6 +23830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22716,6 +23868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22752,6 +23906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22788,6 +23944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22824,6 +23982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22860,6 +24020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22896,6 +24058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22932,6 +24096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22968,6 +24134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23004,6 +24172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23040,6 +24210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23076,6 +24248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23112,6 +24286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23148,6 +24324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23184,6 +24362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23220,6 +24400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23256,6 +24438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23292,6 +24476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23328,6 +24514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23364,6 +24552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23400,6 +24590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23436,6 +24628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23472,6 +24666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23508,6 +24704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23544,6 +24742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23580,6 +24780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23616,6 +24818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23652,6 +24856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23688,6 +24894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23724,6 +24932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23760,6 +24970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23796,6 +25008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23832,6 +25046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23868,6 +25084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23904,6 +25122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23940,6 +25160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23976,6 +25198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24012,6 +25236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24048,6 +25274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24084,6 +25312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24120,6 +25350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24156,6 +25388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24192,6 +25426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24228,6 +25464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24264,6 +25502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24300,6 +25540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24336,6 +25578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24372,6 +25616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24408,6 +25654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24444,6 +25692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24480,6 +25730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24516,6 +25768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24552,6 +25806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24588,6 +25844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24624,6 +25882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24660,6 +25920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24696,6 +25958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24732,6 +25996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24768,6 +26034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24804,6 +26072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24840,6 +26110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24876,6 +26148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24912,6 +26186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24948,6 +26224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24984,6 +26262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.0.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.1.sarif
@@ -1980,8 +1980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2018,8 +2016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2056,8 +2052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2094,8 +2088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2132,8 +2124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2170,8 +2160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2208,8 +2196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2246,8 +2232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2284,8 +2268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2322,8 +2304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2360,8 +2340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2398,8 +2376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2436,8 +2412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2474,8 +2448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2512,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2550,8 +2520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2588,8 +2556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2626,8 +2592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2664,8 +2628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2702,8 +2664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2740,8 +2700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2778,8 +2736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2816,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2854,8 +2808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2892,8 +2844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2930,8 +2880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2968,8 +2916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3006,8 +2952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3044,8 +2988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3082,8 +3024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3120,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3158,8 +3096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3196,8 +3132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3234,8 +3168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3272,8 +3204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3310,8 +3240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3348,8 +3276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3386,8 +3312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3424,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3462,8 +3384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3500,8 +3420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3538,8 +3456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3576,8 +3492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3614,8 +3528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3652,8 +3564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3690,8 +3600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3728,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3766,8 +3672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3804,8 +3708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3842,8 +3744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3880,8 +3780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3918,8 +3816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3956,8 +3852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3994,8 +3888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4032,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4070,8 +3960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4108,8 +3996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4146,8 +4032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4184,8 +4068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4222,8 +4104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4260,8 +4140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4298,8 +4176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4336,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4374,8 +4248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4412,8 +4284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4450,8 +4320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4488,8 +4356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4526,8 +4392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4564,8 +4428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4602,8 +4464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4640,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4678,8 +4536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4716,8 +4572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4754,8 +4608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4792,8 +4644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4830,8 +4680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4868,8 +4716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4906,8 +4752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4944,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4982,8 +4824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5020,8 +4860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5058,8 +4896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5096,8 +4932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5134,8 +4968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5172,8 +5004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5210,8 +5040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5248,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5286,8 +5112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5324,8 +5148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5362,8 +5184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5400,8 +5220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5438,8 +5256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5476,8 +5292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5514,8 +5328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5552,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5590,8 +5400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5628,8 +5436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5666,8 +5472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5704,8 +5508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5742,8 +5544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5780,8 +5580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5818,8 +5616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5856,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5894,8 +5688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5932,8 +5724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5970,8 +5760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,8 +5796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6046,8 +5832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6084,8 +5868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6122,8 +5904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6160,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6198,8 +5976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6236,8 +6012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6274,8 +6048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6312,8 +6084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6350,8 +6120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6388,8 +6156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6426,8 +6192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6464,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6502,8 +6264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6540,8 +6300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6578,8 +6336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6616,8 +6372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6654,8 +6408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6692,8 +6444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6730,8 +6480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6768,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6806,8 +6552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6844,8 +6588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6882,8 +6624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6920,8 +6660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6958,8 +6696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6996,8 +6732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7034,8 +6768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7072,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7110,8 +6840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7148,8 +6876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7186,8 +6912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7224,8 +6948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7262,8 +6984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7300,8 +7020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7338,8 +7056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7376,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7414,8 +7128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7452,8 +7164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7490,8 +7200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7528,8 +7236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7566,8 +7272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7604,8 +7308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7642,8 +7344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7680,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,8 +7416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7756,8 +7452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7794,8 +7488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7832,8 +7524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7870,8 +7560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7908,8 +7596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7946,8 +7632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7984,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8022,8 +7704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8060,8 +7740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8098,8 +7776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8136,8 +7812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8174,8 +7848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8212,8 +7884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8250,8 +7920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8288,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8326,8 +7992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8364,8 +8028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8402,8 +8064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8440,8 +8100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8478,8 +8136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8516,8 +8172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8554,8 +8208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8592,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8630,8 +8280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8668,8 +8316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8706,8 +8352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8744,8 +8388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8782,8 +8424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8820,8 +8460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8858,8 +8496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8896,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8934,8 +8568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8972,8 +8604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9010,8 +8640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9048,8 +8676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9086,8 +8712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9124,8 +8748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9162,8 +8784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9200,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9238,8 +8856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9276,8 +8892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9314,8 +8928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9352,8 +8964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9390,8 +9000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9428,8 +9036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9466,8 +9072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9504,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9542,8 +9144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9580,8 +9180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9618,8 +9216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9656,8 +9252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9694,8 +9288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9732,8 +9324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9770,8 +9360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9808,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9846,8 +9432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9884,8 +9468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9922,8 +9504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9960,8 +9540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9998,8 +9576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10036,8 +9612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10074,8 +9648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10112,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10150,8 +9720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10188,8 +9756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10226,8 +9792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10264,8 +9828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10302,8 +9864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10340,8 +9900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10378,8 +9936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10416,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10454,8 +10008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10492,8 +10044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10530,8 +10080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10568,8 +10116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10606,8 +10152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10644,8 +10188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10682,8 +10224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10720,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10758,8 +10296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10796,8 +10332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10834,8 +10368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10872,8 +10404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10910,8 +10440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10948,8 +10476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10986,8 +10512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11024,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11062,8 +10584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11100,8 +10620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11138,8 +10656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11176,8 +10692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11214,8 +10728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11252,8 +10764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11290,8 +10800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11328,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11366,8 +10872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11404,8 +10908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11442,8 +10944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11480,8 +10980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11518,8 +11016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11556,8 +11052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11594,8 +11088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11632,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11670,8 +11160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11708,8 +11196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11746,8 +11232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11784,8 +11268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11822,8 +11304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11860,8 +11340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11898,8 +11376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11936,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11974,8 +11448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12012,8 +11484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12050,8 +11520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12088,8 +11556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12126,8 +11592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12164,8 +11628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12202,8 +11664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12240,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12278,8 +11736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12316,8 +11772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12354,8 +11808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12392,8 +11844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12430,8 +11880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12468,8 +11916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12506,8 +11952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12544,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12582,8 +12024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12620,8 +12060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12658,8 +12096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12696,8 +12132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12734,8 +12168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12772,8 +12204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12810,8 +12240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12848,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12886,8 +12312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12924,8 +12348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12962,8 +12384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13000,8 +12420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13038,8 +12456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13076,8 +12492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13114,8 +12528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13152,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13190,8 +12600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13228,8 +12636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13266,8 +12672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13304,8 +12708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13342,8 +12744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13380,8 +12780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13418,8 +12816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13456,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13494,8 +12888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13532,8 +12924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13570,8 +12960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13608,8 +12996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13646,8 +13032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13684,8 +13068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13722,8 +13104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13760,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13798,8 +13176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13836,8 +13212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13874,8 +13248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13912,8 +13284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13950,8 +13320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13988,8 +13356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14026,8 +13392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14064,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14102,8 +13464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14140,8 +13500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14178,8 +13536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14216,8 +13572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14254,8 +13608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14292,8 +13644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14330,8 +13680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14368,8 +13716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14406,8 +13752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14444,8 +13788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14482,8 +13824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14520,8 +13860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14558,8 +13896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14596,8 +13932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14634,8 +13968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14672,8 +14004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14710,8 +14040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14748,8 +14076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14786,8 +14112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14824,8 +14148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14862,8 +14184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14900,8 +14220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14938,8 +14256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14976,8 +14292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15014,8 +14328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15052,8 +14364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15090,8 +14400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15128,8 +14436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15166,8 +14472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15204,8 +14508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15242,8 +14544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15280,8 +14580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15318,8 +14616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15356,8 +14652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15394,8 +14688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15432,8 +14724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15470,8 +14760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15508,8 +14796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15546,8 +14832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15584,8 +14868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15622,8 +14904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15660,8 +14940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15698,8 +14976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15736,8 +15012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15774,8 +15048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15812,8 +15084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15850,8 +15120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15888,8 +15156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15926,8 +15192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15964,8 +15228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16002,8 +15264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16040,8 +15300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16078,8 +15336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16116,8 +15372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16154,8 +15408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16192,8 +15444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16230,8 +15480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16268,8 +15516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16306,8 +15552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16344,8 +15588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16382,8 +15624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16420,8 +15660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16458,8 +15696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16496,8 +15732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16534,8 +15768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16572,8 +15804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16610,8 +15840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16648,8 +15876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16686,8 +15912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16724,8 +15948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16762,8 +15984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16800,8 +16020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16838,8 +16056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16876,8 +16092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16914,8 +16128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16952,8 +16164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16990,8 +16200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17028,8 +16236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17066,8 +16272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17104,8 +16308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17142,8 +16344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17180,8 +16380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17218,8 +16416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17256,8 +16452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17294,8 +16488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17332,8 +16524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17370,8 +16560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17408,8 +16596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17446,8 +16632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17484,8 +16668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17522,8 +16704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17560,8 +16740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17598,8 +16776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17636,8 +16812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17674,8 +16848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17712,8 +16884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17750,8 +16920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17788,8 +16956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17826,8 +16992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17864,8 +17028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17902,8 +17064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17940,8 +17100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17978,8 +17136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18016,8 +17172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18054,8 +17208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18092,8 +17244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18130,8 +17280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18168,8 +17316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18206,8 +17352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18244,8 +17388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18282,8 +17424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18320,8 +17460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18358,8 +17496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18396,8 +17532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18434,8 +17568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18472,8 +17604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18510,8 +17640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18548,8 +17676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18586,8 +17712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18624,8 +17748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18662,8 +17784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18700,8 +17820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18738,8 +17856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18776,8 +17892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18814,8 +17928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18852,8 +17964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18890,8 +18000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18928,8 +18036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18966,8 +18072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19004,8 +18108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19042,8 +18144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19080,8 +18180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19118,8 +18216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19156,8 +18252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19194,8 +18288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19232,8 +18324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19270,8 +18360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19308,8 +18396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19346,8 +18432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19384,8 +18468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19422,8 +18504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19460,8 +18540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19498,8 +18576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19536,8 +18612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19574,8 +18648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19612,8 +18684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19650,8 +18720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19688,8 +18756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19726,8 +18792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19764,8 +18828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19802,8 +18864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19840,8 +18900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19878,8 +18936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19916,8 +18972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19954,8 +19008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19992,8 +19044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20030,8 +19080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20068,8 +19116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20106,8 +19152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20144,8 +19188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20182,8 +19224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20220,8 +19260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20258,8 +19296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20296,8 +19332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20334,8 +19368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20372,8 +19404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20410,8 +19440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20448,8 +19476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20486,8 +19512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20524,8 +19548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20562,8 +19584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20600,8 +19620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20638,8 +19656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20676,8 +19692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20714,8 +19728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20752,8 +19764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20790,8 +19800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20828,8 +19836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20866,8 +19872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20904,8 +19908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20942,8 +19944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20980,8 +19980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21018,8 +20016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21056,8 +20052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21094,8 +20088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21132,8 +20124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21170,8 +20160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21208,8 +20196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21246,8 +20232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21284,8 +20268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21322,8 +20304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21360,8 +20340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21398,8 +20376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21436,8 +20412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21474,8 +20448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21512,8 +20484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21550,8 +20520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21588,8 +20556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21626,8 +20592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21664,8 +20628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21702,8 +20664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21740,8 +20700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21778,8 +20736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21816,8 +20772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21854,8 +20808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21892,8 +20844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21930,8 +20880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21968,8 +20916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22006,8 +20952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22044,8 +20988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22082,8 +21024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22120,8 +21060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22158,8 +21096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22196,8 +21132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22234,8 +21168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22272,8 +21204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22310,8 +21240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22348,8 +21276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22386,8 +21312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22424,8 +21348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22462,8 +21384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22500,8 +21420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22538,8 +21456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22576,8 +21492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22614,8 +21528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22652,8 +21564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22690,8 +21600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22728,8 +21636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22766,8 +21672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22804,8 +21708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22842,8 +21744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22880,8 +21780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22918,8 +21816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22956,8 +21852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22994,8 +21888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23032,8 +21924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23070,8 +21960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23108,8 +21996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23146,8 +22032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23184,8 +22068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23222,8 +22104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23260,8 +22140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23298,8 +22176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23336,8 +22212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23374,8 +22248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23412,8 +22284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23450,8 +22320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23488,8 +22356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23526,8 +22392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23564,8 +22428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23602,8 +22464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23640,8 +22500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23678,8 +22536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23716,8 +22572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23754,8 +22608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23792,8 +22644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23830,8 +22680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23868,8 +22716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23906,8 +22752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23944,8 +22788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23982,8 +22824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24020,8 +22860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24058,8 +22896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24096,8 +22932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24134,8 +22968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24172,8 +23004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24210,8 +23040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24248,8 +23076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24286,8 +23112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24324,8 +23148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24362,8 +23184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24400,8 +23220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24438,8 +23256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24476,8 +23292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24514,8 +23328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24552,8 +23364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24590,8 +23400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24628,8 +23436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24666,8 +23472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24704,8 +23508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24742,8 +23544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24780,8 +23580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24818,8 +23616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24856,8 +23652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24894,8 +23688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24932,8 +23724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24970,8 +23760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25008,8 +23796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25046,8 +23832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25084,8 +23868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25122,8 +23904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25160,8 +23940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25198,8 +23976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25236,8 +24012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25274,8 +24048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25312,8 +24084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25350,8 +24120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25388,8 +24156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25426,8 +24192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25464,8 +24228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25502,8 +24264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25540,8 +24300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25578,8 +24336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25616,8 +24372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25654,8 +24408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25692,8 +24444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25730,8 +24480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25768,8 +24516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25806,8 +24552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25844,8 +24588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25882,8 +24624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25920,8 +24660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25958,8 +24696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25996,8 +24732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26034,8 +24768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26072,8 +24804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26110,8 +24840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26148,8 +24876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,8 +24912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26224,8 +24948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26262,8 +24984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.0.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.1.sarif
@@ -1979,6 +1979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2014,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2049,6 +2055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2084,6 +2093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2119,6 +2131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2154,6 +2169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2189,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2224,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2259,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2294,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2329,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2364,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2399,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2434,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2469,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2504,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2539,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2574,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2609,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2644,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2679,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2714,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2749,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2784,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2819,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2854,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2889,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2924,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2959,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2994,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3029,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3064,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3099,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3134,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3169,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3204,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3239,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3274,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3309,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3344,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3379,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3414,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3449,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3484,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3519,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3554,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3589,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3624,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3659,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3694,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3729,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3764,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3799,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3834,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3869,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3904,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3939,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3974,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4009,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4044,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4079,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4114,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4149,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4184,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4219,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4254,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4289,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4324,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4359,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4394,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4429,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4499,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4534,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4569,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4604,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4639,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4674,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4709,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4744,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4779,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4814,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4849,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4884,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4919,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4954,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4989,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5024,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5059,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5094,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5129,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5164,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5199,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5234,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5269,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5304,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5339,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5374,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5409,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5444,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5479,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5514,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5549,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5584,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5619,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5654,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5689,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5759,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5794,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5829,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5864,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5899,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5934,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5969,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6004,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6039,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6074,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6109,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6144,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6179,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6214,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6249,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6284,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6319,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6354,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6389,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6424,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6459,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6494,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6529,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6564,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6599,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6634,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6669,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6704,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6739,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6774,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6809,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6844,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6879,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6914,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6949,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6984,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7019,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7054,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7089,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7124,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7159,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7194,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7229,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7264,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7299,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7334,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7369,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7404,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7439,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7474,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7509,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7544,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7579,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7614,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7649,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7684,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7719,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7754,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7789,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7824,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7859,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7894,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -7929,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -7964,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -7999,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8034,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8069,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8104,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8139,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8174,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8209,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8244,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8279,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8314,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8349,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8384,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8419,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8454,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8489,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8524,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8559,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8594,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8629,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8664,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8699,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8734,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8769,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8804,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -8839,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -8874,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -8909,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -8944,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -8979,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9014,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9049,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9084,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9119,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9154,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9189,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9224,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9259,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9294,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9329,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9364,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9399,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9434,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9469,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9504,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9539,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9574,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9609,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9644,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9679,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9714,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9749,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9784,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9819,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9854,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9889,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9924,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9959,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9994,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10029,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10064,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10099,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10134,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10169,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10204,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10239,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10274,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10309,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10344,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10379,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10414,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10449,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10484,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10519,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10554,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10589,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10624,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10659,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10694,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10729,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10764,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10799,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10834,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10869,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10904,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10939,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10974,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11009,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11044,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11079,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11114,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11149,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11184,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11219,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11254,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11289,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11324,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11359,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11394,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11429,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11464,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11499,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11534,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11569,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11604,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11639,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11674,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11709,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11744,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11779,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11814,6 +12657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11849,6 +12695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11884,6 +12733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11919,6 +12771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11954,6 +12809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11989,6 +12847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12024,6 +12885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12059,6 +12923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12094,6 +12961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12129,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12164,6 +13037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12199,6 +13075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12234,6 +13113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12269,6 +13151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12304,6 +13189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12339,6 +13227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12374,6 +13265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12409,6 +13303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12444,6 +13341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12479,6 +13379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12514,6 +13417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12549,6 +13455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12584,6 +13493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12619,6 +13531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12654,6 +13569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12689,6 +13607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12724,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12759,6 +13683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12794,6 +13721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12829,6 +13759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12864,6 +13797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12899,6 +13835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12934,6 +13873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12969,6 +13911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13004,6 +13949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13039,6 +13987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13074,6 +14025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13109,6 +14063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13144,6 +14101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13179,6 +14139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13214,6 +14177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13249,6 +14215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13284,6 +14253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13319,6 +14291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13354,6 +14329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13389,6 +14367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13424,6 +14405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13459,6 +14443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13494,6 +14481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13529,6 +14519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13564,6 +14557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13599,6 +14595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13634,6 +14633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13669,6 +14671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13704,6 +14709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13739,6 +14747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13774,6 +14785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -13809,6 +14823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13844,6 +14861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -13879,6 +14899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -13914,6 +14937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -13949,6 +14975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13984,6 +15013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14019,6 +15051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14054,6 +15089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14089,6 +15127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14124,6 +15165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14159,6 +15203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14194,6 +15241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14229,6 +15279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14264,6 +15317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14299,6 +15355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14334,6 +15393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14369,6 +15431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14404,6 +15469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14439,6 +15507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14474,6 +15545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14509,6 +15583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14544,6 +15621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14579,6 +15659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14614,6 +15697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14649,6 +15735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14684,6 +15773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14719,6 +15811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14754,6 +15849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14789,6 +15887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14824,6 +15925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -14859,6 +15963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14894,6 +16001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14929,6 +16039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14964,6 +16077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -14999,6 +16115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15034,6 +16153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15069,6 +16191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15104,6 +16229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15139,6 +16267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15174,6 +16305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15209,6 +16343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15244,6 +16381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15279,6 +16419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15314,6 +16457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15349,6 +16495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15384,6 +16533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15419,6 +16571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15454,6 +16609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15489,6 +16647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15524,6 +16685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15559,6 +16723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15594,6 +16761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15629,6 +16799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15664,6 +16837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15699,6 +16875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15734,6 +16913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15769,6 +16951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15804,6 +16989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15839,6 +17027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15874,6 +17065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15909,6 +17103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15944,6 +17141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15979,6 +17179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16014,6 +17217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16049,6 +17255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16084,6 +17293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16119,6 +17331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16154,6 +17369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16189,6 +17407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16224,6 +17445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16259,6 +17483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16294,6 +17521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16329,6 +17559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16364,6 +17597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16399,6 +17635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16434,6 +17673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16469,6 +17711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16504,6 +17749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16539,6 +17787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16574,6 +17825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16609,6 +17863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16644,6 +17901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16679,6 +17939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16714,6 +17977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16749,6 +18015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16784,6 +18053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16819,6 +18091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16854,6 +18129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -16889,6 +18167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16924,6 +18205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16959,6 +18243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -16994,6 +18281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17029,6 +18319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17064,6 +18357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17099,6 +18395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17134,6 +18433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17169,6 +18471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17204,6 +18509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17239,6 +18547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17274,6 +18585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17309,6 +18623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17344,6 +18661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17379,6 +18699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17414,6 +18737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17449,6 +18775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17484,6 +18813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17519,6 +18851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17554,6 +18889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17589,6 +18927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17624,6 +18965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17659,6 +19003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17694,6 +19041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17729,6 +19079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17764,6 +19117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17799,6 +19155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17834,6 +19193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17869,6 +19231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17904,6 +19269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -17939,6 +19307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -17974,6 +19345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18009,6 +19383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18044,6 +19421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18079,6 +19459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18114,6 +19497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18149,6 +19535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18184,6 +19573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18219,6 +19611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18254,6 +19649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18289,6 +19687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18324,6 +19725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18359,6 +19763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18394,6 +19801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18429,6 +19839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18464,6 +19877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18499,6 +19915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18534,6 +19953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18569,6 +19991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18604,6 +20029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18639,6 +20067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18674,6 +20105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18709,6 +20143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18744,6 +20181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18779,6 +20219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18814,6 +20257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18849,6 +20295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18884,6 +20333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18919,6 +20371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18954,6 +20409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18989,6 +20447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19024,6 +20485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19059,6 +20523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19094,6 +20561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19129,6 +20599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19164,6 +20637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19199,6 +20675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19234,6 +20713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19269,6 +20751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19304,6 +20789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19339,6 +20827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19374,6 +20865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19409,6 +20903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19444,6 +20941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19479,6 +20979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19514,6 +21017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19549,6 +21055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19584,6 +21093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19619,6 +21131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19654,6 +21169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19689,6 +21207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19724,6 +21245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19759,6 +21283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -19794,6 +21321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19829,6 +21359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19864,6 +21397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19899,6 +21435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19934,6 +21473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19969,6 +21511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20004,6 +21549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20039,6 +21587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20074,6 +21625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20109,6 +21663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20144,6 +21701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20179,6 +21739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20214,6 +21777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20249,6 +21815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20284,6 +21853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20319,6 +21891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20354,6 +21929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20389,6 +21967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20424,6 +22005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20459,6 +22043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20494,6 +22081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20529,6 +22119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20564,6 +22157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20599,6 +22195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20634,6 +22233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20669,6 +22271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20704,6 +22309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20739,6 +22347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20774,6 +22385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20809,6 +22423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20844,6 +22461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20879,6 +22499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -20914,6 +22537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -20949,6 +22575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -20984,6 +22613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21019,6 +22651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21054,6 +22689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21089,6 +22727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21124,6 +22765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21159,6 +22803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21194,6 +22841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21229,6 +22879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21264,6 +22917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21299,6 +22955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21334,6 +22993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21369,6 +23031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21404,6 +23069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21439,6 +23107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21474,6 +23145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21509,6 +23183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21544,6 +23221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21579,6 +23259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21614,6 +23297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21649,6 +23335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21684,6 +23373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21719,6 +23411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21754,6 +23449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21789,6 +23487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -21824,6 +23525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -21859,6 +23563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -21894,6 +23601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -21929,6 +23639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -21964,6 +23677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -21999,6 +23715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22034,6 +23753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22069,6 +23791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22104,6 +23829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22139,6 +23867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22174,6 +23905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22209,6 +23943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22244,6 +23981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22279,6 +24019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22314,6 +24057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22349,6 +24095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22384,6 +24133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22419,6 +24171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22454,6 +24209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22489,6 +24247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22524,6 +24285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22559,6 +24323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22594,6 +24361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22629,6 +24399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22664,6 +24437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22699,6 +24475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22734,6 +24513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22769,6 +24551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22804,6 +24589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -22839,6 +24627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -22874,6 +24665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -22909,6 +24703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -22944,6 +24741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22979,6 +24779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23014,6 +24817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23049,6 +24855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23084,6 +24893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23119,6 +24931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23154,6 +24969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23189,6 +25007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23224,6 +25045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23259,6 +25083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23294,6 +25121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23329,6 +25159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23364,6 +25197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23399,6 +25235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23434,6 +25273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23469,6 +25311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23504,6 +25349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23539,6 +25387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23574,6 +25425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23609,6 +25463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23644,6 +25501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23679,6 +25539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23714,6 +25577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23749,6 +25615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23784,6 +25653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23819,6 +25691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23854,6 +25729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23889,6 +25767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -23924,6 +25805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23959,6 +25843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23994,6 +25881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24029,6 +25919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24064,6 +25957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24099,6 +25995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24134,6 +26033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24169,6 +26071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24204,6 +26109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24239,6 +26147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24274,6 +26185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24309,6 +26223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24344,6 +26261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.0.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.1.sarif
@@ -1980,6 +1980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2016,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2052,6 +2056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2088,6 +2094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2124,6 +2132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2160,6 +2170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2196,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2232,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2268,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2304,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2340,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2376,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2412,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2448,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2484,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2520,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2556,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2592,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2628,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2664,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2700,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2736,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2772,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2808,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2844,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2880,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2916,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2952,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2988,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3024,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3060,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3096,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3132,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3168,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3204,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3240,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3276,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3312,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3348,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3384,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3420,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3456,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3492,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3528,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3564,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3600,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3636,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3672,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3708,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3744,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3780,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3816,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3852,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3888,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3924,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3960,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3996,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4032,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4068,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4104,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4140,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4176,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4212,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4248,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4284,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4320,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4356,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4392,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4428,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4500,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4536,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4572,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4608,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4644,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4680,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4716,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4752,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4788,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4824,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4860,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4896,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4932,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4968,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5004,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5040,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5076,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5112,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5148,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5184,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5220,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5256,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5292,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5328,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5364,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5400,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5436,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5472,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5508,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5544,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5580,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5616,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5652,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5688,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5760,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5796,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5832,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5868,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5904,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5940,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5976,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6012,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6048,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6084,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6120,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6156,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6192,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6228,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6264,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6300,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6336,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6372,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6408,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6444,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6480,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6516,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6552,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6588,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6624,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6660,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6696,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6732,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6768,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6804,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6840,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6876,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6912,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6948,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6984,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7020,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7056,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7092,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7128,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7164,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7200,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7236,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7272,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7308,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7344,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7380,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7416,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7452,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7488,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7524,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7560,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7596,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7632,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7668,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7704,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7740,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7776,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7812,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7848,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7884,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7920,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7956,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7992,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8028,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8064,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8100,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8136,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8172,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8208,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8244,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8280,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8316,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8352,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8388,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8424,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8460,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8496,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8532,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8568,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8604,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8640,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8676,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8712,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8748,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8784,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8820,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8856,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8892,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8928,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8964,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9000,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9036,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9072,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9108,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9144,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9180,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9216,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9252,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9288,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9324,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9360,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9396,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9432,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9468,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9504,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9540,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9576,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9612,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9648,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9684,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9720,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9756,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9792,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9828,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9864,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9900,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9936,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9972,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10008,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10044,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10080,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10116,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10152,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10188,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10224,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10260,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10296,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10332,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10368,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10404,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10440,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10476,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10512,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10548,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10584,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10620,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10656,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10692,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10728,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10764,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10800,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10836,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10872,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10908,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10944,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10980,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11016,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11052,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11088,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11124,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11160,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11196,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11232,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11268,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11304,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11340,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11376,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11412,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11448,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11484,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11520,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11556,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11592,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11628,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11664,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11700,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11736,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11772,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11808,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11844,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11880,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11916,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11952,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11988,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12024,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12060,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12096,6 +12658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12132,6 +12696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12168,6 +12734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12204,6 +12772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12240,6 +12810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12276,6 +12848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12312,6 +12886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12348,6 +12924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12384,6 +12962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12420,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12456,6 +13038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12492,6 +13076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12528,6 +13114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12564,6 +13152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12600,6 +13190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12636,6 +13228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12672,6 +13266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12708,6 +13304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12744,6 +13342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12780,6 +13380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12852,6 +13456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12888,6 +13494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12924,6 +13532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12960,6 +13570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12996,6 +13608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13032,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13068,6 +13684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13104,6 +13722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13140,6 +13760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13176,6 +13798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13212,6 +13836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13248,6 +13874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13284,6 +13912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13320,6 +13950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13356,6 +13988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13392,6 +14026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13428,6 +14064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13464,6 +14102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13500,6 +14140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13536,6 +14178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13572,6 +14216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13608,6 +14254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13644,6 +14292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13680,6 +14330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13716,6 +14368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13752,6 +14406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13788,6 +14444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13824,6 +14482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13860,6 +14520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13896,6 +14558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13932,6 +14596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13968,6 +14634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14004,6 +14672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14040,6 +14710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14076,6 +14748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14112,6 +14786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14148,6 +14824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14184,6 +14862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14220,6 +14900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14256,6 +14938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14292,6 +14976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14328,6 +15014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14364,6 +15052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14400,6 +15090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14436,6 +15128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14472,6 +15166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14508,6 +15204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14544,6 +15242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14580,6 +15280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14616,6 +15318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14652,6 +15356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14688,6 +15394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14724,6 +15432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14760,6 +15470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14796,6 +15508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14832,6 +15546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14868,6 +15584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14904,6 +15622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14940,6 +15660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14976,6 +15698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15012,6 +15736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15048,6 +15774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15084,6 +15812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15120,6 +15850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15156,6 +15888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15192,6 +15926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15228,6 +15964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15264,6 +16002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15300,6 +16040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15336,6 +16078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15372,6 +16116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15408,6 +16154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15444,6 +16192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15480,6 +16230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15516,6 +16268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15552,6 +16306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15588,6 +16344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15624,6 +16382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15660,6 +16420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15696,6 +16458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15732,6 +16496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15768,6 +16534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15804,6 +16572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15840,6 +16610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15876,6 +16648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15912,6 +16686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15948,6 +16724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15984,6 +16762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16020,6 +16800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16056,6 +16838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16092,6 +16876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16128,6 +16914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16164,6 +16952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16200,6 +16990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16236,6 +17028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16272,6 +17066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16308,6 +17104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16344,6 +17142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16380,6 +17180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16416,6 +17218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16452,6 +17256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16488,6 +17294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16524,6 +17332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16560,6 +17370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16596,6 +17408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16632,6 +17446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16668,6 +17484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16704,6 +17522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16740,6 +17560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16776,6 +17598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16812,6 +17636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16848,6 +17674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16884,6 +17712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16920,6 +17750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16956,6 +17788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16992,6 +17826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17028,6 +17864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17064,6 +17902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17100,6 +17940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17136,6 +17978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17172,6 +18016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17208,6 +18054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17244,6 +18092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17280,6 +18130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17316,6 +18168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17352,6 +18206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17388,6 +18244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17424,6 +18282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17460,6 +18320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17496,6 +18358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17532,6 +18396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17568,6 +18434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17604,6 +18472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17640,6 +18510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17676,6 +18548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17712,6 +18586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17748,6 +18624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17784,6 +18662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17820,6 +18700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17856,6 +18738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17892,6 +18776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17928,6 +18814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17964,6 +18852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18000,6 +18890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18036,6 +18928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18072,6 +18966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18108,6 +19004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18144,6 +19042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18180,6 +19080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18216,6 +19118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18252,6 +19156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18288,6 +19194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18324,6 +19232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18360,6 +19270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18396,6 +19308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18432,6 +19346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18468,6 +19384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18504,6 +19422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18540,6 +19460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18576,6 +19498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18612,6 +19536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18648,6 +19574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18684,6 +19612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18720,6 +19650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18756,6 +19688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18792,6 +19726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18828,6 +19764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18864,6 +19802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18900,6 +19840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18936,6 +19878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18972,6 +19916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19008,6 +19954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19044,6 +19992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19080,6 +20030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19116,6 +20068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19152,6 +20106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19188,6 +20144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19224,6 +20182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19260,6 +20220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19296,6 +20258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19332,6 +20296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19368,6 +20334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19404,6 +20372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19440,6 +20410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19476,6 +20448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19512,6 +20486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19548,6 +20524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19584,6 +20562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19620,6 +20600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19656,6 +20638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19692,6 +20676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19728,6 +20714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19764,6 +20752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19800,6 +20790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19836,6 +20828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19872,6 +20866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19908,6 +20904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19944,6 +20942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19980,6 +20980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20016,6 +21018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20052,6 +21056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20088,6 +21094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20124,6 +21132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20160,6 +21170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20196,6 +21208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20232,6 +21246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20268,6 +21284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20304,6 +21322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20340,6 +21360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20376,6 +21398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20412,6 +21436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20448,6 +21474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20484,6 +21512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20520,6 +21550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20556,6 +21588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20592,6 +21626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20628,6 +21664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20664,6 +21702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20700,6 +21740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20736,6 +21778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20772,6 +21816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20808,6 +21854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20844,6 +21892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20880,6 +21930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20916,6 +21968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20952,6 +22006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20988,6 +22044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21024,6 +22082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21060,6 +22120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21096,6 +22158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21132,6 +22196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21168,6 +22234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21204,6 +22272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21240,6 +22310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21276,6 +22348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21312,6 +22386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21348,6 +22424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21384,6 +22462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21420,6 +22500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21456,6 +22538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21492,6 +22576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21528,6 +22614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21564,6 +22652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21600,6 +22690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21636,6 +22728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21672,6 +22766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21708,6 +22804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21744,6 +22842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21780,6 +22880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21816,6 +22918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21852,6 +22956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21888,6 +22994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21924,6 +23032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21960,6 +23070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21996,6 +23108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22032,6 +23146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22068,6 +23184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22104,6 +23222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22140,6 +23260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22176,6 +23298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22212,6 +23336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22248,6 +23374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22284,6 +23412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22320,6 +23450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22356,6 +23488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22392,6 +23526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22428,6 +23564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22464,6 +23602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22500,6 +23640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22536,6 +23678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22572,6 +23716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22608,6 +23754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22644,6 +23792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22680,6 +23830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22716,6 +23868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22752,6 +23906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22788,6 +23944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22824,6 +23982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22860,6 +24020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22896,6 +24058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22932,6 +24096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22968,6 +24134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23004,6 +24172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23040,6 +24210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23076,6 +24248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23112,6 +24286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23148,6 +24324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23184,6 +24362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23220,6 +24400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23256,6 +24438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23292,6 +24476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23328,6 +24514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23364,6 +24552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23400,6 +24590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23436,6 +24628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23472,6 +24666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23508,6 +24704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23544,6 +24742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23580,6 +24780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23616,6 +24818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23652,6 +24856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23688,6 +24894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23724,6 +24932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23760,6 +24970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23796,6 +25008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23832,6 +25046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23868,6 +25084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23904,6 +25122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23940,6 +25160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23976,6 +25198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24012,6 +25236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24048,6 +25274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24084,6 +25312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24120,6 +25350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24156,6 +25388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24192,6 +25426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24228,6 +25464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24264,6 +25502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24300,6 +25540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24336,6 +25578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24372,6 +25616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24408,6 +25654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24444,6 +25692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24480,6 +25730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24516,6 +25768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24552,6 +25806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24588,6 +25844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24624,6 +25882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24660,6 +25920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24696,6 +25958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24732,6 +25996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24768,6 +26034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24804,6 +26072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24840,6 +26110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24876,6 +26148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24912,6 +26186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24948,6 +26224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24984,6 +26262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.0.2.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.2.sarif
@@ -1980,8 +1980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2018,8 +2016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2056,8 +2052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2094,8 +2088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2132,8 +2124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2170,8 +2160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2208,8 +2196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2246,8 +2232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2284,8 +2268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2322,8 +2304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2360,8 +2340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2398,8 +2376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2436,8 +2412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2474,8 +2448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2512,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2550,8 +2520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2588,8 +2556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2626,8 +2592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2664,8 +2628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2702,8 +2664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2740,8 +2700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2778,8 +2736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2816,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2854,8 +2808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2892,8 +2844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2930,8 +2880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2968,8 +2916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3006,8 +2952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3044,8 +2988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3082,8 +3024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3120,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3158,8 +3096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3196,8 +3132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3234,8 +3168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3272,8 +3204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3310,8 +3240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3348,8 +3276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3386,8 +3312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3424,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3462,8 +3384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3500,8 +3420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3538,8 +3456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3576,8 +3492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3614,8 +3528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3652,8 +3564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3690,8 +3600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3728,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3766,8 +3672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3804,8 +3708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3842,8 +3744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3880,8 +3780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3918,8 +3816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3956,8 +3852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3994,8 +3888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4032,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4070,8 +3960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4108,8 +3996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4146,8 +4032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4184,8 +4068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4222,8 +4104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4260,8 +4140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4298,8 +4176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4336,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4374,8 +4248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4412,8 +4284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4450,8 +4320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4488,8 +4356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4526,8 +4392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4564,8 +4428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4602,8 +4464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4640,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4678,8 +4536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4716,8 +4572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4754,8 +4608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4792,8 +4644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4830,8 +4680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4868,8 +4716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4906,8 +4752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4944,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4982,8 +4824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5020,8 +4860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5058,8 +4896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5096,8 +4932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5134,8 +4968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5172,8 +5004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5210,8 +5040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5248,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5286,8 +5112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5324,8 +5148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5362,8 +5184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5400,8 +5220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5438,8 +5256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5476,8 +5292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5514,8 +5328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5552,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5590,8 +5400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5628,8 +5436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5666,8 +5472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5704,8 +5508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5742,8 +5544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5780,8 +5580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5818,8 +5616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5856,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5894,8 +5688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5932,8 +5724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5970,8 +5760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6008,8 +5796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6046,8 +5832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6084,8 +5868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6122,8 +5904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6160,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6198,8 +5976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6236,8 +6012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6274,8 +6048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6312,8 +6084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6350,8 +6120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6388,8 +6156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6426,8 +6192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6464,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6502,8 +6264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6540,8 +6300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6578,8 +6336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6616,8 +6372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6654,8 +6408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6692,8 +6444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6730,8 +6480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6768,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6806,8 +6552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6844,8 +6588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6882,8 +6624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6920,8 +6660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6958,8 +6696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6996,8 +6732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7034,8 +6768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7072,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7110,8 +6840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7148,8 +6876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7186,8 +6912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7224,8 +6948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7262,8 +6984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7300,8 +7020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7338,8 +7056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7376,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7414,8 +7128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7452,8 +7164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7490,8 +7200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7528,8 +7236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7566,8 +7272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7604,8 +7308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7642,8 +7344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7680,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,8 +7416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7756,8 +7452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7794,8 +7488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7832,8 +7524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7870,8 +7560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7908,8 +7596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7946,8 +7632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7984,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8022,8 +7704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8060,8 +7740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8098,8 +7776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8136,8 +7812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8174,8 +7848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8212,8 +7884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8250,8 +7920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8288,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8326,8 +7992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8364,8 +8028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8402,8 +8064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8440,8 +8100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8478,8 +8136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8516,8 +8172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8554,8 +8208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8592,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8630,8 +8280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8668,8 +8316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8706,8 +8352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8744,8 +8388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8782,8 +8424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8820,8 +8460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8858,8 +8496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8896,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8934,8 +8568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8972,8 +8604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9010,8 +8640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9048,8 +8676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9086,8 +8712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9124,8 +8748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9162,8 +8784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9200,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9238,8 +8856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9276,8 +8892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9314,8 +8928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9352,8 +8964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9390,8 +9000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9428,8 +9036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9466,8 +9072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9504,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9542,8 +9144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9580,8 +9180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9618,8 +9216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9656,8 +9252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9694,8 +9288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9732,8 +9324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9770,8 +9360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9808,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9846,8 +9432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9884,8 +9468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9922,8 +9504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9960,8 +9540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9998,8 +9576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10036,8 +9612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10074,8 +9648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10112,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10150,8 +9720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10188,8 +9756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10226,8 +9792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10264,8 +9828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10302,8 +9864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10340,8 +9900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10378,8 +9936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10416,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10454,8 +10008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10492,8 +10044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10530,8 +10080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10568,8 +10116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10606,8 +10152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10644,8 +10188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10682,8 +10224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10720,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10758,8 +10296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10796,8 +10332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10834,8 +10368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10872,8 +10404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10910,8 +10440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10948,8 +10476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10986,8 +10512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11024,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11062,8 +10584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11100,8 +10620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11138,8 +10656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11176,8 +10692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11214,8 +10728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11252,8 +10764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11290,8 +10800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11328,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11366,8 +10872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11404,8 +10908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11442,8 +10944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11480,8 +10980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11518,8 +11016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11556,8 +11052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11594,8 +11088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11632,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11670,8 +11160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11708,8 +11196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11746,8 +11232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11784,8 +11268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11822,8 +11304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11860,8 +11340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11898,8 +11376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11936,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11974,8 +11448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12012,8 +11484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12050,8 +11520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12088,8 +11556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12126,8 +11592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12164,8 +11628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12202,8 +11664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12240,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12278,8 +11736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12316,8 +11772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12354,8 +11808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12392,8 +11844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12430,8 +11880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12468,8 +11916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12506,8 +11952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12544,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12582,8 +12024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12620,8 +12060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12658,8 +12096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12696,8 +12132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12734,8 +12168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12772,8 +12204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12810,8 +12240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12848,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12886,8 +12312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12924,8 +12348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12962,8 +12384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13000,8 +12420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13038,8 +12456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13076,8 +12492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13114,8 +12528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13152,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13190,8 +12600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13228,8 +12636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13266,8 +12672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13304,8 +12708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13342,8 +12744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13380,8 +12780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13418,8 +12816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13456,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13494,8 +12888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13532,8 +12924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13570,8 +12960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13608,8 +12996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13646,8 +13032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13684,8 +13068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13722,8 +13104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13760,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13798,8 +13176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13836,8 +13212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13874,8 +13248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13912,8 +13284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13950,8 +13320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13988,8 +13356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14026,8 +13392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14064,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14102,8 +13464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14140,8 +13500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14178,8 +13536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14216,8 +13572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14254,8 +13608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14292,8 +13644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14330,8 +13680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14368,8 +13716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14406,8 +13752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14444,8 +13788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14482,8 +13824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14520,8 +13860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14558,8 +13896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14596,8 +13932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14634,8 +13968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14672,8 +14004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14710,8 +14040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14748,8 +14076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14786,8 +14112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14824,8 +14148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14862,8 +14184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14900,8 +14220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14938,8 +14256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14976,8 +14292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15014,8 +14328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15052,8 +14364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15090,8 +14400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15128,8 +14436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15166,8 +14472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15204,8 +14508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15242,8 +14544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15280,8 +14580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15318,8 +14616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15356,8 +14652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15394,8 +14688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15432,8 +14724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15470,8 +14760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15508,8 +14796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15546,8 +14832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15584,8 +14868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15622,8 +14904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15660,8 +14940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15698,8 +14976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15736,8 +15012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15774,8 +15048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15812,8 +15084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15850,8 +15120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15888,8 +15156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15926,8 +15192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15964,8 +15228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16002,8 +15264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16040,8 +15300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16078,8 +15336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16116,8 +15372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16154,8 +15408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16192,8 +15444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16230,8 +15480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16268,8 +15516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16306,8 +15552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16344,8 +15588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16382,8 +15624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16420,8 +15660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16458,8 +15696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16496,8 +15732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16534,8 +15768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16572,8 +15804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16610,8 +15840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16648,8 +15876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16686,8 +15912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16724,8 +15948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16762,8 +15984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16800,8 +16020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16838,8 +16056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16876,8 +16092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16914,8 +16128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16952,8 +16164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16990,8 +16200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17028,8 +16236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17066,8 +16272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17104,8 +16308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17142,8 +16344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17180,8 +16380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17218,8 +16416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17256,8 +16452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17294,8 +16488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17332,8 +16524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17370,8 +16560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17408,8 +16596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17446,8 +16632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17484,8 +16668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17522,8 +16704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17560,8 +16740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17598,8 +16776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17636,8 +16812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17674,8 +16848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17712,8 +16884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17750,8 +16920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17788,8 +16956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17826,8 +16992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17864,8 +17028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17902,8 +17064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17940,8 +17100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17978,8 +17136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18016,8 +17172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18054,8 +17208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18092,8 +17244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18130,8 +17280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18168,8 +17316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18206,8 +17352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18244,8 +17388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18282,8 +17424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18320,8 +17460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18358,8 +17496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18396,8 +17532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18434,8 +17568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18472,8 +17604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18510,8 +17640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18548,8 +17676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18586,8 +17712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18624,8 +17748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18662,8 +17784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18700,8 +17820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18738,8 +17856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18776,8 +17892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18814,8 +17928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18852,8 +17964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18890,8 +18000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18928,8 +18036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18966,8 +18072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19004,8 +18108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19042,8 +18144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19080,8 +18180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19118,8 +18216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19156,8 +18252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19194,8 +18288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19232,8 +18324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19270,8 +18360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19308,8 +18396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19346,8 +18432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19384,8 +18468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19422,8 +18504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19460,8 +18540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19498,8 +18576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19536,8 +18612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19574,8 +18648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19612,8 +18684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19650,8 +18720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19688,8 +18756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19726,8 +18792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19764,8 +18828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19802,8 +18864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19840,8 +18900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19878,8 +18936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19916,8 +18972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19954,8 +19008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19992,8 +19044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20030,8 +19080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20068,8 +19116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20106,8 +19152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20144,8 +19188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20182,8 +19224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20220,8 +19260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20258,8 +19296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20296,8 +19332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20334,8 +19368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20372,8 +19404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20410,8 +19440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20448,8 +19476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20486,8 +19512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20524,8 +19548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20562,8 +19584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20600,8 +19620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20638,8 +19656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20676,8 +19692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20714,8 +19728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20752,8 +19764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20790,8 +19800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20828,8 +19836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20866,8 +19872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20904,8 +19908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20942,8 +19944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20980,8 +19980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21018,8 +20016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21056,8 +20052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21094,8 +20088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21132,8 +20124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21170,8 +20160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21208,8 +20196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21246,8 +20232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21284,8 +20268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21322,8 +20304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21360,8 +20340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21398,8 +20376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21436,8 +20412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21474,8 +20448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21512,8 +20484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21550,8 +20520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21588,8 +20556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21626,8 +20592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21664,8 +20628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21702,8 +20664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21740,8 +20700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21778,8 +20736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21816,8 +20772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21854,8 +20808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21892,8 +20844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21930,8 +20880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21968,8 +20916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22006,8 +20952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22044,8 +20988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22082,8 +21024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22120,8 +21060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22158,8 +21096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22196,8 +21132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22234,8 +21168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22272,8 +21204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22310,8 +21240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22348,8 +21276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22386,8 +21312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22424,8 +21348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22462,8 +21384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22500,8 +21420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22538,8 +21456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22576,8 +21492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22614,8 +21528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22652,8 +21564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22690,8 +21600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22728,8 +21636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22766,8 +21672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22804,8 +21708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22842,8 +21744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22880,8 +21780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22918,8 +21816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22956,8 +21852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22994,8 +21888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23032,8 +21924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23070,8 +21960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23108,8 +21996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23146,8 +22032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23184,8 +22068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23222,8 +22104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23260,8 +22140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23298,8 +22176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23336,8 +22212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23374,8 +22248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23412,8 +22284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23450,8 +22320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23488,8 +22356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23526,8 +22392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23564,8 +22428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23602,8 +22464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23640,8 +22500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23678,8 +22536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23716,8 +22572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23754,8 +22608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23792,8 +22644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23830,8 +22680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23868,8 +22716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23906,8 +22752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23944,8 +22788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23982,8 +22824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24020,8 +22860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24058,8 +22896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24096,8 +22932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24134,8 +22968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24172,8 +23004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24210,8 +23040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24248,8 +23076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24286,8 +23112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24324,8 +23148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24362,8 +23184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24400,8 +23220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24438,8 +23256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24476,8 +23292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24514,8 +23328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24552,8 +23364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24590,8 +23400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24628,8 +23436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24666,8 +23472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24704,8 +23508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24742,8 +23544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24780,8 +23580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24818,8 +23616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24856,8 +23652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24894,8 +23688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24932,8 +23724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24970,8 +23760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25008,8 +23796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25046,8 +23832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25084,8 +23868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25122,8 +23904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25160,8 +23940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25198,8 +23976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25236,8 +24012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25274,8 +24048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25312,8 +24084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25350,8 +24120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25388,8 +24156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25426,8 +24192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25464,8 +24228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25502,8 +24264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25540,8 +24300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25578,8 +24336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25616,8 +24372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25654,8 +24408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25692,8 +24444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25730,8 +24480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25768,8 +24516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25806,8 +24552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25844,8 +24588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25882,8 +24624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25920,8 +24660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25958,8 +24696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25996,8 +24732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26034,8 +24768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26072,8 +24804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26110,8 +24840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26148,8 +24876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,8 +24912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26224,8 +24948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26262,8 +24984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.0.2.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.2.sarif
@@ -1979,6 +1979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2014,6 +2017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2049,6 +2055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2084,6 +2093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2119,6 +2131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2154,6 +2169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2189,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2224,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2259,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2294,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2329,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2364,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2399,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2434,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2469,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2504,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2539,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2574,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2609,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2644,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2679,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2714,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2749,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2784,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2819,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2854,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2889,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2924,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2959,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2994,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3029,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3064,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3099,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3134,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3169,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3204,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3239,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3274,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3309,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3344,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3379,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3414,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3449,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3484,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3519,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3554,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3589,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3624,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3659,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3694,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3729,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3764,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3799,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3834,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3869,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3904,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3939,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -3974,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4009,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4044,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4079,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4114,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4149,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4184,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4219,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4254,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4289,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4324,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4359,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4394,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4429,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4499,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4534,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4569,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4604,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4639,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4674,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4709,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4744,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4779,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4814,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4849,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4884,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -4919,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -4954,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -4989,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5024,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5059,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5094,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5129,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5164,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5199,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5234,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5269,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5304,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5339,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5374,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5409,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5444,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5479,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5514,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5549,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5584,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5619,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5654,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5689,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5759,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5794,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5829,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5864,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5899,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -5934,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5969,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6004,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6039,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6074,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6109,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6144,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6179,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6214,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6249,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6284,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6319,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6354,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6389,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6424,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6459,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6494,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6529,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6564,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6599,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6634,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6669,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6704,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6739,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6774,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6809,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6844,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6879,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6914,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6949,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6984,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7019,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7054,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7089,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7124,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7159,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7194,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7229,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7264,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7299,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7334,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7369,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7404,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7439,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7474,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7509,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7544,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7579,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7614,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7649,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7684,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7719,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7754,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7789,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7824,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -7859,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7894,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -7929,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -7964,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -7999,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8034,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8069,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8104,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8139,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8174,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8209,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8244,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8279,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8314,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8349,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8384,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8419,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8454,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8489,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8524,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8559,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8594,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8629,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8664,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8699,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8734,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8769,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -8804,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -8839,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -8874,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -8909,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -8944,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -8979,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9014,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9049,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9084,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9119,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9154,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9189,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9224,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9259,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9294,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9329,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9364,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9399,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9434,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9469,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9504,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9539,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9574,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9609,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9644,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9679,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9714,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9749,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9784,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9819,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9854,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9889,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9924,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9959,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9994,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10029,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10064,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10099,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10134,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10169,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10204,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10239,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10274,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10309,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10344,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10379,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10414,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10449,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10484,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10519,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10554,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10589,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10624,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10659,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10694,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10729,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10764,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10799,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10834,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10869,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10904,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10939,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10974,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11009,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11044,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11079,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11114,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11149,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11184,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11219,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11254,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11289,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11324,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11359,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11394,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11429,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11464,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11499,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11534,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11569,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11604,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11639,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11674,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11709,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11744,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11779,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11814,6 +12657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11849,6 +12695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11884,6 +12733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11919,6 +12771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11954,6 +12809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11989,6 +12847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12024,6 +12885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12059,6 +12923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12094,6 +12961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12129,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12164,6 +13037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12199,6 +13075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12234,6 +13113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12269,6 +13151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12304,6 +13189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12339,6 +13227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12374,6 +13265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12409,6 +13303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12444,6 +13341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12479,6 +13379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12514,6 +13417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12549,6 +13455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12584,6 +13493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12619,6 +13531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12654,6 +13569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12689,6 +13607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12724,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12759,6 +13683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12794,6 +13721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12829,6 +13759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12864,6 +13797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12899,6 +13835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12934,6 +13873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12969,6 +13911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13004,6 +13949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13039,6 +13987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13074,6 +14025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13109,6 +14063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13144,6 +14101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13179,6 +14139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13214,6 +14177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13249,6 +14215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13284,6 +14253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13319,6 +14291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13354,6 +14329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13389,6 +14367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13424,6 +14405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13459,6 +14443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13494,6 +14481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13529,6 +14519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13564,6 +14557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13599,6 +14595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13634,6 +14633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13669,6 +14671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13704,6 +14709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13739,6 +14747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13774,6 +14785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -13809,6 +14823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -13844,6 +14861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -13879,6 +14899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -13914,6 +14937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -13949,6 +14975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13984,6 +15013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14019,6 +15051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14054,6 +15089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14089,6 +15127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14124,6 +15165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14159,6 +15203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14194,6 +15241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14229,6 +15279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14264,6 +15317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14299,6 +15355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14334,6 +15393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14369,6 +15431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14404,6 +15469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14439,6 +15507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14474,6 +15545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14509,6 +15583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14544,6 +15621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14579,6 +15659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14614,6 +15697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14649,6 +15735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14684,6 +15773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14719,6 +15811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14754,6 +15849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14789,6 +15887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14824,6 +15925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -14859,6 +15963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14894,6 +16001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14929,6 +16039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14964,6 +16077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -14999,6 +16115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15034,6 +16153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15069,6 +16191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15104,6 +16229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15139,6 +16267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15174,6 +16305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15209,6 +16343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15244,6 +16381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15279,6 +16419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15314,6 +16457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15349,6 +16495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15384,6 +16533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15419,6 +16571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15454,6 +16609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15489,6 +16647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15524,6 +16685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15559,6 +16723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15594,6 +16761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15629,6 +16799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15664,6 +16837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15699,6 +16875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15734,6 +16913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15769,6 +16951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15804,6 +16989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15839,6 +17027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15874,6 +17065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15909,6 +17103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15944,6 +17141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15979,6 +17179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16014,6 +17217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16049,6 +17255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16084,6 +17293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16119,6 +17331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16154,6 +17369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16189,6 +17407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16224,6 +17445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16259,6 +17483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16294,6 +17521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16329,6 +17559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16364,6 +17597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16399,6 +17635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16434,6 +17673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16469,6 +17711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16504,6 +17749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16539,6 +17787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16574,6 +17825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16609,6 +17863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16644,6 +17901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16679,6 +17939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16714,6 +17977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16749,6 +18015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16784,6 +18053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16819,6 +18091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16854,6 +18129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -16889,6 +18167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16924,6 +18205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16959,6 +18243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -16994,6 +18281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17029,6 +18319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17064,6 +18357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17099,6 +18395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17134,6 +18433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17169,6 +18471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17204,6 +18509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17239,6 +18547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17274,6 +18585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17309,6 +18623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17344,6 +18661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17379,6 +18699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17414,6 +18737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17449,6 +18775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17484,6 +18813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17519,6 +18851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17554,6 +18889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17589,6 +18927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17624,6 +18965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17659,6 +19003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17694,6 +19041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17729,6 +19079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17764,6 +19117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17799,6 +19155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17834,6 +19193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17869,6 +19231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17904,6 +19269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -17939,6 +19307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -17974,6 +19345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18009,6 +19383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18044,6 +19421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18079,6 +19459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18114,6 +19497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18149,6 +19535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18184,6 +19573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18219,6 +19611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18254,6 +19649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18289,6 +19687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18324,6 +19725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18359,6 +19763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18394,6 +19801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18429,6 +19839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18464,6 +19877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18499,6 +19915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18534,6 +19953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18569,6 +19991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18604,6 +20029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18639,6 +20067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18674,6 +20105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18709,6 +20143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18744,6 +20181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18779,6 +20219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18814,6 +20257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18849,6 +20295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18884,6 +20333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18919,6 +20371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18954,6 +20409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18989,6 +20447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19024,6 +20485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19059,6 +20523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19094,6 +20561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19129,6 +20599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19164,6 +20637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19199,6 +20675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19234,6 +20713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19269,6 +20751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19304,6 +20789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19339,6 +20827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19374,6 +20865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19409,6 +20903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19444,6 +20941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19479,6 +20979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19514,6 +21017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19549,6 +21055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19584,6 +21093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19619,6 +21131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19654,6 +21169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19689,6 +21207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19724,6 +21245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19759,6 +21283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -19794,6 +21321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19829,6 +21359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19864,6 +21397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19899,6 +21435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19934,6 +21473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19969,6 +21511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20004,6 +21549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20039,6 +21587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20074,6 +21625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20109,6 +21663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20144,6 +21701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20179,6 +21739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20214,6 +21777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20249,6 +21815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20284,6 +21853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20319,6 +21891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20354,6 +21929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20389,6 +21967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20424,6 +22005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20459,6 +22043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20494,6 +22081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20529,6 +22119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20564,6 +22157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20599,6 +22195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20634,6 +22233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20669,6 +22271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20704,6 +22309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20739,6 +22347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20774,6 +22385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20809,6 +22423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20844,6 +22461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20879,6 +22499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -20914,6 +22537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -20949,6 +22575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -20984,6 +22613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21019,6 +22651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21054,6 +22689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21089,6 +22727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21124,6 +22765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21159,6 +22803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21194,6 +22841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21229,6 +22879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21264,6 +22917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21299,6 +22955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21334,6 +22993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21369,6 +23031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21404,6 +23069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21439,6 +23107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21474,6 +23145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21509,6 +23183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21544,6 +23221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21579,6 +23259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21614,6 +23297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21649,6 +23335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21684,6 +23373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21719,6 +23411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21754,6 +23449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21789,6 +23487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -21824,6 +23525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -21859,6 +23563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -21894,6 +23601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -21929,6 +23639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -21964,6 +23677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -21999,6 +23715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22034,6 +23753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22069,6 +23791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22104,6 +23829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22139,6 +23867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22174,6 +23905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22209,6 +23943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22244,6 +23981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22279,6 +24019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22314,6 +24057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22349,6 +24095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22384,6 +24133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22419,6 +24171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22454,6 +24209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22489,6 +24247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22524,6 +24285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22559,6 +24323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22594,6 +24361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22629,6 +24399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22664,6 +24437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22699,6 +24475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22734,6 +24513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22769,6 +24551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22804,6 +24589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -22839,6 +24627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -22874,6 +24665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -22909,6 +24703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -22944,6 +24741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22979,6 +24779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23014,6 +24817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23049,6 +24855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23084,6 +24893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23119,6 +24931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23154,6 +24969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23189,6 +25007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23224,6 +25045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23259,6 +25083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23294,6 +25121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23329,6 +25159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23364,6 +25197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23399,6 +25235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23434,6 +25273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23469,6 +25311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23504,6 +25349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23539,6 +25387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23574,6 +25425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23609,6 +25463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23644,6 +25501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23679,6 +25539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23714,6 +25577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23749,6 +25615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23784,6 +25653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23819,6 +25691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23854,6 +25729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23889,6 +25767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -23924,6 +25805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23959,6 +25843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23994,6 +25881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24029,6 +25919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24064,6 +25957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24099,6 +25995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24134,6 +26033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24169,6 +26071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24204,6 +26109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24239,6 +26147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24274,6 +26185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24309,6 +26223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24344,6 +26261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.0.2.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.2.sarif
@@ -1980,6 +1980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2016,6 +2018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2052,6 +2056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2088,6 +2094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2124,6 +2132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2160,6 +2170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2196,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2232,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2268,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2304,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2340,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2376,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2412,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2448,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2484,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2520,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2556,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2592,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2628,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2664,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2700,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2736,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2772,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2808,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2844,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2880,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -2916,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2952,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -2988,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3024,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3060,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3096,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3132,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3168,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3204,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3240,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3276,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -3312,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3348,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3384,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3420,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3456,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3492,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3528,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3564,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3600,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3636,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3672,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3708,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3744,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3780,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3816,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3852,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -3888,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -3924,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -3960,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -3996,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4032,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4068,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4104,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4140,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4176,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4212,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4248,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4284,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4320,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4356,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4392,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4428,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4464,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4500,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4536,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4572,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4608,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4644,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4680,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4716,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4752,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4788,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4824,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4860,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -4896,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -4932,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -4968,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5004,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5040,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5076,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5112,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5148,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5184,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5220,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5256,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5292,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5328,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5364,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5400,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5436,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5472,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5508,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5544,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5580,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5616,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5652,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5688,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5724,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5760,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5796,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5832,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5868,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5904,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -5940,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -5976,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6012,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6048,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6084,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6120,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6156,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6192,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6228,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6264,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6300,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6336,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6372,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6408,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6444,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6480,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6516,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6552,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6588,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6624,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6660,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6696,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6732,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6768,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6804,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6840,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6876,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6912,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -6948,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6984,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7020,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7056,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7092,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7128,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7164,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7200,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7236,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7272,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7308,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7344,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7380,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7416,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7452,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7488,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7524,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7560,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7596,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7632,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7668,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7704,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7740,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7776,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7812,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7848,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7884,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7920,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7956,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7992,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8028,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8064,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8100,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8136,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8172,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8208,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8244,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8280,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8316,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8352,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8388,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8424,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8460,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8496,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8532,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8568,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8604,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8640,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8676,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8712,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8748,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8784,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8820,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8856,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8892,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8928,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8964,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9000,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9036,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9072,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9108,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9144,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9180,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9216,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9252,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9288,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9324,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9360,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9396,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9432,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9468,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9504,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9540,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9576,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9612,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9648,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9684,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9720,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9756,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9792,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9828,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9864,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9900,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9936,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9972,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10008,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10044,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10080,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10116,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10152,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10188,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10224,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10260,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10296,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10332,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10368,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10404,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10440,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10476,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10512,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10548,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10584,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10620,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10656,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10692,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10728,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10764,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10800,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10836,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10872,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10908,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10944,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10980,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11016,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11052,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11088,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11124,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11160,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11196,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11232,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11268,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11304,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11340,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11376,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11412,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11448,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11484,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11520,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11556,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11592,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11628,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11664,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11700,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11736,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11772,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11808,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11844,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11880,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11916,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11952,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11988,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12024,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12060,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12096,6 +12658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12132,6 +12696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12168,6 +12734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12204,6 +12772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12240,6 +12810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12276,6 +12848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12312,6 +12886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12348,6 +12924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12384,6 +12962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12420,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12456,6 +13038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12492,6 +13076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12528,6 +13114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12564,6 +13152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12600,6 +13190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12636,6 +13228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12672,6 +13266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12708,6 +13304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12744,6 +13342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12780,6 +13380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12852,6 +13456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12888,6 +13494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12924,6 +13532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12960,6 +13570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12996,6 +13608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13032,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13068,6 +13684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13104,6 +13722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13140,6 +13760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13176,6 +13798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13212,6 +13836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13248,6 +13874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13284,6 +13912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13320,6 +13950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13356,6 +13988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13392,6 +14026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13428,6 +14064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13464,6 +14102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13500,6 +14140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13536,6 +14178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13572,6 +14216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13608,6 +14254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13644,6 +14292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13680,6 +14330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13716,6 +14368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13752,6 +14406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13788,6 +14444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13824,6 +14482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13860,6 +14520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13896,6 +14558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13932,6 +14596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13968,6 +14634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14004,6 +14672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14040,6 +14710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14076,6 +14748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14112,6 +14786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14148,6 +14824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14184,6 +14862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14220,6 +14900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14256,6 +14938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14292,6 +14976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14328,6 +15014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14364,6 +15052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14400,6 +15090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14436,6 +15128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14472,6 +15166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14508,6 +15204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14544,6 +15242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14580,6 +15280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14616,6 +15318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14652,6 +15356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14688,6 +15394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14724,6 +15432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14760,6 +15470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14796,6 +15508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14832,6 +15546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14868,6 +15584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14904,6 +15622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14940,6 +15660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14976,6 +15698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15012,6 +15736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15048,6 +15774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15084,6 +15812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15120,6 +15850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15156,6 +15888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15192,6 +15926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15228,6 +15964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15264,6 +16002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15300,6 +16040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15336,6 +16078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15372,6 +16116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15408,6 +16154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15444,6 +16192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15480,6 +16230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15516,6 +16268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15552,6 +16306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15588,6 +16344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15624,6 +16382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15660,6 +16420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15696,6 +16458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15732,6 +16496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15768,6 +16534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15804,6 +16572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15840,6 +16610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15876,6 +16648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15912,6 +16686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15948,6 +16724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15984,6 +16762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16020,6 +16800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16056,6 +16838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16092,6 +16876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16128,6 +16914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16164,6 +16952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16200,6 +16990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16236,6 +17028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16272,6 +17066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16308,6 +17104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16344,6 +17142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16380,6 +17180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16416,6 +17218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16452,6 +17256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16488,6 +17294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16524,6 +17332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16560,6 +17370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16596,6 +17408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16632,6 +17446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16668,6 +17484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16704,6 +17522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16740,6 +17560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16776,6 +17598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16812,6 +17636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16848,6 +17674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16884,6 +17712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16920,6 +17750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16956,6 +17788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16992,6 +17826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17028,6 +17864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17064,6 +17902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17100,6 +17940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17136,6 +17978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17172,6 +18016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17208,6 +18054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17244,6 +18092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17280,6 +18130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17316,6 +18168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17352,6 +18206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17388,6 +18244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17424,6 +18282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17460,6 +18320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17496,6 +18358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17532,6 +18396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17568,6 +18434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17604,6 +18472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17640,6 +18510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17676,6 +18548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17712,6 +18586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17748,6 +18624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17784,6 +18662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17820,6 +18700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17856,6 +18738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17892,6 +18776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17928,6 +18814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17964,6 +18852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18000,6 +18890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18036,6 +18928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18072,6 +18966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18108,6 +19004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18144,6 +19042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18180,6 +19080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18216,6 +19118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18252,6 +19156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18288,6 +19194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18324,6 +19232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18360,6 +19270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18396,6 +19308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18432,6 +19346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18468,6 +19384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18504,6 +19422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18540,6 +19460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18576,6 +19498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18612,6 +19536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18648,6 +19574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18684,6 +19612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18720,6 +19650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18756,6 +19688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18792,6 +19726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18828,6 +19764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18864,6 +19802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18900,6 +19840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18936,6 +19878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18972,6 +19916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19008,6 +19954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19044,6 +19992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19080,6 +20030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19116,6 +20068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19152,6 +20106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19188,6 +20144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19224,6 +20182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19260,6 +20220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19296,6 +20258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19332,6 +20296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19368,6 +20334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19404,6 +20372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19440,6 +20410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19476,6 +20448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19512,6 +20486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19548,6 +20524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19584,6 +20562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19620,6 +20600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19656,6 +20638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19692,6 +20676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19728,6 +20714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19764,6 +20752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19800,6 +20790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19836,6 +20828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19872,6 +20866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19908,6 +20904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19944,6 +20942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19980,6 +20980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20016,6 +21018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20052,6 +21056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20088,6 +21094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20124,6 +21132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20160,6 +21170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20196,6 +21208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20232,6 +21246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20268,6 +21284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20304,6 +21322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20340,6 +21360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20376,6 +21398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20412,6 +21436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20448,6 +21474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20484,6 +21512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20520,6 +21550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20556,6 +21588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20592,6 +21626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20628,6 +21664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20664,6 +21702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20700,6 +21740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20736,6 +21778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20772,6 +21816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20808,6 +21854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20844,6 +21892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20880,6 +21930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20916,6 +21968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20952,6 +22006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20988,6 +22044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21024,6 +22082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21060,6 +22120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21096,6 +22158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21132,6 +22196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21168,6 +22234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21204,6 +22272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21240,6 +22310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21276,6 +22348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21312,6 +22386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21348,6 +22424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21384,6 +22462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21420,6 +22500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21456,6 +22538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21492,6 +22576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21528,6 +22614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21564,6 +22652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21600,6 +22690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21636,6 +22728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21672,6 +22766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21708,6 +22804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21744,6 +22842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21780,6 +22880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21816,6 +22918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21852,6 +22956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21888,6 +22994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21924,6 +23032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21960,6 +23070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21996,6 +23108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22032,6 +23146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22068,6 +23184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22104,6 +23222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22140,6 +23260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22176,6 +23298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22212,6 +23336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22248,6 +23374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22284,6 +23412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22320,6 +23450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22356,6 +23488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22392,6 +23526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22428,6 +23564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22464,6 +23602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22500,6 +23640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22536,6 +23678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22572,6 +23716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22608,6 +23754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22644,6 +23792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22680,6 +23830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22716,6 +23868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22752,6 +23906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22788,6 +23944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22824,6 +23982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22860,6 +24020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22896,6 +24058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22932,6 +24096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22968,6 +24134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23004,6 +24172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23040,6 +24210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23076,6 +24248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23112,6 +24286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23148,6 +24324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23184,6 +24362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23220,6 +24400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23256,6 +24438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23292,6 +24476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23328,6 +24514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23364,6 +24552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23400,6 +24590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23436,6 +24628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23472,6 +24666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23508,6 +24704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23544,6 +24742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23580,6 +24780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23616,6 +24818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23652,6 +24856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23688,6 +24894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23724,6 +24932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23760,6 +24970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23796,6 +25008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23832,6 +25046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23868,6 +25084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23904,6 +25122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23940,6 +25160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23976,6 +25198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24012,6 +25236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24048,6 +25274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24084,6 +25312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24120,6 +25350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24156,6 +25388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24192,6 +25426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24228,6 +25464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24264,6 +25502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24300,6 +25540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24336,6 +25578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24372,6 +25616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24408,6 +25654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24444,6 +25692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24480,6 +25730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24516,6 +25768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24552,6 +25806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24588,6 +25844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24624,6 +25882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24660,6 +25920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24696,6 +25958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24732,6 +25996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24768,6 +26034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24804,6 +26072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24840,6 +26110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24876,6 +26148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24912,6 +26186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24948,6 +26224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24984,6 +26262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.1.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.1.1.sarif
@@ -2186,6 +2186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2222,6 +2224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2258,6 +2262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2294,6 +2300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2330,6 +2338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2366,6 +2376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2402,6 +2414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2438,6 +2452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2474,6 +2490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2510,6 +2528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2546,6 +2566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2582,6 +2604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2618,6 +2642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2654,6 +2680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2690,6 +2718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2726,6 +2756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2762,6 +2794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2798,6 +2832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2834,6 +2870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2870,6 +2908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2906,6 +2946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2942,6 +2984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2978,6 +3022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3014,6 +3060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3050,6 +3098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3086,6 +3136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3122,6 +3174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3158,6 +3212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3194,6 +3250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3230,6 +3288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3266,6 +3326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3302,6 +3364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3338,6 +3402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3374,6 +3440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3410,6 +3478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3446,6 +3516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3482,6 +3554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3518,6 +3592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3554,6 +3630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3590,6 +3668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3626,6 +3706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3662,6 +3744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3698,6 +3782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3734,6 +3820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3770,6 +3858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3806,6 +3896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3842,6 +3934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3878,6 +3972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3914,6 +4010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3950,6 +4048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3986,6 +4086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4022,6 +4124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4058,6 +4162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4094,6 +4200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4130,6 +4238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4166,6 +4276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4202,6 +4314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4238,6 +4352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4274,6 +4390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4310,6 +4428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4346,6 +4466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4382,6 +4504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4418,6 +4542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4454,6 +4580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4490,6 +4618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4526,6 +4656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4562,6 +4694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4598,6 +4732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4634,6 +4770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4670,6 +4808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4706,6 +4846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4742,6 +4884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4778,6 +4922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4814,6 +4960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4850,6 +4998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4886,6 +5036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4922,6 +5074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4958,6 +5112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4994,6 +5150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5030,6 +5188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5066,6 +5226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5102,6 +5264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5138,6 +5302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5174,6 +5340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5210,6 +5378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5246,6 +5416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5282,6 +5454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5318,6 +5492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5354,6 +5530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5390,6 +5568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5426,6 +5606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5462,6 +5644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5498,6 +5682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5534,6 +5720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5570,6 +5758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5606,6 +5796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5642,6 +5834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5678,6 +5872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5714,6 +5910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5750,6 +5948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5786,6 +5986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5822,6 +6024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5858,6 +6062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5894,6 +6100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5930,6 +6138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5966,6 +6176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6002,6 +6214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6038,6 +6252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6074,6 +6290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6110,6 +6328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6146,6 +6366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6182,6 +6404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6218,6 +6442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6254,6 +6480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6290,6 +6518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6326,6 +6556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6362,6 +6594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6398,6 +6632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6434,6 +6670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6470,6 +6708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6506,6 +6746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6542,6 +6784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6578,6 +6822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6614,6 +6860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6650,6 +6898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6686,6 +6936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6722,6 +6974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6758,6 +7012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6794,6 +7050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6830,6 +7088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6866,6 +7126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6902,6 +7164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6938,6 +7202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6974,6 +7240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7010,6 +7278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7046,6 +7316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7082,6 +7354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7118,6 +7392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7154,6 +7430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7190,6 +7468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7226,6 +7506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7262,6 +7544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7298,6 +7582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7334,6 +7620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7370,6 +7658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7406,6 +7696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7442,6 +7734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7478,6 +7772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7514,6 +7810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7550,6 +7848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7586,6 +7886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7622,6 +7924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7658,6 +7962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7694,6 +8000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7730,6 +8038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7766,6 +8076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7802,6 +8114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7838,6 +8152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7874,6 +8190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7910,6 +8228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7946,6 +8266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7982,6 +8304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8018,6 +8342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8054,6 +8380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8090,6 +8418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8126,6 +8456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8162,6 +8494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8198,6 +8532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8234,6 +8570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8270,6 +8608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8306,6 +8646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8342,6 +8684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8378,6 +8722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8414,6 +8760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8450,6 +8798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8486,6 +8836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8522,6 +8874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8558,6 +8912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8594,6 +8950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8630,6 +8988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8666,6 +9026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8702,6 +9064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8738,6 +9102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8774,6 +9140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8810,6 +9178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8846,6 +9216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8882,6 +9254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8918,6 +9292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8954,6 +9330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8990,6 +9368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9026,6 +9406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9062,6 +9444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9098,6 +9482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9134,6 +9520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9170,6 +9558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9206,6 +9596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9242,6 +9634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9278,6 +9672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9314,6 +9710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9350,6 +9748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9386,6 +9786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9422,6 +9824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9458,6 +9862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9494,6 +9900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9530,6 +9938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9566,6 +9976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9602,6 +10014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9638,6 +10052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9674,6 +10090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9710,6 +10128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9746,6 +10166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9782,6 +10204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9818,6 +10242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9854,6 +10280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9890,6 +10318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9926,6 +10356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9962,6 +10394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9998,6 +10432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10034,6 +10470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10070,6 +10508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10106,6 +10546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10142,6 +10584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10178,6 +10622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10214,6 +10660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10250,6 +10698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10286,6 +10736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10322,6 +10774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10358,6 +10812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10394,6 +10850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10430,6 +10888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10466,6 +10926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10502,6 +10964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10538,6 +11002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10574,6 +11040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10610,6 +11078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10646,6 +11116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10682,6 +11154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10718,6 +11192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10754,6 +11230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10790,6 +11268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10826,6 +11306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10862,6 +11344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10898,6 +11382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10934,6 +11420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10970,6 +11458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11006,6 +11496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11042,6 +11534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11078,6 +11572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11114,6 +11610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11150,6 +11648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11186,6 +11686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11222,6 +11724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11258,6 +11762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11294,6 +11800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11330,6 +11838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11366,6 +11876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11402,6 +11914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11438,6 +11952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11474,6 +11990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11510,6 +12028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11546,6 +12066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11582,6 +12104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11618,6 +12142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11654,6 +12180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11690,6 +12218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11726,6 +12256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11762,6 +12294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11798,6 +12332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11834,6 +12370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11870,6 +12408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11906,6 +12446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11942,6 +12484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11978,6 +12522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12014,6 +12560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12050,6 +12598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12086,6 +12636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12122,6 +12674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12158,6 +12712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12194,6 +12750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12230,6 +12788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12266,6 +12826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12302,6 +12864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12338,6 +12902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12374,6 +12940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12410,6 +12978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12446,6 +13016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12482,6 +13054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12518,6 +13092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12554,6 +13130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12590,6 +13168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12626,6 +13206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12662,6 +13244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12698,6 +13282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12734,6 +13320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12770,6 +13358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12806,6 +13396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12842,6 +13434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12878,6 +13472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12914,6 +13510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12950,6 +13548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12986,6 +13586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13022,6 +13624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13058,6 +13662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13094,6 +13700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13130,6 +13738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13166,6 +13776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13202,6 +13814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13238,6 +13852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13274,6 +13890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13310,6 +13928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13346,6 +13966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13382,6 +14004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13418,6 +14042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13454,6 +14080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13490,6 +14118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13526,6 +14156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13562,6 +14194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13598,6 +14232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13634,6 +14270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13670,6 +14308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13706,6 +14346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13742,6 +14384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13778,6 +14422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13814,6 +14460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13850,6 +14498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13886,6 +14536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13922,6 +14574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13958,6 +14612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13994,6 +14650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14030,6 +14688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14066,6 +14726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14102,6 +14764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14138,6 +14802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14174,6 +14840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14210,6 +14878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14246,6 +14916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14282,6 +14954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14318,6 +14992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14354,6 +15030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14390,6 +15068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14426,6 +15106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14462,6 +15144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14498,6 +15182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14534,6 +15220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14570,6 +15258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14606,6 +15296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14642,6 +15334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14678,6 +15372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14714,6 +15410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14750,6 +15448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14786,6 +15486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14822,6 +15524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14858,6 +15562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14894,6 +15600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14930,6 +15638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14966,6 +15676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15002,6 +15714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15038,6 +15752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15074,6 +15790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15110,6 +15828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15146,6 +15866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15182,6 +15904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15218,6 +15942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15254,6 +15980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -15290,6 +16018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15326,6 +16056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15362,6 +16094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15398,6 +16132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15434,6 +16170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15470,6 +16208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15506,6 +16246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15542,6 +16284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15578,6 +16322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15614,6 +16360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15650,6 +16398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15686,6 +16436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15722,6 +16474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15758,6 +16512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15794,6 +16550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15830,6 +16588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15866,6 +16626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15902,6 +16664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15938,6 +16702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15974,6 +16740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16010,6 +16778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16046,6 +16816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16082,6 +16854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16118,6 +16892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16154,6 +16930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16190,6 +16968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -16226,6 +17006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -16262,6 +17044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -16298,6 +17082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -16334,6 +17120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -16370,6 +17158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16406,6 +17196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16442,6 +17234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16478,6 +17272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16514,6 +17310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16550,6 +17348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16586,6 +17386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16622,6 +17424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16658,6 +17462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16694,6 +17500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16730,6 +17538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16766,6 +17576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16802,6 +17614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16838,6 +17652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16874,6 +17690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16910,6 +17728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16946,6 +17766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16982,6 +17804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17018,6 +17842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17054,6 +17880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17090,6 +17918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17126,6 +17956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17162,6 +17994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -17198,6 +18032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -17234,6 +18070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -17270,6 +18108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17306,6 +18146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17342,6 +18184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -17378,6 +18222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -17414,6 +18260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17450,6 +18298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17486,6 +18336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17522,6 +18374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17558,6 +18412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17594,6 +18450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17630,6 +18488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17666,6 +18526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17702,6 +18564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17738,6 +18602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17774,6 +18640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17810,6 +18678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17846,6 +18716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17882,6 +18754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17918,6 +18792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17954,6 +18830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17990,6 +18868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18026,6 +18906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18062,6 +18944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18098,6 +18982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18134,6 +19020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18170,6 +19058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18206,6 +19096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18242,6 +19134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18278,6 +19172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18314,6 +19210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -18350,6 +19248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -18386,6 +19286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -18422,6 +19324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18458,6 +19362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18494,6 +19400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18530,6 +19438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18566,6 +19476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18602,6 +19514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18638,6 +19552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18674,6 +19590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18710,6 +19628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18746,6 +19666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18782,6 +19704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18818,6 +19742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18854,6 +19780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18890,6 +19818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18926,6 +19856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18962,6 +19894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18998,6 +19932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19034,6 +19970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19070,6 +20008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19106,6 +20046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19142,6 +20084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19178,6 +20122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19214,6 +20160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19250,6 +20198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -19286,6 +20236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19322,6 +20274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19358,6 +20312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -19394,6 +20350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19430,6 +20388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19466,6 +20426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19502,6 +20464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19538,6 +20502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19574,6 +20540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19610,6 +20578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19646,6 +20616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19682,6 +20654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19718,6 +20692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19754,6 +20730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19790,6 +20768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19826,6 +20806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19862,6 +20844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19898,6 +20882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19934,6 +20920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19970,6 +20958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20006,6 +20996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20042,6 +21034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20078,6 +21072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20114,6 +21110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20150,6 +21148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20186,6 +21186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20222,6 +21224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20258,6 +21262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20294,6 +21300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20330,6 +21338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20366,6 +21376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -20402,6 +21414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20438,6 +21452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20474,6 +21490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20510,6 +21528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20546,6 +21566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20582,6 +21604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20618,6 +21642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20654,6 +21680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20690,6 +21718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20726,6 +21756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20762,6 +21794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20798,6 +21832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20834,6 +21870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20870,6 +21908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20906,6 +21946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20942,6 +21984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20978,6 +22022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21014,6 +22060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21050,6 +22098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21086,6 +22136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21122,6 +22174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21158,6 +22212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21194,6 +22250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21230,6 +22288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21266,6 +22326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -21302,6 +22364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -21338,6 +22402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -21374,6 +22440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21410,6 +22478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21446,6 +22516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -21482,6 +22554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -21518,6 +22592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21554,6 +22630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21590,6 +22668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21626,6 +22706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21662,6 +22744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21698,6 +22782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21734,6 +22820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21770,6 +22858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21806,6 +22896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21842,6 +22934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21878,6 +22972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21914,6 +23010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21950,6 +23048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21986,6 +23086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22022,6 +23124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22058,6 +23162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22094,6 +23200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22130,6 +23238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22166,6 +23276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22202,6 +23314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22238,6 +23352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22274,6 +23390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22310,6 +23428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -22346,6 +23466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -22382,6 +23504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -22418,6 +23542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -22454,6 +23580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -22490,6 +23618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -22526,6 +23656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -22562,6 +23694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22598,6 +23732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22634,6 +23770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22670,6 +23808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22706,6 +23846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22742,6 +23884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22778,6 +23922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22814,6 +23960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22850,6 +23998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22886,6 +24036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22922,6 +24074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22958,6 +24112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22994,6 +24150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23030,6 +24188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23066,6 +24226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -23102,6 +24264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -23138,6 +24302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23174,6 +24340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23210,6 +24378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23246,6 +24416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23282,6 +24454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23318,6 +24492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -23354,6 +24530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -23390,6 +24568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23426,6 +24606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -23462,6 +24644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -23498,6 +24682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -23534,6 +24720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -23570,6 +24758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23606,6 +24796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23642,6 +24834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23678,6 +24872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23714,6 +24910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23750,6 +24948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23786,6 +24986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23822,6 +25024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23858,6 +25062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23894,6 +25100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23930,6 +25138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23966,6 +25176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24002,6 +25214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24038,6 +25252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24074,6 +25290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24110,6 +25328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -24146,6 +25366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -24182,6 +25404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24218,6 +25442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24254,6 +25480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24290,6 +25518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24326,6 +25556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -24362,6 +25594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24398,6 +25632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24434,6 +25670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24470,6 +25708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24506,6 +25746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24542,6 +25784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24578,6 +25822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24614,6 +25860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24650,6 +25898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24686,6 +25936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24722,6 +25974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24758,6 +26012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24794,6 +26050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24830,6 +26088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24866,6 +26126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24902,6 +26164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24938,6 +26202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24974,6 +26240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25010,6 +26278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25046,6 +26316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25082,6 +26354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25118,6 +26392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -25154,6 +26430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -25190,6 +26468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.1.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.1.1.sarif
@@ -2186,8 +2186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2224,8 +2222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2262,8 +2258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2300,8 +2294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2338,8 +2330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2376,8 +2366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2414,8 +2402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2452,8 +2438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2490,8 +2474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2528,8 +2510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2566,8 +2546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2604,8 +2582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2642,8 +2618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2680,8 +2654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2718,8 +2690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2756,8 +2726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2794,8 +2762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2832,8 +2798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2870,8 +2834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2908,8 +2870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2946,8 +2906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2984,8 +2942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3022,8 +2978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3060,8 +3014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3098,8 +3050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3136,8 +3086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3174,8 +3122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3212,8 +3158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3250,8 +3194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3288,8 +3230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3326,8 +3266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3364,8 +3302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3402,8 +3338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3440,8 +3374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3478,8 +3410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3516,8 +3446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3554,8 +3482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3592,8 +3518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3630,8 +3554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3668,8 +3590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3706,8 +3626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3744,8 +3662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3782,8 +3698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3820,8 +3734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3858,8 +3770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3896,8 +3806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3934,8 +3842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3972,8 +3878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -4010,8 +3914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4048,8 +3950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4086,8 +3986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4124,8 +4022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4162,8 +4058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4200,8 +4094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4238,8 +4130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4276,8 +4166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4314,8 +4202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4352,8 +4238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4390,8 +4274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4428,8 +4310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4466,8 +4346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4504,8 +4382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4542,8 +4418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4580,8 +4454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4618,8 +4490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4656,8 +4526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4694,8 +4562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4732,8 +4598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4770,8 +4634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4808,8 +4670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4846,8 +4706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4884,8 +4742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4922,8 +4778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4960,8 +4814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4998,8 +4850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5036,8 +4886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5074,8 +4922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5112,8 +4958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5150,8 +4994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5188,8 +5030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5226,8 +5066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5264,8 +5102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5302,8 +5138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5340,8 +5174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5378,8 +5210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5416,8 +5246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5454,8 +5282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5492,8 +5318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5530,8 +5354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5568,8 +5390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5606,8 +5426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5644,8 +5462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5682,8 +5498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5720,8 +5534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5758,8 +5570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5796,8 +5606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5834,8 +5642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5872,8 +5678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5910,8 +5714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5948,8 +5750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5986,8 +5786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -6024,8 +5822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6062,8 +5858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6100,8 +5894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6138,8 +5930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6176,8 +5966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6214,8 +6002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6252,8 +6038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6290,8 +6074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6328,8 +6110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6366,8 +6146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6404,8 +6182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6442,8 +6218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6480,8 +6254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6518,8 +6290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6556,8 +6326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6594,8 +6362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6632,8 +6398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6670,8 +6434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6708,8 +6470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6746,8 +6506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6784,8 +6542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6822,8 +6578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6860,8 +6614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6898,8 +6650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6936,8 +6686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6974,8 +6722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -7012,8 +6758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -7050,8 +6794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -7088,8 +6830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -7126,8 +6866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7164,8 +6902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7202,8 +6938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7240,8 +6974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7278,8 +7010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7316,8 +7046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7354,8 +7082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7392,8 +7118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7430,8 +7154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7468,8 +7190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7506,8 +7226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7544,8 +7262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7582,8 +7298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7620,8 +7334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7658,8 +7370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7696,8 +7406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7734,8 +7442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7772,8 +7478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7810,8 +7514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7848,8 +7550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7886,8 +7586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7924,8 +7622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7962,8 +7658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -8000,8 +7694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -8038,8 +7730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -8076,8 +7766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -8114,8 +7802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -8152,8 +7838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -8190,8 +7874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8228,8 +7910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8266,8 +7946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8304,8 +7982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8342,8 +8018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8380,8 +8054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8418,8 +8090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8456,8 +8126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8494,8 +8162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8532,8 +8198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8570,8 +8234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8608,8 +8270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8646,8 +8306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8684,8 +8342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8722,8 +8378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8760,8 +8414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8798,8 +8450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8836,8 +8486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8874,8 +8522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8912,8 +8558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8950,8 +8594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8988,8 +8630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9026,8 +8666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9064,8 +8702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9102,8 +8738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9140,8 +8774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9178,8 +8810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9216,8 +8846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9254,8 +8882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9292,8 +8918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9330,8 +8954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9368,8 +8990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9406,8 +9026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9444,8 +9062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9482,8 +9098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9520,8 +9134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9558,8 +9170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9596,8 +9206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9634,8 +9242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9672,8 +9278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9710,8 +9314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9748,8 +9350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9786,8 +9386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9824,8 +9422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9862,8 +9458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9900,8 +9494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9938,8 +9530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9976,8 +9566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10014,8 +9602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10052,8 +9638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10090,8 +9674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10128,8 +9710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10166,8 +9746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10204,8 +9782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10242,8 +9818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10280,8 +9854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10318,8 +9890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10356,8 +9926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10394,8 +9962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10432,8 +9998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10470,8 +10034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10508,8 +10070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10546,8 +10106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10584,8 +10142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10622,8 +10178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10660,8 +10214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10698,8 +10250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10736,8 +10286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10774,8 +10322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10812,8 +10358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10850,8 +10394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10888,8 +10430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10926,8 +10466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10964,8 +10502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -11002,8 +10538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -11040,8 +10574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11078,8 +10610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -11116,8 +10646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11154,8 +10682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -11192,8 +10718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11230,8 +10754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11268,8 +10790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11306,8 +10826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11344,8 +10862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11382,8 +10898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11420,8 +10934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11458,8 +10970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11496,8 +11006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11534,8 +11042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11572,8 +11078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11610,8 +11114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11648,8 +11150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11686,8 +11186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11724,8 +11222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11762,8 +11258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11800,8 +11294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11838,8 +11330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11876,8 +11366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11914,8 +11402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11952,8 +11438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11990,8 +11474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -12028,8 +11510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12066,8 +11546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -12104,8 +11582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12142,8 +11618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -12180,8 +11654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12218,8 +11690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12256,8 +11726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12294,8 +11762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12332,8 +11798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12370,8 +11834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12408,8 +11870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12446,8 +11906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12484,8 +11942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12522,8 +11978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12560,8 +12014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12598,8 +12050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12636,8 +12086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12674,8 +12122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12712,8 +12158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12750,8 +12194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12788,8 +12230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12826,8 +12266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12864,8 +12302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12902,8 +12338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12940,8 +12374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12978,8 +12410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13016,8 +12446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13054,8 +12482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -13092,8 +12518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -13130,8 +12554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -13168,8 +12590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13206,8 +12626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13244,8 +12662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13282,8 +12698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13320,8 +12734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13358,8 +12770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13396,8 +12806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13434,8 +12842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13472,8 +12878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13510,8 +12914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13548,8 +12950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13586,8 +12986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13624,8 +13022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13662,8 +13058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13700,8 +13094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13738,8 +13130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13776,8 +13166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13814,8 +13202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13852,8 +13238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13890,8 +13274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13928,8 +13310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13966,8 +13346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14004,8 +13382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14042,8 +13418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14080,8 +13454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14118,8 +13490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14156,8 +13526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14194,8 +13562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14232,8 +13598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14270,8 +13634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14308,8 +13670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14346,8 +13706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14384,8 +13742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14422,8 +13778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14460,8 +13814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14498,8 +13850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14536,8 +13886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14574,8 +13922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14612,8 +13958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14650,8 +13994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14688,8 +14030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14726,8 +14066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14764,8 +14102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -14802,8 +14138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14840,8 +14174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -14878,8 +14210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -14916,8 +14246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14954,8 +14282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14992,8 +14318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -15030,8 +14354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -15068,8 +14390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -15106,8 +14426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -15144,8 +14462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -15182,8 +14498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15220,8 +14534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15258,8 +14570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15296,8 +14606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15334,8 +14642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15372,8 +14678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15410,8 +14714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15448,8 +14750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15486,8 +14786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15524,8 +14822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15562,8 +14858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15600,8 +14894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15638,8 +14930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15676,8 +14966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15714,8 +15002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15752,8 +15038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15790,8 +15074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15828,8 +15110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -15866,8 +15146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15904,8 +15182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -15942,8 +15218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -15980,8 +15254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16018,8 +15290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16056,8 +15326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16094,8 +15362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16132,8 +15398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -16170,8 +15434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16208,8 +15470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16246,8 +15506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16284,8 +15542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16322,8 +15578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16360,8 +15614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16398,8 +15650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16436,8 +15686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16474,8 +15722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16512,8 +15758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16550,8 +15794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16588,8 +15830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16626,8 +15866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16664,8 +15902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16702,8 +15938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16740,8 +15974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16778,8 +16010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16816,8 +16046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16854,8 +16082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16892,8 +16118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -16930,8 +16154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -16968,8 +16190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -17006,8 +16226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -17044,8 +16262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -17082,8 +16298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -17120,8 +16334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -17158,8 +16370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -17196,8 +16406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17234,8 +16442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17272,8 +16478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17310,8 +16514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17348,8 +16550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17386,8 +16586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17424,8 +16622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17462,8 +16658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17500,8 +16694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17538,8 +16730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17576,8 +16766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17614,8 +16802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17652,8 +16838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17690,8 +16874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17728,8 +16910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17766,8 +16946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17804,8 +16982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17842,8 +17018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17880,8 +17054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17918,8 +17090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17956,8 +17126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17994,8 +17162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -18032,8 +17198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -18070,8 +17234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -18108,8 +17270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18146,8 +17306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18184,8 +17342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18222,8 +17378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18260,8 +17414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18298,8 +17450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18336,8 +17486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18374,8 +17522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18412,8 +17558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18450,8 +17594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18488,8 +17630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18526,8 +17666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18564,8 +17702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18602,8 +17738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18640,8 +17774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18678,8 +17810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18716,8 +17846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18754,8 +17882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18792,8 +17918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18830,8 +17954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18868,8 +17990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18906,8 +18026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18944,8 +18062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18982,8 +18098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -19020,8 +18134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -19058,8 +18170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19096,8 +18206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19134,8 +18242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19172,8 +18278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19210,8 +18314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19248,8 +18350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19286,8 +18386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19324,8 +18422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19362,8 +18458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19400,8 +18494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19438,8 +18530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19476,8 +18566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19514,8 +18602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19552,8 +18638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19590,8 +18674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19628,8 +18710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19666,8 +18746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19704,8 +18782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19742,8 +18818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19780,8 +18854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19818,8 +18890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19856,8 +18926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19894,8 +18962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19932,8 +18998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19970,8 +19034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -20008,8 +19070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -20046,8 +19106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20084,8 +19142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -20122,8 +19178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -20160,8 +19214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20198,8 +19250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20236,8 +19286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20274,8 +19322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20312,8 +19358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20350,8 +19394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20388,8 +19430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20426,8 +19466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20464,8 +19502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20502,8 +19538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20540,8 +19574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20578,8 +19610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20616,8 +19646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20654,8 +19682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20692,8 +19718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20730,8 +19754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20768,8 +19790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20806,8 +19826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20844,8 +19862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20882,8 +19898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20920,8 +19934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20958,8 +19970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20996,8 +20006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21034,8 +20042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21072,8 +20078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21110,8 +20114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21148,8 +20150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21186,8 +20186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21224,8 +20222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21262,8 +20258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21300,8 +20294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21338,8 +20330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21376,8 +20366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21414,8 +20402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21452,8 +20438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21490,8 +20474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21528,8 +20510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21566,8 +20546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21604,8 +20582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21642,8 +20618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21680,8 +20654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21718,8 +20690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21756,8 +20726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21794,8 +20762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21832,8 +20798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21870,8 +20834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21908,8 +20870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21946,8 +20906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21984,8 +20942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -22022,8 +20978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -22060,8 +21014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -22098,8 +21050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -22136,8 +21086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -22174,8 +21122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22212,8 +21158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22250,8 +21194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22288,8 +21230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22326,8 +21266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22364,8 +21302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22402,8 +21338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22440,8 +21374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22478,8 +21410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22516,8 +21446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22554,8 +21482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22592,8 +21518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22630,8 +21554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22668,8 +21590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22706,8 +21626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22744,8 +21662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22782,8 +21698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22820,8 +21734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22858,8 +21770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22896,8 +21806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22934,8 +21842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22972,8 +21878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23010,8 +21914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23048,8 +21950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23086,8 +21986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23124,8 +22022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -23162,8 +22058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -23200,8 +22094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23238,8 +22130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23276,8 +22166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23314,8 +22202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23352,8 +22238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23390,8 +22274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23428,8 +22310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23466,8 +22346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23504,8 +22382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23542,8 +22418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23580,8 +22454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23618,8 +22490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23656,8 +22526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23694,8 +22562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23732,8 +22598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23770,8 +22634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23808,8 +22670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23846,8 +22706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23884,8 +22742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23922,8 +22778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23960,8 +22814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23998,8 +22850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24036,8 +22886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -24074,8 +22922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24112,8 +22958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -24150,8 +22994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -24188,8 +23030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24226,8 +23066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24264,8 +23102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24302,8 +23138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24340,8 +23174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24378,8 +23210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24416,8 +23246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24454,8 +23282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24492,8 +23318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24530,8 +23354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24568,8 +23390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24606,8 +23426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24644,8 +23462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24682,8 +23498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24720,8 +23534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24758,8 +23570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24796,8 +23606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24834,8 +23642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24872,8 +23678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24910,8 +23714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24948,8 +23750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24986,8 +23786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25024,8 +23822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25062,8 +23858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25100,8 +23894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25138,8 +23930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25176,8 +23966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25214,8 +24002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25252,8 +24038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25290,8 +24074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25328,8 +24110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25366,8 +24146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25404,8 +24182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25442,8 +24218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25480,8 +24254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25518,8 +24290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25556,8 +24326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25594,8 +24362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25632,8 +24398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25670,8 +24434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25708,8 +24470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25746,8 +24506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25784,8 +24542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25822,8 +24578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25860,8 +24614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25898,8 +24650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25936,8 +24686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25974,8 +24722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26012,8 +24758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26050,8 +24794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26088,8 +24830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26126,8 +24866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26164,8 +24902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26202,8 +24938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26240,8 +24974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26278,8 +25010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26316,8 +25046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26354,8 +25082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26392,8 +25118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26430,8 +25154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26468,8 +25190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.1.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.1.1.sarif
@@ -2185,6 +2185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2220,6 +2223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2255,6 +2261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2290,6 +2299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2325,6 +2337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2360,6 +2375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2395,6 +2413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2430,6 +2451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2465,6 +2489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2500,6 +2527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2535,6 +2565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2570,6 +2603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2605,6 +2641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2640,6 +2679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2675,6 +2717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2710,6 +2755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2745,6 +2793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2780,6 +2831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2815,6 +2869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2850,6 +2907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2885,6 +2945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2920,6 +2983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2955,6 +3021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -2990,6 +3059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3025,6 +3097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3060,6 +3135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3095,6 +3173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3130,6 +3211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3165,6 +3249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3200,6 +3287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3235,6 +3325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3270,6 +3363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3305,6 +3401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3340,6 +3439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3375,6 +3477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3410,6 +3515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3445,6 +3553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3480,6 +3591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3515,6 +3629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3550,6 +3667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3585,6 +3705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3620,6 +3743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3655,6 +3781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3690,6 +3819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3725,6 +3857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3760,6 +3895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3795,6 +3933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3830,6 +3971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3865,6 +4009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3900,6 +4047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3935,6 +4085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3970,6 +4123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4005,6 +4161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4040,6 +4199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4075,6 +4237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4110,6 +4275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4145,6 +4313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4180,6 +4351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4215,6 +4389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4250,6 +4427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4285,6 +4465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4320,6 +4503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4355,6 +4541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4390,6 +4579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4425,6 +4617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4460,6 +4655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4495,6 +4693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4530,6 +4731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4565,6 +4769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4600,6 +4807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4635,6 +4845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4670,6 +4883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4705,6 +4921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4740,6 +4959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4775,6 +4997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4810,6 +5035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4845,6 +5073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4880,6 +5111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4915,6 +5149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4950,6 +5187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4985,6 +5225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5020,6 +5263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5055,6 +5301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5090,6 +5339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5125,6 +5377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5160,6 +5415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5195,6 +5453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5230,6 +5491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5265,6 +5529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5300,6 +5567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5335,6 +5605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5370,6 +5643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5405,6 +5681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5440,6 +5719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5475,6 +5757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5510,6 +5795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5545,6 +5833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5580,6 +5871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5615,6 +5909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5650,6 +5947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5685,6 +5985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5720,6 +6023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5755,6 +6061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5790,6 +6099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5825,6 +6137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5860,6 +6175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5895,6 +6213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5930,6 +6251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5965,6 +6289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6000,6 +6327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6035,6 +6365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6070,6 +6403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6105,6 +6441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6140,6 +6479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6175,6 +6517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6210,6 +6555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6245,6 +6593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6280,6 +6631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6315,6 +6669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6350,6 +6707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6385,6 +6745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6420,6 +6783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6455,6 +6821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6490,6 +6859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6525,6 +6897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6560,6 +6935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6595,6 +6973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6630,6 +7011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6665,6 +7049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6700,6 +7087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6735,6 +7125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6770,6 +7163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6805,6 +7201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6840,6 +7239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6875,6 +7277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6910,6 +7315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6945,6 +7353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6980,6 +7391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7015,6 +7429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7050,6 +7467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7085,6 +7505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7120,6 +7543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7155,6 +7581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7190,6 +7619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7225,6 +7657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7260,6 +7695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7295,6 +7733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7330,6 +7771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7365,6 +7809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7400,6 +7847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7435,6 +7885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7470,6 +7923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7505,6 +7961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7540,6 +7999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7575,6 +8037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7610,6 +8075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7645,6 +8113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7680,6 +8151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7715,6 +8189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7750,6 +8227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7785,6 +8265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7820,6 +8303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7855,6 +8341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7890,6 +8379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7925,6 +8417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7960,6 +8455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7995,6 +8493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8030,6 +8531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8065,6 +8569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8100,6 +8607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8135,6 +8645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8170,6 +8683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8205,6 +8721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8240,6 +8759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8275,6 +8797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8310,6 +8835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8345,6 +8873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8380,6 +8911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8415,6 +8949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8450,6 +8987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8485,6 +9025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8520,6 +9063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8555,6 +9101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8590,6 +9139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8625,6 +9177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8660,6 +9215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8695,6 +9253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8730,6 +9291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8765,6 +9329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8800,6 +9367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8835,6 +9405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8870,6 +9443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8905,6 +9481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -8940,6 +9519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -8975,6 +9557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9010,6 +9595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9045,6 +9633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9080,6 +9671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9115,6 +9709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9150,6 +9747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9185,6 +9785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9220,6 +9823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9255,6 +9861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9290,6 +9899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9325,6 +9937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9360,6 +9975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9395,6 +10013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9430,6 +10051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9465,6 +10089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9500,6 +10127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9535,6 +10165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9570,6 +10203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9605,6 +10241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9640,6 +10279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9675,6 +10317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9710,6 +10355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9745,6 +10393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9780,6 +10431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9815,6 +10469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9850,6 +10507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9885,6 +10545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9920,6 +10583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9955,6 +10621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9990,6 +10659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10025,6 +10697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10060,6 +10735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10095,6 +10773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10130,6 +10811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10165,6 +10849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10200,6 +10887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10235,6 +10925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10270,6 +10963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10305,6 +11001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10340,6 +11039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10375,6 +11077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10410,6 +11115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10445,6 +11153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10480,6 +11191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10515,6 +11229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10550,6 +11267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10585,6 +11305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10620,6 +11343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10655,6 +11381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10690,6 +11419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10725,6 +11457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10760,6 +11495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10795,6 +11533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10830,6 +11571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10865,6 +11609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10900,6 +11647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10935,6 +11685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10970,6 +11723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11005,6 +11761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11040,6 +11799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11075,6 +11837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11110,6 +11875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11145,6 +11913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11180,6 +11951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11215,6 +11989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11250,6 +12027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11285,6 +12065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11320,6 +12103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11355,6 +12141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11390,6 +12179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11425,6 +12217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11460,6 +12255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11495,6 +12293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11530,6 +12331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11565,6 +12369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11600,6 +12407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11635,6 +12445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11670,6 +12483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11705,6 +12521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11740,6 +12559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11775,6 +12597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11810,6 +12635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11845,6 +12673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11880,6 +12711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11915,6 +12749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11950,6 +12787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11985,6 +12825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12020,6 +12863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12055,6 +12901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12090,6 +12939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12125,6 +12977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12160,6 +13015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12195,6 +13053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12230,6 +13091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12265,6 +13129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12300,6 +13167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12335,6 +13205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12370,6 +13243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12405,6 +13281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12440,6 +13319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12475,6 +13357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12510,6 +13395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12545,6 +13433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12580,6 +13471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12615,6 +13509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12650,6 +13547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12685,6 +13585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12720,6 +13623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12755,6 +13661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12790,6 +13699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12825,6 +13737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12860,6 +13775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12895,6 +13813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12930,6 +13851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12965,6 +13889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13000,6 +13927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13035,6 +13965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13070,6 +14003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13105,6 +14041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13140,6 +14079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13175,6 +14117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13210,6 +14155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13245,6 +14193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13280,6 +14231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13315,6 +14269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13350,6 +14307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -13385,6 +14345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -13420,6 +14383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -13455,6 +14421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -13490,6 +14459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -13525,6 +14497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13560,6 +14535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -13595,6 +14573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13630,6 +14611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -13665,6 +14649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -13700,6 +14687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13735,6 +14725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13770,6 +14763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -13805,6 +14801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13840,6 +14839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -13875,6 +14877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -13910,6 +14915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13945,6 +14953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13980,6 +14991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -14015,6 +15029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -14050,6 +15067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -14085,6 +15105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -14120,6 +15143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -14155,6 +15181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14190,6 +15219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -14225,6 +15257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -14260,6 +15295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -14295,6 +15333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -14330,6 +15371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -14365,6 +15409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -14400,6 +15447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -14435,6 +15485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14470,6 +15523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -14505,6 +15561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14540,6 +15599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -14575,6 +15637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14610,6 +15675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -14645,6 +15713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14680,6 +15751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -14715,6 +15789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -14750,6 +15827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -14785,6 +15865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14820,6 +15903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -14855,6 +15941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -14890,6 +15979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -14925,6 +16017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -14960,6 +16055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -14995,6 +16093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15030,6 +16131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -15065,6 +16169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -15100,6 +16207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -15135,6 +16245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15170,6 +16283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -15205,6 +16321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -15240,6 +16359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -15275,6 +16397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -15310,6 +16435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -15345,6 +16473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -15380,6 +16511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -15415,6 +16549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -15450,6 +16587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -15485,6 +16625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -15520,6 +16663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -15555,6 +16701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -15590,6 +16739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -15625,6 +16777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -15660,6 +16815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -15695,6 +16853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -15730,6 +16891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -15765,6 +16929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -15800,6 +16967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -15835,6 +17005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -15870,6 +17043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -15905,6 +17081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -15940,6 +17119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15975,6 +17157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -16010,6 +17195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -16045,6 +17233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -16080,6 +17271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -16115,6 +17309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -16150,6 +17347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -16185,6 +17385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -16220,6 +17423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -16255,6 +17461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -16290,6 +17499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -16325,6 +17537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -16360,6 +17575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -16395,6 +17613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -16430,6 +17651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16465,6 +17689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -16500,6 +17727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -16535,6 +17765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16570,6 +17803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -16605,6 +17841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -16640,6 +17879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -16675,6 +17917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -16710,6 +17955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -16745,6 +17993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -16780,6 +18031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -16815,6 +18069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -16850,6 +18107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -16885,6 +18145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16920,6 +18183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -16955,6 +18221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -16990,6 +18259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17025,6 +18297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17060,6 +18335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -17095,6 +18373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17130,6 +18411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17165,6 +18449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -17200,6 +18487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17235,6 +18525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17270,6 +18563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -17305,6 +18601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -17340,6 +18639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17375,6 +18677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -17410,6 +18715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -17445,6 +18753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -17480,6 +18791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17515,6 +18829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17550,6 +18867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17585,6 +18905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17620,6 +18943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -17655,6 +18981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -17690,6 +19019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -17725,6 +19057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -17760,6 +19095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -17795,6 +19133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -17830,6 +19171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -17865,6 +19209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -17900,6 +19247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -17935,6 +19285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -17970,6 +19323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18005,6 +19361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18040,6 +19399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18075,6 +19437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18110,6 +19475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -18145,6 +19513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -18180,6 +19551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -18215,6 +19589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18250,6 +19627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18285,6 +19665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18320,6 +19703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -18355,6 +19741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -18390,6 +19779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -18425,6 +19817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -18460,6 +19855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -18495,6 +19893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -18530,6 +19931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18565,6 +19969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -18600,6 +20007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -18635,6 +20045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18670,6 +20083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -18705,6 +20121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -18740,6 +20159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -18775,6 +20197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -18810,6 +20235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -18845,6 +20273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18880,6 +20311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -18915,6 +20349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -18950,6 +20387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -18985,6 +20425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19020,6 +20463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19055,6 +20501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -19090,6 +20539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19125,6 +20577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -19160,6 +20615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -19195,6 +20653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19230,6 +20691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19265,6 +20729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19300,6 +20767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19335,6 +20805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19370,6 +20843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19405,6 +20881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19440,6 +20919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19475,6 +20957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -19510,6 +20995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19545,6 +21033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -19580,6 +21071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -19615,6 +21109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19650,6 +21147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19685,6 +21185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -19720,6 +21223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19755,6 +21261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19790,6 +21299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19825,6 +21337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -19860,6 +21375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -19895,6 +21413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19930,6 +21451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -19965,6 +21489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -20000,6 +21527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -20035,6 +21565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20070,6 +21603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20105,6 +21641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20140,6 +21679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20175,6 +21717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -20210,6 +21755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -20245,6 +21793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20280,6 +21831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20315,6 +21869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -20350,6 +21907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -20385,6 +21945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -20420,6 +21983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -20455,6 +22021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -20490,6 +22059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -20525,6 +22097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -20560,6 +22135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -20595,6 +22173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -20630,6 +22211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -20665,6 +22249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -20700,6 +22287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -20735,6 +22325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -20770,6 +22363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -20805,6 +22401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -20840,6 +22439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20875,6 +22477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -20910,6 +22515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -20945,6 +22553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -20980,6 +22591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21015,6 +22629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21050,6 +22667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21085,6 +22705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -21120,6 +22743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -21155,6 +22781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -21190,6 +22819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -21225,6 +22857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -21260,6 +22895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -21295,6 +22933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -21330,6 +22971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21365,6 +23009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21400,6 +23047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21435,6 +23085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21470,6 +23123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -21505,6 +23161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -21540,6 +23199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21575,6 +23237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -21610,6 +23275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21645,6 +23313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -21680,6 +23351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -21715,6 +23389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -21750,6 +23427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -21785,6 +23465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -21820,6 +23503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -21855,6 +23541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -21890,6 +23579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -21925,6 +23617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -21960,6 +23655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -21995,6 +23693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -22030,6 +23731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -22065,6 +23769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -22100,6 +23807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22135,6 +23845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22170,6 +23883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -22205,6 +23921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -22240,6 +23959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -22275,6 +23997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -22310,6 +24035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -22345,6 +24073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22380,6 +24111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -22415,6 +24149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -22450,6 +24187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22485,6 +24225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -22520,6 +24263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -22555,6 +24301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22590,6 +24339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -22625,6 +24377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -22660,6 +24415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -22695,6 +24453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -22730,6 +24491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -22765,6 +24529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -22800,6 +24567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -22835,6 +24605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -22870,6 +24643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -22905,6 +24681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -22940,6 +24719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -22975,6 +24757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23010,6 +24795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -23045,6 +24833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -23080,6 +24871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -23115,6 +24909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -23150,6 +24947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23185,6 +24985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23220,6 +25023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23255,6 +25061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23290,6 +25099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23325,6 +25137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23360,6 +25175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23395,6 +25213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23430,6 +25251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23465,6 +25289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23500,6 +25327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -23535,6 +25365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -23570,6 +25403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -23605,6 +25441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -23640,6 +25479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -23675,6 +25517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -23710,6 +25555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -23745,6 +25593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -23780,6 +25631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -23815,6 +25669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23850,6 +25707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23885,6 +25745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23920,6 +25783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -23955,6 +25821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23990,6 +25859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24025,6 +25897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24060,6 +25935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24095,6 +25973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24130,6 +26011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -24165,6 +26049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24200,6 +26087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24235,6 +26125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24270,6 +26163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -24305,6 +26201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24340,6 +26239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -24375,6 +26277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24410,6 +26315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24445,6 +26353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -24480,6 +26391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -24515,6 +26429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -24550,6 +26467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.2.0.sarif
+++ b/src/test-resources/w3citylights-axe-v4.2.0.sarif
@@ -2282,8 +2282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2320,8 +2318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2358,8 +2354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2396,8 +2390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2434,8 +2426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2472,8 +2462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2510,8 +2498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2548,8 +2534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2586,8 +2570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2624,8 +2606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2662,8 +2642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2700,8 +2678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2738,8 +2714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2776,8 +2750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2814,8 +2786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2852,8 +2822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2890,8 +2858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2928,8 +2894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2966,8 +2930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -3004,8 +2966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3042,8 +3002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3080,8 +3038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3118,8 +3074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3156,8 +3110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3194,8 +3146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3232,8 +3182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3270,8 +3218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3308,8 +3254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3346,8 +3290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3384,8 +3326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3422,8 +3362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3460,8 +3398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3498,8 +3434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3536,8 +3470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3574,8 +3506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3612,8 +3542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3650,8 +3578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3688,8 +3614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3726,8 +3650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3764,8 +3686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3802,8 +3722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3840,8 +3758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3878,8 +3794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3916,8 +3830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3954,8 +3866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3992,8 +3902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4030,8 +3938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4068,8 +3974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -4106,8 +4010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4144,8 +4046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4182,8 +4082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4220,8 +4118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4258,8 +4154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4296,8 +4190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4334,8 +4226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4372,8 +4262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4410,8 +4298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4448,8 +4334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4486,8 +4370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4524,8 +4406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4562,8 +4442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4600,8 +4478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4638,8 +4514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4676,8 +4550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4714,8 +4586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4752,8 +4622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4790,8 +4658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4828,8 +4694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4866,8 +4730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4904,8 +4766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4942,8 +4802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4980,8 +4838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5018,8 +4874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5056,8 +4910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5094,8 +4946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5132,8 +4982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5170,8 +5018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5208,8 +5054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5246,8 +5090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5284,8 +5126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5322,8 +5162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5360,8 +5198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5398,8 +5234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5436,8 +5270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5474,8 +5306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5512,8 +5342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5550,8 +5378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5588,8 +5414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5626,8 +5450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5664,8 +5486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5702,8 +5522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5740,8 +5558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5778,8 +5594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5816,8 +5630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5854,8 +5666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5892,8 +5702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5930,8 +5738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5968,8 +5774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -6006,8 +5810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -6044,8 +5846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -6082,8 +5882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -6120,8 +5918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6158,8 +5954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6196,8 +5990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6234,8 +6026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6272,8 +6062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6310,8 +6098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6348,8 +6134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6386,8 +6170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6424,8 +6206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6462,8 +6242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6500,8 +6278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6538,8 +6314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6576,8 +6350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6614,8 +6386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6652,8 +6422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6690,8 +6458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6728,8 +6494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6766,8 +6530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6804,8 +6566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6842,8 +6602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6880,8 +6638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6918,8 +6674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6956,8 +6710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6994,8 +6746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -7032,8 +6782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -7070,8 +6818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -7108,8 +6854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -7146,8 +6890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -7184,8 +6926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -7222,8 +6962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7260,8 +6998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7298,8 +7034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7336,8 +7070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7374,8 +7106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7412,8 +7142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7450,8 +7178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7488,8 +7214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7526,8 +7250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7564,8 +7286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7602,8 +7322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7640,8 +7358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7678,8 +7394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7716,8 +7430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7754,8 +7466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7792,8 +7502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7830,8 +7538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7868,8 +7574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7906,8 +7610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7944,8 +7646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7982,8 +7682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -8020,8 +7718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8058,8 +7754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -8096,8 +7790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -8134,8 +7826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -8172,8 +7862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -8210,8 +7898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -8248,8 +7934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -8286,8 +7970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8324,8 +8006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8362,8 +8042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8400,8 +8078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8438,8 +8114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8476,8 +8150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8514,8 +8186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8552,8 +8222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8590,8 +8258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8628,8 +8294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8666,8 +8330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8704,8 +8366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8742,8 +8402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8780,8 +8438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8818,8 +8474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8856,8 +8510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8894,8 +8546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8932,8 +8582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8970,8 +8618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9008,8 +8654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9046,8 +8690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9084,8 +8726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9122,8 +8762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9160,8 +8798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9198,8 +8834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9236,8 +8870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9274,8 +8906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9312,8 +8942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9350,8 +8978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9388,8 +9014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9426,8 +9050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9464,8 +9086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9502,8 +9122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9540,8 +9158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9578,8 +9194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9616,8 +9230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9654,8 +9266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9692,8 +9302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9730,8 +9338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9768,8 +9374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9806,8 +9410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9844,8 +9446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9882,8 +9482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9920,8 +9518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9958,8 +9554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9996,8 +9590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10034,8 +9626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10072,8 +9662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10110,8 +9698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10148,8 +9734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10186,8 +9770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10224,8 +9806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10262,8 +9842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10300,8 +9878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10338,8 +9914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10376,8 +9950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10414,8 +9986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10452,8 +10022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10490,8 +10058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10528,8 +10094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10566,8 +10130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10604,8 +10166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10642,8 +10202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10680,8 +10238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10718,8 +10274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10756,8 +10310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10794,8 +10346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10832,8 +10382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10870,8 +10418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10908,8 +10454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10946,8 +10490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10984,8 +10526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11022,8 +10562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11060,8 +10598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -11098,8 +10634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -11136,8 +10670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11174,8 +10706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -11212,8 +10742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11250,8 +10778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -11288,8 +10814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11326,8 +10850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11364,8 +10886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11402,8 +10922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11440,8 +10958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11478,8 +10994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11516,8 +11030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11554,8 +11066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11592,8 +11102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11630,8 +11138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11668,8 +11174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11706,8 +11210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11744,8 +11246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11782,8 +11282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11820,8 +11318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11858,8 +11354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11896,8 +11390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11934,8 +11426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11972,8 +11462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -12010,8 +11498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -12048,8 +11534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12086,8 +11570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -12124,8 +11606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12162,8 +11642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -12200,8 +11678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12238,8 +11714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -12276,8 +11750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12314,8 +11786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12352,8 +11822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12390,8 +11858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12428,8 +11894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12466,8 +11930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12504,8 +11966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12542,8 +12002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12580,8 +12038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12618,8 +12074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12656,8 +12110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12694,8 +12146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12732,8 +12182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12770,8 +12218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12808,8 +12254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12846,8 +12290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12884,8 +12326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12922,8 +12362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12960,8 +12398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12998,8 +12434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13036,8 +12470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13074,8 +12506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13112,8 +12542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13150,8 +12578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -13188,8 +12614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -13226,8 +12650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -13264,8 +12686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13302,8 +12722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13340,8 +12758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13378,8 +12794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13416,8 +12830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13454,8 +12866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13492,8 +12902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13530,8 +12938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13568,8 +12974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13606,8 +13010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13644,8 +13046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13682,8 +13082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13720,8 +13118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13758,8 +13154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13796,8 +13190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13834,8 +13226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13872,8 +13262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13910,8 +13298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13948,8 +13334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13986,8 +13370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -14024,8 +13406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14062,8 +13442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14100,8 +13478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14138,8 +13514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14176,8 +13550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14214,8 +13586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14252,8 +13622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14290,8 +13658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14328,8 +13694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14366,8 +13730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14404,8 +13766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14442,8 +13802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14480,8 +13838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14518,8 +13874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14556,8 +13910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14594,8 +13946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -14632,8 +13982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -14670,8 +14018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -14708,8 +14054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -14746,8 +14090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -14784,8 +14126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -14822,8 +14162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -14860,8 +14198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -14898,8 +14234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -14936,8 +14270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -14974,8 +14306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15012,8 +14342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15050,8 +14378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15088,8 +14414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15126,8 +14450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15164,8 +14486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15202,8 +14522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15240,8 +14558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -15278,8 +14594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -15316,8 +14630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -15354,8 +14666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -15392,8 +14702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -15430,8 +14738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15468,8 +14774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15506,8 +14810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -15544,8 +14846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -15582,8 +14882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15620,8 +14918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -15658,8 +14954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15696,8 +14990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -15734,8 +15026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15772,8 +15062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -15810,8 +15098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15848,8 +15134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15886,8 +15170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15924,8 +15206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15962,8 +15242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -16000,8 +15278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16038,8 +15314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16076,8 +15350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16114,8 +15386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -16152,8 +15422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -16190,8 +15458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16228,8 +15494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -16266,8 +15530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16304,8 +15566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -16342,8 +15602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -16380,8 +15638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16418,8 +15674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -16456,8 +15710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16494,8 +15746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -16532,8 +15782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -16570,8 +15818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -16608,8 +15854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -16646,8 +15890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -16684,8 +15926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -16722,8 +15962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -16760,8 +15998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -16798,8 +16034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -16836,8 +16070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -16874,8 +16106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -16912,8 +16142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16950,8 +16178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -16988,8 +16214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -17026,8 +16250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -17064,8 +16286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -17102,8 +16322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -17140,8 +16358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -17178,8 +16394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -17216,8 +16430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -17254,8 +16466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -17292,8 +16502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -17330,8 +16538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -17368,8 +16574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -17406,8 +16610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -17444,8 +16646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -17482,8 +16682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -17520,8 +16718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -17558,8 +16754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -17596,8 +16790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -17634,8 +16826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -17672,8 +16862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -17710,8 +16898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -17748,8 +16934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -17786,8 +16970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -17824,8 +17006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -17862,8 +17042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -17900,8 +17078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -17938,8 +17114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -17976,8 +17150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -18014,8 +17186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -18052,8 +17222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -18090,8 +17258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18128,8 +17294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -18166,8 +17330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -18204,8 +17366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18242,8 +17402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18280,8 +17438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -18318,8 +17474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -18356,8 +17510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -18394,8 +17546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -18432,8 +17582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -18470,8 +17618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -18508,8 +17654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -18546,8 +17690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -18584,8 +17726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -18622,8 +17762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18660,8 +17798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -18698,8 +17834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -18736,8 +17870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -18774,8 +17906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -18812,8 +17942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -18850,8 +17978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -18888,8 +18014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -18926,8 +18050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -18964,8 +18086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -19002,8 +18122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -19040,8 +18158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -19078,8 +18194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -19116,8 +18230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -19154,8 +18266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -19192,8 +18302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -19230,8 +18338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -19268,8 +18374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -19306,8 +18410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -19344,8 +18446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -19382,8 +18482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -19420,8 +18518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -19458,8 +18554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -19496,8 +18590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -19534,8 +18626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -19572,8 +18662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -19610,8 +18698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -19648,8 +18734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -19686,8 +18770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -19724,8 +18806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -19762,8 +18842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -19800,8 +18878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -19838,8 +18914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -19876,8 +18950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19914,8 +18986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -19952,8 +19022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19990,8 +19058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20028,8 +19094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -20066,8 +19130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -20104,8 +19166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -20142,8 +19202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -20180,8 +19238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -20218,8 +19274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -20256,8 +19310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -20294,8 +19346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -20332,8 +19382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20370,8 +19418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20408,8 +19454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -20446,8 +19490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -20484,8 +19526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -20522,8 +19562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20560,8 +19598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -20598,8 +19634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20636,8 +19670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20674,8 +19706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20712,8 +19742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20750,8 +19778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20788,8 +19814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -20826,8 +19850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -20864,8 +19886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20902,8 +19922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -20940,8 +19958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -20978,8 +19994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -21016,8 +20030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21054,8 +20066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21092,8 +20102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21130,8 +20138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21168,8 +20174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -21206,8 +20210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -21244,8 +20246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -21282,8 +20282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21320,8 +20318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21358,8 +20354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21396,8 +20390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21434,8 +20426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -21472,8 +20462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -21510,8 +20498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -21548,8 +20534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21586,8 +20570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21624,8 +20606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21662,8 +20642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21700,8 +20678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -21738,8 +20714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -21776,8 +20750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -21814,8 +20786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21852,8 +20822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21890,8 +20858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21928,8 +20894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21966,8 +20930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -22004,8 +20966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -22042,8 +21002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -22080,8 +21038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -22118,8 +21074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -22156,8 +21110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22194,8 +21146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -22232,8 +21182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -22270,8 +21218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22308,8 +21254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -22346,8 +21290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -22384,8 +21326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22422,8 +21362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -22460,8 +21398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -22498,8 +21434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22536,8 +21470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -22574,8 +21506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22612,8 +21542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22650,8 +21578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22688,8 +21614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22726,8 +21650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22764,8 +21686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22802,8 +21722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -22840,8 +21758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22878,8 +21794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22916,8 +21830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22954,8 +21866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22992,8 +21902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23030,8 +21938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -23068,8 +21974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23106,8 +22010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -23144,8 +22046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23182,8 +22082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -23220,8 +22118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23258,8 +22154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -23296,8 +22190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23334,8 +22226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23372,8 +22262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23410,8 +22298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23448,8 +22334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23486,8 +22370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -23524,8 +22406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23562,8 +22442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23600,8 +22478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -23638,8 +22514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23676,8 +22550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23714,8 +22586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -23752,8 +22622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23790,8 +22658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -23828,8 +22694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23866,8 +22730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23904,8 +22766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -23942,8 +22802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -23980,8 +22838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -24018,8 +22874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -24056,8 +22910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -24094,8 +22946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -24132,8 +22982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -24170,8 +23018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -24208,8 +23054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -24246,8 +23090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -24284,8 +23126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -24322,8 +23162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -24360,8 +23198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -24398,8 +23234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -24436,8 +23270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -24474,8 +23306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24512,8 +23342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -24550,8 +23378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -24588,8 +23414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -24626,8 +23450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -24664,8 +23486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24702,8 +23522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -24740,8 +23558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -24778,8 +23594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -24816,8 +23630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -24854,8 +23666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -24892,8 +23702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -24930,8 +23738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -24968,8 +23774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -25006,8 +23810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -25044,8 +23846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -25082,8 +23882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -25120,8 +23918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -25158,8 +23954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -25196,8 +23990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -25234,8 +24026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -25272,8 +24062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25310,8 +24098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -25348,8 +24134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -25386,8 +24170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -25424,8 +24206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25462,8 +24242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -25500,8 +24278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -25538,8 +24314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -25576,8 +24350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -25614,8 +24386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -25652,8 +24422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25690,8 +24458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25728,8 +24494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25766,8 +24530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25804,8 +24566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25842,8 +24602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25880,8 +24638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25918,8 +24674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25956,8 +24710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25994,8 +24746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -26032,8 +24782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -26070,8 +24818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -26108,8 +24854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -26146,8 +24890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -26184,8 +24926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -26222,8 +24962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -26260,8 +24998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -26298,8 +25034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -26336,8 +25070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -26374,8 +25106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -26412,8 +25142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -26450,8 +25178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -26488,8 +25214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -26526,8 +25250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -26564,8 +25286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -26602,8 +25322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -26640,8 +25358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -26678,8 +25394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -26716,8 +25430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -26754,8 +25466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -26792,8 +25502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -26830,8 +25538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -26868,8 +25574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -26906,8 +25610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -26944,8 +25646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -26982,8 +25682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -27020,8 +25718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -27058,8 +25754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -27096,8 +25790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -27134,8 +25826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -27172,8 +25862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -27210,8 +25898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -27248,8 +25934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -27286,8 +25970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -27324,8 +26006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -27362,8 +26042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -27400,8 +26078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -27438,8 +26114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -27476,8 +26150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -27514,8 +26186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -27552,8 +26222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -27590,8 +26258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -27628,8 +26294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -27666,8 +26330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -27704,8 +26366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -27742,8 +26402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -27780,8 +26438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -27818,8 +26474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -27856,8 +26510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -27894,8 +26546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27932,8 +26582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27970,8 +26618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28008,8 +26654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28046,8 +26690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28084,8 +26726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28122,8 +26762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28160,8 +26798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28198,8 +26834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -28236,8 +26870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -28274,8 +26906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28312,8 +26942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28350,8 +26978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28388,8 +27014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28426,8 +27050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28464,8 +27086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28502,8 +27122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28540,8 +27158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28578,8 +27194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -28616,8 +27230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -28654,8 +27266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -28692,8 +27302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.2.0.sarif
+++ b/src/test-resources/w3citylights-axe-v4.2.0.sarif
@@ -2281,6 +2281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2316,6 +2319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2351,6 +2357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2386,6 +2395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2421,6 +2433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2456,6 +2471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2491,6 +2509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2526,6 +2547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2561,6 +2585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2596,6 +2623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2631,6 +2661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2666,6 +2699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2701,6 +2737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2736,6 +2775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2771,6 +2813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2806,6 +2851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2841,6 +2889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2876,6 +2927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2911,6 +2965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2946,6 +3003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2981,6 +3041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3016,6 +3079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3051,6 +3117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3086,6 +3155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3121,6 +3193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3156,6 +3231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3191,6 +3269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3226,6 +3307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3261,6 +3345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3296,6 +3383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3331,6 +3421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3366,6 +3459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3401,6 +3497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3436,6 +3535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3471,6 +3573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3506,6 +3611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3541,6 +3649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3576,6 +3687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3611,6 +3725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3646,6 +3763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3681,6 +3801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3716,6 +3839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3751,6 +3877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3786,6 +3915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3821,6 +3953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3856,6 +3991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3891,6 +4029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3926,6 +4067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3961,6 +4105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3996,6 +4143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4031,6 +4181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4066,6 +4219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4101,6 +4257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4136,6 +4295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4171,6 +4333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4206,6 +4371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4241,6 +4409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4276,6 +4447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4311,6 +4485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4346,6 +4523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4381,6 +4561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4416,6 +4599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4451,6 +4637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4486,6 +4675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4521,6 +4713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4556,6 +4751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4591,6 +4789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4626,6 +4827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4661,6 +4865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4696,6 +4903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4731,6 +4941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4766,6 +4979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4801,6 +5017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4836,6 +5055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4871,6 +5093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4906,6 +5131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4941,6 +5169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4976,6 +5207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5011,6 +5245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5046,6 +5283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5081,6 +5321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5116,6 +5359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5151,6 +5397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5186,6 +5435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5221,6 +5473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5256,6 +5511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5291,6 +5549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5326,6 +5587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5361,6 +5625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5396,6 +5663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5431,6 +5701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5466,6 +5739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5501,6 +5777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5536,6 +5815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5571,6 +5853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5606,6 +5891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5641,6 +5929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5676,6 +5967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5711,6 +6005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5746,6 +6043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5781,6 +6081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5816,6 +6119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5851,6 +6157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5886,6 +6195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5921,6 +6233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5956,6 +6271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5991,6 +6309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6026,6 +6347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6061,6 +6385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6096,6 +6423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6131,6 +6461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6166,6 +6499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6201,6 +6537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6236,6 +6575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6271,6 +6613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6306,6 +6651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6341,6 +6689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6376,6 +6727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6411,6 +6765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6446,6 +6803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6481,6 +6841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6516,6 +6879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6551,6 +6917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6586,6 +6955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6621,6 +6993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6656,6 +7031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6691,6 +7069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6726,6 +7107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6761,6 +7145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6796,6 +7183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6831,6 +7221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6866,6 +7259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6901,6 +7297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6936,6 +7335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6971,6 +7373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7006,6 +7411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7041,6 +7449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7076,6 +7487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7111,6 +7525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7146,6 +7563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7181,6 +7601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7216,6 +7639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7251,6 +7677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7286,6 +7715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7321,6 +7753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7356,6 +7791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7391,6 +7829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7426,6 +7867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7461,6 +7905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7496,6 +7943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7531,6 +7981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7566,6 +8019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7601,6 +8057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7636,6 +8095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7671,6 +8133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7706,6 +8171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7741,6 +8209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7776,6 +8247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7811,6 +8285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7846,6 +8323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7881,6 +8361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7916,6 +8399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7951,6 +8437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7986,6 +8475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8021,6 +8513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8056,6 +8551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8091,6 +8589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8126,6 +8627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8161,6 +8665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8196,6 +8703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8231,6 +8741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8266,6 +8779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8301,6 +8817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8336,6 +8855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8371,6 +8893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8406,6 +8931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8441,6 +8969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8476,6 +9007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8511,6 +9045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8546,6 +9083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8581,6 +9121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8616,6 +9159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8651,6 +9197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8686,6 +9235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8721,6 +9273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8756,6 +9311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8791,6 +9349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8826,6 +9387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8861,6 +9425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8896,6 +9463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8931,6 +9501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8966,6 +9539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9001,6 +9577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9036,6 +9615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9071,6 +9653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9106,6 +9691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9141,6 +9729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9176,6 +9767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9211,6 +9805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9246,6 +9843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9281,6 +9881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9316,6 +9919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9351,6 +9957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9386,6 +9995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9421,6 +10033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9456,6 +10071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9491,6 +10109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9526,6 +10147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9561,6 +10185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9596,6 +10223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9631,6 +10261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9666,6 +10299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9701,6 +10337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9736,6 +10375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9771,6 +10413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9806,6 +10451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9841,6 +10489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9876,6 +10527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9911,6 +10565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9946,6 +10603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9981,6 +10641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10016,6 +10679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10051,6 +10717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10086,6 +10755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10121,6 +10793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10156,6 +10831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10191,6 +10869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10226,6 +10907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10261,6 +10945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10296,6 +10983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10331,6 +11021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10366,6 +11059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10401,6 +11097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10436,6 +11135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10471,6 +11173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10506,6 +11211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10541,6 +11249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10576,6 +11287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10611,6 +11325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10646,6 +11363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10681,6 +11401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10716,6 +11439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10751,6 +11477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10786,6 +11515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10821,6 +11553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10856,6 +11591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10891,6 +11629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10926,6 +11667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10961,6 +11705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10996,6 +11743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11031,6 +11781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11066,6 +11819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11101,6 +11857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11136,6 +11895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11171,6 +11933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11206,6 +11971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11241,6 +12009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11276,6 +12047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11311,6 +12085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11346,6 +12123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11381,6 +12161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11416,6 +12199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11451,6 +12237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11486,6 +12275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11521,6 +12313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11556,6 +12351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11591,6 +12389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11626,6 +12427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11661,6 +12465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11696,6 +12503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11731,6 +12541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11766,6 +12579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11801,6 +12617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11836,6 +12655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11871,6 +12693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11906,6 +12731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11941,6 +12769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11976,6 +12807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12011,6 +12845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12046,6 +12883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12081,6 +12921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12116,6 +12959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12151,6 +12997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12186,6 +13035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12221,6 +13073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12256,6 +13111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12291,6 +13149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12326,6 +13187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12361,6 +13225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12396,6 +13263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12431,6 +13301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12466,6 +13339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12501,6 +13377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12536,6 +13415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12571,6 +13453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12606,6 +13491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12641,6 +13529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12676,6 +13567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12711,6 +13605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12746,6 +13643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12781,6 +13681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12851,6 +13757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12886,6 +13795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12921,6 +13833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12956,6 +13871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12991,6 +13909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13026,6 +13947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13061,6 +13985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13096,6 +14023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13131,6 +14061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13166,6 +14099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13201,6 +14137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13236,6 +14175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13271,6 +14213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13306,6 +14251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13341,6 +14289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13376,6 +14327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13411,6 +14365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13446,6 +14403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13481,6 +14441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13516,6 +14479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13551,6 +14517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -13586,6 +14555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13621,6 +14593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13656,6 +14631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -13691,6 +14669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -13726,6 +14707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -13761,6 +14745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -13796,6 +14783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -13831,6 +14821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -13866,6 +14859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -13901,6 +14897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -13936,6 +14935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -13971,6 +14973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -14006,6 +15011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -14041,6 +15049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -14076,6 +15087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -14111,6 +15125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -14146,6 +15163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -14181,6 +15201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -14216,6 +15239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -14251,6 +15277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -14286,6 +15315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -14321,6 +15353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -14356,6 +15391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -14391,6 +15429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14426,6 +15467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14461,6 +15505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -14496,6 +15543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -14531,6 +15581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14566,6 +15619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14601,6 +15657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14636,6 +15695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -14671,6 +15733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14706,6 +15771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -14741,6 +15809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14776,6 +15847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -14811,6 +15885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14846,6 +15923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14881,6 +15961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14916,6 +15999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14951,6 +16037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14986,6 +16075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15021,6 +16113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15056,6 +16151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -15091,6 +16189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15126,6 +16227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -15161,6 +16265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15196,6 +16303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -15231,6 +16341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -15266,6 +16379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15301,6 +16417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -15336,6 +16455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15371,6 +16493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -15406,6 +16531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -15441,6 +16569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15476,6 +16607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15511,6 +16645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15546,6 +16683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15581,6 +16721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15616,6 +16759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -15651,6 +16797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -15686,6 +16835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -15721,6 +16873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -15756,6 +16911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -15791,6 +16949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -15826,6 +16987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -15861,6 +17025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -15896,6 +17063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -15931,6 +17101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -15966,6 +17139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16001,6 +17177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -16036,6 +17215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -16071,6 +17253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -16106,6 +17291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -16141,6 +17329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -16176,6 +17367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -16211,6 +17405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -16246,6 +17443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -16281,6 +17481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -16316,6 +17519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -16351,6 +17557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -16386,6 +17595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -16421,6 +17633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16456,6 +17671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16491,6 +17709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16526,6 +17747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16561,6 +17785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -16596,6 +17823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -16631,6 +17861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -16666,6 +17899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -16701,6 +17937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -16736,6 +17975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -16771,6 +18013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -16806,6 +18051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -16841,6 +18089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16876,6 +18127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -16911,6 +18165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -16946,6 +18203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16981,6 +18241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17016,6 +18279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17051,6 +18317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17086,6 +18355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -17121,6 +18393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -17156,6 +18431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17191,6 +18469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17226,6 +18507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -17261,6 +18545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -17296,6 +18583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -17331,6 +18621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17366,6 +18659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17401,6 +18697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17436,6 +18735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17471,6 +18773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17506,6 +18811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17541,6 +18849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -17576,6 +18887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -17611,6 +18925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -17646,6 +18963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -17681,6 +19001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -17716,6 +19039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -17751,6 +19077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -17786,6 +19115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -17821,6 +19153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -17856,6 +19191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -17891,6 +19229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -17926,6 +19267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -17961,6 +19305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -17996,6 +19343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -18031,6 +19381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -18066,6 +19419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -18101,6 +19457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -18136,6 +19495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -18171,6 +19533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -18206,6 +19571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -18241,6 +19609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -18276,6 +19647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -18311,6 +19685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -18346,6 +19723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18381,6 +19761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18416,6 +19799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18451,6 +19837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -18486,6 +19875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18521,6 +19913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -18556,6 +19951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18591,6 +19989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18626,6 +20027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18661,6 +20065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -18696,6 +20103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -18731,6 +20141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -18766,6 +20179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -18801,6 +20217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -18836,6 +20255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -18871,6 +20293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -18906,6 +20331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18941,6 +20369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18976,6 +20407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -19011,6 +20445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -19046,6 +20483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -19081,6 +20521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19116,6 +20559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -19151,6 +20597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19186,6 +20635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19221,6 +20673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19256,6 +20711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19291,6 +20749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19326,6 +20787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19361,6 +20825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19396,6 +20863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19431,6 +20901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -19466,6 +20939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -19501,6 +20977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -19536,6 +21015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19571,6 +21053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19606,6 +21091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19641,6 +21129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19676,6 +21167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -19711,6 +21205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -19746,6 +21243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -19781,6 +21281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19816,6 +21319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19851,6 +21357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19886,6 +21395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19921,6 +21433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19956,6 +21471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19991,6 +21509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -20026,6 +21547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20061,6 +21585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20096,6 +21623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20131,6 +21661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20166,6 +21699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -20201,6 +21737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -20236,6 +21775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -20271,6 +21813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20306,6 +21851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20341,6 +21889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20376,6 +21927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20411,6 +21965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -20446,6 +22003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -20481,6 +22041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -20516,6 +22079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -20551,6 +22117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -20586,6 +22155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20621,6 +22193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -20656,6 +22231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -20691,6 +22269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20726,6 +22307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -20761,6 +22345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -20796,6 +22383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20831,6 +22421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20866,6 +22459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20901,6 +22497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20936,6 +22535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20971,6 +22573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21006,6 +22611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21041,6 +22649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21076,6 +22687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21111,6 +22725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21146,6 +22763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21181,6 +22801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21216,6 +22839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21251,6 +22877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21286,6 +22915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21321,6 +22953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21356,6 +22991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21391,6 +23029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21426,6 +23067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21461,6 +23105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21496,6 +23143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21531,6 +23181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21566,6 +23219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21601,6 +23257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21636,6 +23295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21671,6 +23333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21706,6 +23371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21741,6 +23409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21776,6 +23447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21811,6 +23485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21846,6 +23523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21881,6 +23561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21916,6 +23599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21951,6 +23637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21986,6 +23675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22021,6 +23713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -22056,6 +23751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22091,6 +23789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -22126,6 +23827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -22161,6 +23865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22196,6 +23903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -22231,6 +23941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -22266,6 +23979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -22301,6 +24017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22336,6 +24055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22371,6 +24093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -22406,6 +24131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -22441,6 +24169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -22476,6 +24207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -22511,6 +24245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -22546,6 +24283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -22581,6 +24321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -22616,6 +24359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -22651,6 +24397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22686,6 +24435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22721,6 +24473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22756,6 +24511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22791,6 +24549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22826,6 +24587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22861,6 +24625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22896,6 +24663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22931,6 +24701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22966,6 +24739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -23001,6 +24777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -23036,6 +24815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -23071,6 +24853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -23106,6 +24891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -23141,6 +24929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -23176,6 +24967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -23211,6 +25005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -23246,6 +25043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -23281,6 +25081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -23316,6 +25119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -23351,6 +25157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -23386,6 +25195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23421,6 +25233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23456,6 +25271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23491,6 +25309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23526,6 +25347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -23561,6 +25385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -23596,6 +25423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23631,6 +25461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23666,6 +25499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23701,6 +25537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23736,6 +25575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23771,6 +25613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23806,6 +25651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23841,6 +25689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23876,6 +25727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23911,6 +25765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23946,6 +25803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23981,6 +25841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24016,6 +25879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24051,6 +25917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24086,6 +25955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24121,6 +25993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -24156,6 +26031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24191,6 +26069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24226,6 +26107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -24261,6 +26145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -24296,6 +26183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24331,6 +26221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24366,6 +26259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -24401,6 +26297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24436,6 +26335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -24471,6 +26373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -24506,6 +26411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24541,6 +26449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24576,6 +26487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24611,6 +26525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24646,6 +26563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24681,6 +26601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24716,6 +26639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24751,6 +26677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24786,6 +26715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24821,6 +26753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24856,6 +26791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24891,6 +26829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24926,6 +26867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24961,6 +26905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24996,6 +26943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -25031,6 +26981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25066,6 +27019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -25101,6 +27057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -25136,6 +27095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -25171,6 +27133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -25206,6 +27171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25241,6 +27209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25276,6 +27247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25311,6 +27285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25346,6 +27323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25381,6 +27361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25416,6 +27399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25451,6 +27437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25486,6 +27475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25521,6 +27513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25556,6 +27551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25591,6 +27589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25626,6 +27627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25661,6 +27665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25696,6 +27703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25731,6 +27741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25766,6 +27779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25801,6 +27817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25836,6 +27855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25871,6 +27893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25906,6 +27931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25941,6 +27969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25976,6 +28007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26011,6 +28045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26046,6 +28083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26081,6 +28121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26116,6 +28159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26151,6 +28197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,6 +28235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26221,6 +28273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26256,6 +28311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26291,6 +28349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26326,6 +28387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26361,6 +28425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26396,6 +28463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26431,6 +28501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26466,6 +28539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26501,6 +28577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26536,6 +28615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26571,6 +28653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26606,6 +28691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.2.0.sarif
+++ b/src/test-resources/w3citylights-axe-v4.2.0.sarif
@@ -2282,6 +2282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2318,6 +2320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2354,6 +2358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2390,6 +2396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2426,6 +2434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2462,6 +2472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2498,6 +2510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2534,6 +2548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2570,6 +2586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2606,6 +2624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2642,6 +2662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2678,6 +2700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2714,6 +2738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2750,6 +2776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2786,6 +2814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2822,6 +2852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2858,6 +2890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2894,6 +2928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2930,6 +2966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2966,6 +3004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3002,6 +3042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3038,6 +3080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3074,6 +3118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3110,6 +3156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3146,6 +3194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3182,6 +3232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3218,6 +3270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3254,6 +3308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3290,6 +3346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3326,6 +3384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3362,6 +3422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3398,6 +3460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3434,6 +3498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3470,6 +3536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3506,6 +3574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3542,6 +3612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3578,6 +3650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3614,6 +3688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3650,6 +3726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3686,6 +3764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3722,6 +3802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3758,6 +3840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3794,6 +3878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3830,6 +3916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3866,6 +3954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3902,6 +3992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3938,6 +4030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3974,6 +4068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -4010,6 +4106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4046,6 +4144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4082,6 +4182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4118,6 +4220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4154,6 +4258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4190,6 +4296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4226,6 +4334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4262,6 +4372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4298,6 +4410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4334,6 +4448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4370,6 +4486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4406,6 +4524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4442,6 +4562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4478,6 +4600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4514,6 +4638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4550,6 +4676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4586,6 +4714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4622,6 +4752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4658,6 +4790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4694,6 +4828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4730,6 +4866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4766,6 +4904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4802,6 +4942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4838,6 +4980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4874,6 +5018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4910,6 +5056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4946,6 +5094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4982,6 +5132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5018,6 +5170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5054,6 +5208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5090,6 +5246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5126,6 +5284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5162,6 +5322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5198,6 +5360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5234,6 +5398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5270,6 +5436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5306,6 +5474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5342,6 +5512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5378,6 +5550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5414,6 +5588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5450,6 +5626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5486,6 +5664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5522,6 +5702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5558,6 +5740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5594,6 +5778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5630,6 +5816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5666,6 +5854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5702,6 +5892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5738,6 +5930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5774,6 +5968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5810,6 +6006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5846,6 +6044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5882,6 +6082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5918,6 +6120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5954,6 +6158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5990,6 +6196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6026,6 +6234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6062,6 +6272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6098,6 +6310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6134,6 +6348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6170,6 +6386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6206,6 +6424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6242,6 +6462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6278,6 +6500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6314,6 +6538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6350,6 +6576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6386,6 +6614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6422,6 +6652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6458,6 +6690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6494,6 +6728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6530,6 +6766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6566,6 +6804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6602,6 +6842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6638,6 +6880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6674,6 +6918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6710,6 +6956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6746,6 +6994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6782,6 +7032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6818,6 +7070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6854,6 +7108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6890,6 +7146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6926,6 +7184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6962,6 +7222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6998,6 +7260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7034,6 +7298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7070,6 +7336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7106,6 +7374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7142,6 +7412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7178,6 +7450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7214,6 +7488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7250,6 +7526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7286,6 +7564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7322,6 +7602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7358,6 +7640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7394,6 +7678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7430,6 +7716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7466,6 +7754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7502,6 +7792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7538,6 +7830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7574,6 +7868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7610,6 +7906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7646,6 +7944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7682,6 +7982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,6 +8020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7754,6 +8058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7790,6 +8096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7826,6 +8134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7862,6 +8172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7898,6 +8210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7934,6 +8248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7970,6 +8286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8006,6 +8324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8042,6 +8362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8078,6 +8400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8114,6 +8438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8150,6 +8476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8186,6 +8514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8222,6 +8552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8258,6 +8590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8294,6 +8628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8330,6 +8666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8366,6 +8704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8402,6 +8742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8438,6 +8780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8474,6 +8818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8510,6 +8856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8546,6 +8894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8582,6 +8932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8618,6 +8970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8654,6 +9008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8690,6 +9046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8726,6 +9084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8762,6 +9122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8798,6 +9160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8834,6 +9198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8870,6 +9236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8906,6 +9274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8942,6 +9312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8978,6 +9350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9014,6 +9388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9050,6 +9426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9086,6 +9464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9122,6 +9502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9158,6 +9540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9194,6 +9578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9230,6 +9616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9266,6 +9654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9302,6 +9692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9338,6 +9730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9374,6 +9768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9410,6 +9806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9446,6 +9844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9482,6 +9882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9518,6 +9920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9554,6 +9958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9590,6 +9996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9626,6 +10034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9662,6 +10072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9698,6 +10110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9734,6 +10148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9770,6 +10186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9806,6 +10224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9842,6 +10262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9878,6 +10300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9914,6 +10338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9950,6 +10376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9986,6 +10414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10022,6 +10452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10058,6 +10490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10094,6 +10528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10130,6 +10566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10166,6 +10604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10202,6 +10642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10238,6 +10680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10274,6 +10718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10310,6 +10756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10346,6 +10794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10382,6 +10832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10418,6 +10870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10454,6 +10908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10490,6 +10946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10526,6 +10984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10562,6 +11022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10598,6 +11060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10634,6 +11098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10670,6 +11136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10706,6 +11174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10742,6 +11212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10778,6 +11250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10814,6 +11288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10850,6 +11326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10886,6 +11364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10922,6 +11402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10958,6 +11440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10994,6 +11478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11030,6 +11516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11066,6 +11554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11102,6 +11592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11138,6 +11630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11174,6 +11668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11210,6 +11706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11246,6 +11744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11282,6 +11782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11318,6 +11820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11354,6 +11858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11390,6 +11896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11426,6 +11934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11462,6 +11972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11498,6 +12010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11534,6 +12048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11570,6 +12086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11606,6 +12124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11642,6 +12162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11678,6 +12200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11714,6 +12238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11750,6 +12276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11786,6 +12314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11822,6 +12352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11858,6 +12390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11894,6 +12428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11930,6 +12466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11966,6 +12504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12002,6 +12542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12038,6 +12580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12074,6 +12618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12110,6 +12656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12146,6 +12694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12182,6 +12732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12218,6 +12770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12254,6 +12808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12290,6 +12846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12326,6 +12884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12362,6 +12922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12398,6 +12960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12434,6 +12998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12470,6 +13036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12506,6 +13074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12542,6 +13112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12578,6 +13150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12614,6 +13188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12650,6 +13226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12686,6 +13264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12722,6 +13302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12758,6 +13340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12794,6 +13378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12830,6 +13416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12866,6 +13454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12902,6 +13492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12938,6 +13530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12974,6 +13568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13010,6 +13606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13046,6 +13644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13082,6 +13682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13118,6 +13720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13154,6 +13758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13190,6 +13796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13226,6 +13834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13262,6 +13872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13298,6 +13910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13334,6 +13948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13370,6 +13986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13406,6 +14024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13442,6 +14062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13478,6 +14100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13514,6 +14138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13550,6 +14176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13586,6 +14214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13622,6 +14252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13658,6 +14290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13694,6 +14328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13730,6 +14366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13766,6 +14404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13802,6 +14442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13838,6 +14480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13874,6 +14518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -13910,6 +14556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13946,6 +14594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13982,6 +14632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -14018,6 +14670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -14054,6 +14708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -14090,6 +14746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -14126,6 +14784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -14162,6 +14822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -14198,6 +14860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -14234,6 +14898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -14270,6 +14936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -14306,6 +14974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -14342,6 +15012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -14378,6 +15050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -14414,6 +15088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -14450,6 +15126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -14486,6 +15164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -14522,6 +15202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -14558,6 +15240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -14594,6 +15278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -14630,6 +15316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -14666,6 +15354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -14702,6 +15392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -14738,6 +15430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14774,6 +15468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14810,6 +15506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -14846,6 +15544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -14882,6 +15582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14918,6 +15620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14954,6 +15658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14990,6 +15696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -15026,6 +15734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15062,6 +15772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -15098,6 +15810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15134,6 +15848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15170,6 +15886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15206,6 +15924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15242,6 +15962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15278,6 +16000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15314,6 +16038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15350,6 +16076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15386,6 +16114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15422,6 +16152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -15458,6 +16190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15494,6 +16228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -15530,6 +16266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15566,6 +16304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -15602,6 +16342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -15638,6 +16380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15674,6 +16418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -15710,6 +16456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15746,6 +16494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -15782,6 +16532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -15818,6 +16570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15854,6 +16608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15890,6 +16646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15926,6 +16684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15962,6 +16722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15998,6 +16760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -16034,6 +16798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -16070,6 +16836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -16106,6 +16874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -16142,6 +16912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16178,6 +16950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -16214,6 +16988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -16250,6 +17026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -16286,6 +17064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -16322,6 +17102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -16358,6 +17140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16394,6 +17178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -16430,6 +17216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -16466,6 +17254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -16502,6 +17292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -16538,6 +17330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -16574,6 +17368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -16610,6 +17406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -16646,6 +17444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -16682,6 +17482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -16718,6 +17520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -16754,6 +17558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -16790,6 +17596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -16826,6 +17634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16862,6 +17672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16898,6 +17710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16934,6 +17748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16970,6 +17786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -17006,6 +17824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -17042,6 +17862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -17078,6 +17900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -17114,6 +17938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -17150,6 +17976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -17186,6 +18014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -17222,6 +18052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -17258,6 +18090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17294,6 +18128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -17330,6 +18166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -17366,6 +18204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17402,6 +18242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17438,6 +18280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17474,6 +18318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17510,6 +18356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -17546,6 +18394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -17582,6 +18432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17618,6 +18470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17654,6 +18508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -17690,6 +18546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -17726,6 +18584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -17762,6 +18622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17798,6 +18660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17834,6 +18698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17870,6 +18736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17906,6 +18774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17942,6 +18812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17978,6 +18850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -18014,6 +18888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -18050,6 +18926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -18086,6 +18964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -18122,6 +19002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -18158,6 +19040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -18194,6 +19078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -18230,6 +19116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -18266,6 +19154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -18302,6 +19192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -18338,6 +19230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -18374,6 +19268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -18410,6 +19306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -18446,6 +19344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -18482,6 +19382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -18518,6 +19420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -18554,6 +19458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -18590,6 +19496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -18626,6 +19534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -18662,6 +19572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -18698,6 +19610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -18734,6 +19648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -18770,6 +19686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -18806,6 +19724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18842,6 +19762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18878,6 +19800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18914,6 +19838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -18950,6 +19876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18986,6 +19914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -19022,6 +19952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19058,6 +19990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19094,6 +20028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19130,6 +20066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -19166,6 +20104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -19202,6 +20142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -19238,6 +20180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -19274,6 +20218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -19310,6 +20256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -19346,6 +20294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -19382,6 +20332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19418,6 +20370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19454,6 +20408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -19490,6 +20446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -19526,6 +20484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -19562,6 +20522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19598,6 +20560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -19634,6 +20598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19670,6 +20636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19706,6 +20674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19742,6 +20712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19778,6 +20750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19814,6 +20788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19850,6 +20826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19886,6 +20864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19922,6 +20902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -19958,6 +20940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -19994,6 +20978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -20030,6 +21016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20066,6 +21054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20102,6 +21092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20138,6 +21130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20174,6 +21168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -20210,6 +21206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -20246,6 +21244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -20282,6 +21282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20318,6 +21320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20354,6 +21358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20390,6 +21396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20426,6 +21434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -20462,6 +21472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -20498,6 +21510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -20534,6 +21548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20570,6 +21586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20606,6 +21624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20642,6 +21662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20678,6 +21700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -20714,6 +21738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -20750,6 +21776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -20786,6 +21814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20822,6 +21852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20858,6 +21890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20894,6 +21928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20930,6 +21966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -20966,6 +22004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -21002,6 +22042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -21038,6 +22080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -21074,6 +22118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -21110,6 +22156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21146,6 +22194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -21182,6 +22232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -21218,6 +22270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21254,6 +22308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -21290,6 +22346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -21326,6 +22384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21362,6 +22422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -21398,6 +22460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21434,6 +22498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21470,6 +22536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -21506,6 +22574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21542,6 +22612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21578,6 +22650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21614,6 +22688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21650,6 +22726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21686,6 +22764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21722,6 +22802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21758,6 +22840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21794,6 +22878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21830,6 +22916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21866,6 +22954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21902,6 +22992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21938,6 +23030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21974,6 +23068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22010,6 +23106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22046,6 +23144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22082,6 +23182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22118,6 +23220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22154,6 +23258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22190,6 +23296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22226,6 +23334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22262,6 +23372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22298,6 +23410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22334,6 +23448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22370,6 +23486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22406,6 +23524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22442,6 +23562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22478,6 +23600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22514,6 +23638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22550,6 +23676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22586,6 +23714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -22622,6 +23752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22658,6 +23790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -22694,6 +23828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -22730,6 +23866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22766,6 +23904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -22802,6 +23942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -22838,6 +23980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -22874,6 +24018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22910,6 +24056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22946,6 +24094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -22982,6 +24132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -23018,6 +24170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -23054,6 +24208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -23090,6 +24246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -23126,6 +24284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -23162,6 +24322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -23198,6 +24360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -23234,6 +24398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23270,6 +24436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23306,6 +24474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23342,6 +24512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23378,6 +24550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -23414,6 +24588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -23450,6 +24626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -23486,6 +24664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23522,6 +24702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23558,6 +24740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -23594,6 +24778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -23630,6 +24816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -23666,6 +24854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -23702,6 +24892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -23738,6 +24930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -23774,6 +24968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -23810,6 +25006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -23846,6 +25044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -23882,6 +25082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -23918,6 +25120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -23954,6 +25158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -23990,6 +25196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -24026,6 +25234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -24062,6 +25272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24098,6 +25310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -24134,6 +25348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -24170,6 +25386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -24206,6 +25424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24242,6 +25462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -24278,6 +25500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -24314,6 +25538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -24350,6 +25576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -24386,6 +25614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -24422,6 +25652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24458,6 +25690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24494,6 +25728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24530,6 +25766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24566,6 +25804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24602,6 +25842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24638,6 +25880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24674,6 +25918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24710,6 +25956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24746,6 +25994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -24782,6 +26032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24818,6 +26070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24854,6 +26108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -24890,6 +26146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -24926,6 +26184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24962,6 +26222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24998,6 +26260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -25034,6 +26298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25070,6 +26336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -25106,6 +26374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -25142,6 +26412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25178,6 +26450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -25214,6 +26488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -25250,6 +26526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25286,6 +26564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -25322,6 +26602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -25358,6 +26640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -25394,6 +26678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -25430,6 +26716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -25466,6 +26754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -25502,6 +26792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25538,6 +26830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -25574,6 +26868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -25610,6 +26906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -25646,6 +26944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -25682,6 +26982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25718,6 +27020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -25754,6 +27058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -25790,6 +27096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -25826,6 +27134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -25862,6 +27172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25898,6 +27210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25934,6 +27248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25970,6 +27286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -26006,6 +27324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -26042,6 +27362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -26078,6 +27400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -26114,6 +27438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -26150,6 +27476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -26186,6 +27514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -26222,6 +27552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -26258,6 +27590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -26294,6 +27628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -26330,6 +27666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -26366,6 +27704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -26402,6 +27742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -26438,6 +27780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -26474,6 +27818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -26510,6 +27856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26546,6 +27894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26582,6 +27932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26618,6 +27970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26654,6 +28008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26690,6 +28046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26726,6 +28084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26762,6 +28122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26798,6 +28160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26834,6 +28198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26870,6 +28236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26906,6 +28274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26942,6 +28312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26978,6 +28350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27014,6 +28388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27050,6 +28426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27086,6 +28464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27122,6 +28502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27158,6 +28540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27194,6 +28578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -27230,6 +28616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -27266,6 +28654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -27302,6 +28692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.3.2.sarif
+++ b/src/test-resources/w3citylights-axe-v4.3.2.sarif
@@ -2282,8 +2282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2320,8 +2318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2358,8 +2354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2396,8 +2390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2434,8 +2426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2472,8 +2462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2510,8 +2498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2548,8 +2534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2586,8 +2570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2624,8 +2606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2662,8 +2642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2700,8 +2678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2738,8 +2714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2776,8 +2750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2814,8 +2786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2852,8 +2822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2890,8 +2858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2928,8 +2894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2966,8 +2930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -3004,8 +2966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3042,8 +3002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3080,8 +3038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3118,8 +3074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3156,8 +3110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3194,8 +3146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3232,8 +3182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3270,8 +3218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3308,8 +3254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3346,8 +3290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3384,8 +3326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3422,8 +3362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3460,8 +3398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3498,8 +3434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3536,8 +3470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3574,8 +3506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3612,8 +3542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3650,8 +3578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3688,8 +3614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3726,8 +3650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3764,8 +3686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3802,8 +3722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3840,8 +3758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3878,8 +3794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3916,8 +3830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3954,8 +3866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3992,8 +3902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4030,8 +3938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4068,8 +3974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -4106,8 +4010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4144,8 +4046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4182,8 +4082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4220,8 +4118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4258,8 +4154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4296,8 +4190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4334,8 +4226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4372,8 +4262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4410,8 +4298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4448,8 +4334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4486,8 +4370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4524,8 +4406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4562,8 +4442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4600,8 +4478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4638,8 +4514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4676,8 +4550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4714,8 +4586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4752,8 +4622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4790,8 +4658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4828,8 +4694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4866,8 +4730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4904,8 +4766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4942,8 +4802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4980,8 +4838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5018,8 +4874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5056,8 +4910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5094,8 +4946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5132,8 +4982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5170,8 +5018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5208,8 +5054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5246,8 +5090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5284,8 +5126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5322,8 +5162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5360,8 +5198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5398,8 +5234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5436,8 +5270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5474,8 +5306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5512,8 +5342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5550,8 +5378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5588,8 +5414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5626,8 +5450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5664,8 +5486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5702,8 +5522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5740,8 +5558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5778,8 +5594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5816,8 +5630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5854,8 +5666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5892,8 +5702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5930,8 +5738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5968,8 +5774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -6006,8 +5810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -6044,8 +5846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -6082,8 +5882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -6120,8 +5918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6158,8 +5954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6196,8 +5990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6234,8 +6026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6272,8 +6062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6310,8 +6098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6348,8 +6134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6386,8 +6170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6424,8 +6206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6462,8 +6242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6500,8 +6278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6538,8 +6314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6576,8 +6350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6614,8 +6386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6652,8 +6422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6690,8 +6458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6728,8 +6494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6766,8 +6530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6804,8 +6566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6842,8 +6602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6880,8 +6638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6918,8 +6674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6956,8 +6710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6994,8 +6746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -7032,8 +6782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -7070,8 +6818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -7108,8 +6854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -7146,8 +6890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -7184,8 +6926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -7222,8 +6962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7260,8 +6998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7298,8 +7034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7336,8 +7070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7374,8 +7106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7412,8 +7142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7450,8 +7178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7488,8 +7214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7526,8 +7250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7564,8 +7286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7602,8 +7322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7640,8 +7358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7678,8 +7394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7716,8 +7430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7754,8 +7466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7792,8 +7502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7830,8 +7538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7868,8 +7574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7906,8 +7610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7944,8 +7646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7982,8 +7682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -8020,8 +7718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8058,8 +7754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -8096,8 +7790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -8134,8 +7826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -8172,8 +7862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -8210,8 +7898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -8248,8 +7934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -8286,8 +7970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8324,8 +8006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8362,8 +8042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8400,8 +8078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8438,8 +8114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8476,8 +8150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8514,8 +8186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8552,8 +8222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8590,8 +8258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8628,8 +8294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8666,8 +8330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8704,8 +8366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8742,8 +8402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8780,8 +8438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8818,8 +8474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8856,8 +8510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8894,8 +8546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8932,8 +8582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8970,8 +8618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -9008,8 +8654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9046,8 +8690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9084,8 +8726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9122,8 +8762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9160,8 +8798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9198,8 +8834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9236,8 +8870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9274,8 +8906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9312,8 +8942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9350,8 +8978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9388,8 +9014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9426,8 +9050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9464,8 +9086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9502,8 +9122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9540,8 +9158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9578,8 +9194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9616,8 +9230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9654,8 +9266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9692,8 +9302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9730,8 +9338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9768,8 +9374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9806,8 +9410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9844,8 +9446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9882,8 +9482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9920,8 +9518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9958,8 +9554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9996,8 +9590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10034,8 +9626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10072,8 +9662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10110,8 +9698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10148,8 +9734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10186,8 +9770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10224,8 +9806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10262,8 +9842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10300,8 +9878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10338,8 +9914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10376,8 +9950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10414,8 +9986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10452,8 +10022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10490,8 +10058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10528,8 +10094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10566,8 +10130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10604,8 +10166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10642,8 +10202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10680,8 +10238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10718,8 +10274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10756,8 +10310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10794,8 +10346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10832,8 +10382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10870,8 +10418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10908,8 +10454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10946,8 +10490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10984,8 +10526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11022,8 +10562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11060,8 +10598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -11098,8 +10634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -11136,8 +10670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11174,8 +10706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -11212,8 +10742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11250,8 +10778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -11288,8 +10814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11326,8 +10850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11364,8 +10886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11402,8 +10922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11440,8 +10958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11478,8 +10994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11516,8 +11030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11554,8 +11066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11592,8 +11102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11630,8 +11138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11668,8 +11174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11706,8 +11210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11744,8 +11246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11782,8 +11282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11820,8 +11318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11858,8 +11354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11896,8 +11390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11934,8 +11426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11972,8 +11462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -12010,8 +11498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -12048,8 +11534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12086,8 +11570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -12124,8 +11606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12162,8 +11642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -12200,8 +11678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12238,8 +11714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -12276,8 +11750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12314,8 +11786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12352,8 +11822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12390,8 +11858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12428,8 +11894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12466,8 +11930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12504,8 +11966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12542,8 +12002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12580,8 +12038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12618,8 +12074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12656,8 +12110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12694,8 +12146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12732,8 +12182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12770,8 +12218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12808,8 +12254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12846,8 +12290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12884,8 +12326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12922,8 +12362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12960,8 +12398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12998,8 +12434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13036,8 +12470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13074,8 +12506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13112,8 +12542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13150,8 +12578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -13188,8 +12614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -13226,8 +12650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -13264,8 +12686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13302,8 +12722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13340,8 +12758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13378,8 +12794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13416,8 +12830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13454,8 +12866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13492,8 +12902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13530,8 +12938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13568,8 +12974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13606,8 +13010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13644,8 +13046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13682,8 +13082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13720,8 +13118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13758,8 +13154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13796,8 +13190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13834,8 +13226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13872,8 +13262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13910,8 +13298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13948,8 +13334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13986,8 +13370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -14024,8 +13406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14062,8 +13442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14100,8 +13478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14138,8 +13514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14176,8 +13550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14214,8 +13586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14252,8 +13622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14290,8 +13658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14328,8 +13694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14366,8 +13730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14404,8 +13766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14442,8 +13802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14480,8 +13838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14518,8 +13874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14556,8 +13910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14594,8 +13946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -14632,8 +13982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -14670,8 +14018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -14708,8 +14054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -14746,8 +14090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -14784,8 +14126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -14822,8 +14162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -14860,8 +14198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -14898,8 +14234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -14936,8 +14270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -14974,8 +14306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -15012,8 +14342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15050,8 +14378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15088,8 +14414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15126,8 +14450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15164,8 +14486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15202,8 +14522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15240,8 +14558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -15278,8 +14594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -15316,8 +14630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -15354,8 +14666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -15392,8 +14702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -15430,8 +14738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15468,8 +14774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15506,8 +14810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -15544,8 +14846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -15582,8 +14882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15620,8 +14918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -15658,8 +14954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15696,8 +14990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -15734,8 +15026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15772,8 +15062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -15810,8 +15098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15848,8 +15134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15886,8 +15170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15924,8 +15206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15962,8 +15242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -16000,8 +15278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16038,8 +15314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16076,8 +15350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16114,8 +15386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -16152,8 +15422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -16190,8 +15458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16228,8 +15494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -16266,8 +15530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16304,8 +15566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -16342,8 +15602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -16380,8 +15638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16418,8 +15674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -16456,8 +15710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16494,8 +15746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -16532,8 +15782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -16570,8 +15818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -16608,8 +15854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -16646,8 +15890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -16684,8 +15926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -16722,8 +15962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -16760,8 +15998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -16798,8 +16034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -16836,8 +16070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -16874,8 +16106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -16912,8 +16142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16950,8 +16178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -16988,8 +16214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -17026,8 +16250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -17064,8 +16286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -17102,8 +16322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -17140,8 +16358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -17178,8 +16394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -17216,8 +16430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -17254,8 +16466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -17292,8 +16502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -17330,8 +16538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -17368,8 +16574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -17406,8 +16610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -17444,8 +16646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -17482,8 +16682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -17520,8 +16718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -17558,8 +16754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -17596,8 +16790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -17634,8 +16826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -17672,8 +16862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -17710,8 +16898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -17748,8 +16934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -17786,8 +16970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -17824,8 +17006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -17862,8 +17042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -17900,8 +17078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -17938,8 +17114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -17976,8 +17150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -18014,8 +17186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -18052,8 +17222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -18090,8 +17258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18128,8 +17294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -18166,8 +17330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -18204,8 +17366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18242,8 +17402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18280,8 +17438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -18318,8 +17474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -18356,8 +17510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -18394,8 +17546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -18432,8 +17582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -18470,8 +17618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -18508,8 +17654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -18546,8 +17690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -18584,8 +17726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -18622,8 +17762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18660,8 +17798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -18698,8 +17834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -18736,8 +17870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -18774,8 +17906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -18812,8 +17942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -18850,8 +17978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -18888,8 +18014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -18926,8 +18050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -18964,8 +18086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -19002,8 +18122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -19040,8 +18158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -19078,8 +18194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -19116,8 +18230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -19154,8 +18266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -19192,8 +18302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -19230,8 +18338,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -19268,8 +18374,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -19306,8 +18410,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -19344,8 +18446,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -19382,8 +18482,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -19420,8 +18518,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -19458,8 +18554,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -19496,8 +18590,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -19534,8 +18626,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -19572,8 +18662,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -19610,8 +18698,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -19648,8 +18734,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -19686,8 +18770,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -19724,8 +18806,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -19762,8 +18842,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -19800,8 +18878,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -19838,8 +18914,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -19876,8 +18950,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19914,8 +18986,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -19952,8 +19022,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19990,8 +19058,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20028,8 +19094,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -20066,8 +19130,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -20104,8 +19166,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -20142,8 +19202,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -20180,8 +19238,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -20218,8 +19274,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -20256,8 +19310,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -20294,8 +19346,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -20332,8 +19382,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20370,8 +19418,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20408,8 +19454,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -20446,8 +19490,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -20484,8 +19526,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -20522,8 +19562,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20560,8 +19598,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -20598,8 +19634,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20636,8 +19670,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20674,8 +19706,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20712,8 +19742,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20750,8 +19778,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20788,8 +19814,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -20826,8 +19850,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -20864,8 +19886,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20902,8 +19922,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -20940,8 +19958,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -20978,8 +19994,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -21016,8 +20030,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21054,8 +20066,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21092,8 +20102,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21130,8 +20138,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21168,8 +20174,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -21206,8 +20210,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -21244,8 +20246,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -21282,8 +20282,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21320,8 +20318,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21358,8 +20354,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21396,8 +20390,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21434,8 +20426,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -21472,8 +20462,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -21510,8 +20498,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -21548,8 +20534,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21586,8 +20570,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21624,8 +20606,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21662,8 +20642,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21700,8 +20678,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -21738,8 +20714,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -21776,8 +20750,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -21814,8 +20786,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21852,8 +20822,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21890,8 +20858,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21928,8 +20894,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21966,8 +20930,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -22004,8 +20966,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -22042,8 +21002,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -22080,8 +21038,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -22118,8 +21074,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -22156,8 +21110,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22194,8 +21146,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -22232,8 +21182,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -22270,8 +21218,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22308,8 +21254,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -22346,8 +21290,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -22384,8 +21326,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22422,8 +21362,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -22460,8 +21398,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -22498,8 +21434,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22536,8 +21470,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -22574,8 +21506,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22612,8 +21542,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22650,8 +21578,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22688,8 +21614,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22726,8 +21650,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22764,8 +21686,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22802,8 +21722,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -22840,8 +21758,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22878,8 +21794,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22916,8 +21830,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22954,8 +21866,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22992,8 +21902,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23030,8 +21938,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -23068,8 +21974,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23106,8 +22010,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -23144,8 +22046,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23182,8 +22082,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -23220,8 +22118,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23258,8 +22154,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -23296,8 +22190,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23334,8 +22226,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23372,8 +22262,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23410,8 +22298,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23448,8 +22334,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23486,8 +22370,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -23524,8 +22406,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23562,8 +22442,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23600,8 +22478,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -23638,8 +22514,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23676,8 +22550,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23714,8 +22586,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -23752,8 +22622,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23790,8 +22658,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -23828,8 +22694,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23866,8 +22730,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23904,8 +22766,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -23942,8 +22802,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -23980,8 +22838,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -24018,8 +22874,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -24056,8 +22910,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -24094,8 +22946,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -24132,8 +22982,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -24170,8 +23018,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -24208,8 +23054,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -24246,8 +23090,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -24284,8 +23126,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -24322,8 +23162,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -24360,8 +23198,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -24398,8 +23234,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -24436,8 +23270,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -24474,8 +23306,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24512,8 +23342,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -24550,8 +23378,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -24588,8 +23414,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -24626,8 +23450,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -24664,8 +23486,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24702,8 +23522,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -24740,8 +23558,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -24778,8 +23594,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -24816,8 +23630,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -24854,8 +23666,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -24892,8 +23702,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -24930,8 +23738,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -24968,8 +23774,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -25006,8 +23810,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -25044,8 +23846,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -25082,8 +23882,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -25120,8 +23918,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -25158,8 +23954,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -25196,8 +23990,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -25234,8 +24026,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -25272,8 +24062,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25310,8 +24098,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -25348,8 +24134,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -25386,8 +24170,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -25424,8 +24206,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25462,8 +24242,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -25500,8 +24278,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -25538,8 +24314,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -25576,8 +24350,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -25614,8 +24386,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -25652,8 +24422,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25690,8 +24458,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25728,8 +24494,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25766,8 +24530,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25804,8 +24566,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25842,8 +24602,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25880,8 +24638,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25918,8 +24674,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25956,8 +24710,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25994,8 +24746,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -26032,8 +24782,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -26070,8 +24818,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -26108,8 +24854,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -26146,8 +24890,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -26184,8 +24926,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -26222,8 +24962,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -26260,8 +24998,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -26298,8 +25034,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -26336,8 +25070,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -26374,8 +25106,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -26412,8 +25142,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -26450,8 +25178,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -26488,8 +25214,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -26526,8 +25250,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -26564,8 +25286,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -26602,8 +25322,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -26640,8 +25358,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -26678,8 +25394,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -26716,8 +25430,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -26754,8 +25466,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -26792,8 +25502,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -26830,8 +25538,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -26868,8 +25574,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -26906,8 +25610,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -26944,8 +25646,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -26982,8 +25682,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -27020,8 +25718,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -27058,8 +25754,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -27096,8 +25790,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -27134,8 +25826,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -27172,8 +25862,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -27210,8 +25898,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -27248,8 +25934,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -27286,8 +25970,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -27324,8 +26006,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -27362,8 +26042,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -27400,8 +26078,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -27438,8 +26114,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -27476,8 +26150,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -27514,8 +26186,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -27552,8 +26222,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -27590,8 +26258,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -27628,8 +26294,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -27666,8 +26330,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -27704,8 +26366,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -27742,8 +26402,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -27780,8 +26438,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -27818,8 +26474,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -27856,8 +26510,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -27894,8 +26546,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27932,8 +26582,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27970,8 +26618,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28008,8 +26654,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28046,8 +26690,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28084,8 +26726,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28122,8 +26762,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28160,8 +26798,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28198,8 +26834,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -28236,8 +26870,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -28274,8 +26906,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28312,8 +26942,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28350,8 +26978,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28388,8 +27014,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28426,8 +27050,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28464,8 +27086,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28502,8 +27122,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28540,8 +27158,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28578,8 +27194,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -28616,8 +27230,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -28654,8 +27266,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -28692,8 +27302,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.3.2.sarif
+++ b/src/test-resources/w3citylights-axe-v4.3.2.sarif
@@ -2281,6 +2281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2316,6 +2319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2351,6 +2357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2386,6 +2395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2421,6 +2433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2456,6 +2471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2491,6 +2509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2526,6 +2547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2561,6 +2585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2596,6 +2623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2631,6 +2661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2666,6 +2699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2701,6 +2737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2736,6 +2775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2771,6 +2813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2806,6 +2851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2841,6 +2889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2876,6 +2927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2911,6 +2965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2946,6 +3003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2981,6 +3041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3016,6 +3079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3051,6 +3117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3086,6 +3155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3121,6 +3193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3156,6 +3231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3191,6 +3269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3226,6 +3307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3261,6 +3345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3296,6 +3383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3331,6 +3421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3366,6 +3459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3401,6 +3497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3436,6 +3535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3471,6 +3573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3506,6 +3611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3541,6 +3649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3576,6 +3687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3611,6 +3725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3646,6 +3763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3681,6 +3801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3716,6 +3839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3751,6 +3877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3786,6 +3915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3821,6 +3953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3856,6 +3991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3891,6 +4029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3926,6 +4067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3961,6 +4105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3996,6 +4143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4031,6 +4181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4066,6 +4219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4101,6 +4257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4136,6 +4295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4171,6 +4333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4206,6 +4371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4241,6 +4409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4276,6 +4447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4311,6 +4485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4346,6 +4523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4381,6 +4561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4416,6 +4599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4451,6 +4637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4486,6 +4675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4521,6 +4713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4556,6 +4751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4591,6 +4789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4626,6 +4827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4661,6 +4865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4696,6 +4903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4731,6 +4941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4766,6 +4979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4801,6 +5017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4836,6 +5055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4871,6 +5093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4906,6 +5131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4941,6 +5169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4976,6 +5207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5011,6 +5245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5046,6 +5283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5081,6 +5321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5116,6 +5359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5151,6 +5397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5186,6 +5435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5221,6 +5473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5256,6 +5511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5291,6 +5549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5326,6 +5587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5361,6 +5625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5396,6 +5663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5431,6 +5701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5466,6 +5739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5501,6 +5777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5536,6 +5815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5571,6 +5853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5606,6 +5891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5641,6 +5929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5676,6 +5967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5711,6 +6005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5746,6 +6043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5781,6 +6081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5816,6 +6119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5851,6 +6157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5886,6 +6195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5921,6 +6233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5956,6 +6271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5991,6 +6309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6026,6 +6347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6061,6 +6385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6096,6 +6423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6131,6 +6461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6166,6 +6499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6201,6 +6537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6236,6 +6575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6271,6 +6613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6306,6 +6651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6341,6 +6689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6376,6 +6727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6411,6 +6765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6446,6 +6803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6481,6 +6841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6516,6 +6879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6551,6 +6917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6586,6 +6955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6621,6 +6993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6656,6 +7031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6691,6 +7069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6726,6 +7107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6761,6 +7145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6796,6 +7183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6831,6 +7221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6866,6 +7259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6901,6 +7297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6936,6 +7335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6971,6 +7373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7006,6 +7411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7041,6 +7449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7076,6 +7487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7111,6 +7525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7146,6 +7563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7181,6 +7601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7216,6 +7639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7251,6 +7677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7286,6 +7715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7321,6 +7753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7356,6 +7791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7391,6 +7829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7426,6 +7867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7461,6 +7905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7496,6 +7943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7531,6 +7981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7566,6 +8019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7601,6 +8057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7636,6 +8095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7671,6 +8133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7706,6 +8171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7741,6 +8209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7776,6 +8247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7811,6 +8285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7846,6 +8323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7881,6 +8361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7916,6 +8399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7951,6 +8437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7986,6 +8475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8021,6 +8513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8056,6 +8551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8091,6 +8589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8126,6 +8627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8161,6 +8665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8196,6 +8703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8231,6 +8741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8266,6 +8779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8301,6 +8817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8336,6 +8855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8371,6 +8893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8406,6 +8931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8441,6 +8969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8476,6 +9007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8511,6 +9045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8546,6 +9083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8581,6 +9121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8616,6 +9159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8651,6 +9197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8686,6 +9235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8721,6 +9273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8756,6 +9311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8791,6 +9349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8826,6 +9387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8861,6 +9425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8896,6 +9463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8931,6 +9501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8966,6 +9539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9001,6 +9577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9036,6 +9615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9071,6 +9653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9106,6 +9691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9141,6 +9729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9176,6 +9767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9211,6 +9805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9246,6 +9843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9281,6 +9881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9316,6 +9919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9351,6 +9957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9386,6 +9995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9421,6 +10033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9456,6 +10071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9491,6 +10109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9526,6 +10147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9561,6 +10185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9596,6 +10223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9631,6 +10261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9666,6 +10299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9701,6 +10337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9736,6 +10375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9771,6 +10413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9806,6 +10451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9841,6 +10489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9876,6 +10527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9911,6 +10565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9946,6 +10603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9981,6 +10641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10016,6 +10679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10051,6 +10717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10086,6 +10755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10121,6 +10793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10156,6 +10831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10191,6 +10869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10226,6 +10907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10261,6 +10945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10296,6 +10983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10331,6 +11021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10366,6 +11059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10401,6 +11097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10436,6 +11135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10471,6 +11173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10506,6 +11211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10541,6 +11249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10576,6 +11287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10611,6 +11325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10646,6 +11363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10681,6 +11401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10716,6 +11439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10751,6 +11477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10786,6 +11515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10821,6 +11553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10856,6 +11591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10891,6 +11629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10926,6 +11667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10961,6 +11705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10996,6 +11743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11031,6 +11781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11066,6 +11819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11101,6 +11857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11136,6 +11895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11171,6 +11933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11206,6 +11971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11241,6 +12009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11276,6 +12047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11311,6 +12085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11346,6 +12123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11381,6 +12161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11416,6 +12199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11451,6 +12237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11486,6 +12275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11521,6 +12313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11556,6 +12351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11591,6 +12389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11626,6 +12427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11661,6 +12465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11696,6 +12503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11731,6 +12541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11766,6 +12579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11801,6 +12617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11836,6 +12655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11871,6 +12693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11906,6 +12731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11941,6 +12769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11976,6 +12807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12011,6 +12845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12046,6 +12883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12081,6 +12921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12116,6 +12959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12151,6 +12997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12186,6 +13035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12221,6 +13073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12256,6 +13111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12291,6 +13149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12326,6 +13187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12361,6 +13225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12396,6 +13263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12431,6 +13301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12466,6 +13339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12501,6 +13377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12536,6 +13415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12571,6 +13453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12606,6 +13491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12641,6 +13529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12676,6 +13567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12711,6 +13605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12746,6 +13643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12781,6 +13681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12816,6 +13719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12851,6 +13757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12886,6 +13795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12921,6 +13833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12956,6 +13871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12991,6 +13909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13026,6 +13947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13061,6 +13985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13096,6 +14023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13131,6 +14061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13166,6 +14099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13201,6 +14137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13236,6 +14175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13271,6 +14213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13306,6 +14251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13341,6 +14289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13376,6 +14327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13411,6 +14365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13446,6 +14403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13481,6 +14441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13516,6 +14479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13551,6 +14517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -13586,6 +14555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13621,6 +14593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13656,6 +14631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -13691,6 +14669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -13726,6 +14707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -13761,6 +14745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -13796,6 +14783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -13831,6 +14821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -13866,6 +14859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -13901,6 +14897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -13936,6 +14935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -13971,6 +14973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -14006,6 +15011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -14041,6 +15049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -14076,6 +15087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -14111,6 +15125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -14146,6 +15163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -14181,6 +15201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -14216,6 +15239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -14251,6 +15277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -14286,6 +15315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -14321,6 +15353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -14356,6 +15391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -14391,6 +15429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14426,6 +15467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14461,6 +15505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -14496,6 +15543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -14531,6 +15581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14566,6 +15619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14601,6 +15657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14636,6 +15695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -14671,6 +15733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14706,6 +15771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -14741,6 +15809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14776,6 +15847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -14811,6 +15885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14846,6 +15923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14881,6 +15961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14916,6 +15999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14951,6 +16037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14986,6 +16075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15021,6 +16113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15056,6 +16151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -15091,6 +16189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15126,6 +16227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -15161,6 +16265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15196,6 +16303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -15231,6 +16341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -15266,6 +16379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15301,6 +16417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -15336,6 +16455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15371,6 +16493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -15406,6 +16531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -15441,6 +16569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15476,6 +16607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15511,6 +16645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15546,6 +16683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15581,6 +16721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15616,6 +16759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -15651,6 +16797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -15686,6 +16835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -15721,6 +16873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -15756,6 +16911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -15791,6 +16949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -15826,6 +16987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -15861,6 +17025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -15896,6 +17063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -15931,6 +17101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -15966,6 +17139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16001,6 +17177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -16036,6 +17215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -16071,6 +17253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -16106,6 +17291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -16141,6 +17329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -16176,6 +17367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -16211,6 +17405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -16246,6 +17443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -16281,6 +17481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -16316,6 +17519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -16351,6 +17557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -16386,6 +17595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -16421,6 +17633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16456,6 +17671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16491,6 +17709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16526,6 +17747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16561,6 +17785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -16596,6 +17823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -16631,6 +17861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -16666,6 +17899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -16701,6 +17937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -16736,6 +17975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -16771,6 +18013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -16806,6 +18051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -16841,6 +18089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16876,6 +18127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -16911,6 +18165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -16946,6 +18203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16981,6 +18241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17016,6 +18279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17051,6 +18317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17086,6 +18355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -17121,6 +18393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -17156,6 +18431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17191,6 +18469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17226,6 +18507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -17261,6 +18545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -17296,6 +18583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -17331,6 +18621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17366,6 +18659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17401,6 +18697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17436,6 +18735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17471,6 +18773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17506,6 +18811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17541,6 +18849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -17576,6 +18887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -17611,6 +18925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -17646,6 +18963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -17681,6 +19001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -17716,6 +19039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -17751,6 +19077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -17786,6 +19115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -17821,6 +19153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -17856,6 +19191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -17891,6 +19229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -17926,6 +19267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -17961,6 +19305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -17996,6 +19343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -18031,6 +19381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -18066,6 +19419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -18101,6 +19457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -18136,6 +19495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -18171,6 +19533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -18206,6 +19571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -18241,6 +19609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -18276,6 +19647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -18311,6 +19685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -18346,6 +19723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18381,6 +19761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18416,6 +19799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18451,6 +19837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -18486,6 +19875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18521,6 +19913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -18556,6 +19951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18591,6 +19989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18626,6 +20027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18661,6 +20065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -18696,6 +20103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -18731,6 +20141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -18766,6 +20179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -18801,6 +20217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -18836,6 +20255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -18871,6 +20293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -18906,6 +20331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18941,6 +20369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18976,6 +20407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -19011,6 +20445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -19046,6 +20483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -19081,6 +20521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19116,6 +20559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -19151,6 +20597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19186,6 +20635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19221,6 +20673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19256,6 +20711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19291,6 +20749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19326,6 +20787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19361,6 +20825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19396,6 +20863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19431,6 +20901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -19466,6 +20939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -19501,6 +20977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -19536,6 +21015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19571,6 +21053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19606,6 +21091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19641,6 +21129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19676,6 +21167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -19711,6 +21205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -19746,6 +21243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -19781,6 +21281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19816,6 +21319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19851,6 +21357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19886,6 +21395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19921,6 +21433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19956,6 +21471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19991,6 +21509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -20026,6 +21547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20061,6 +21585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20096,6 +21623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20131,6 +21661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20166,6 +21699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -20201,6 +21737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -20236,6 +21775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -20271,6 +21813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20306,6 +21851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20341,6 +21889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20376,6 +21927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20411,6 +21965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -20446,6 +22003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -20481,6 +22041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -20516,6 +22079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -20551,6 +22117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -20586,6 +22155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20621,6 +22193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -20656,6 +22231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -20691,6 +22269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20726,6 +22307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -20761,6 +22345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -20796,6 +22383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20831,6 +22421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20866,6 +22459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20901,6 +22497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20936,6 +22535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20971,6 +22573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21006,6 +22611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21041,6 +22649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21076,6 +22687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21111,6 +22725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21146,6 +22763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21181,6 +22801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21216,6 +22839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21251,6 +22877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21286,6 +22915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21321,6 +22953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21356,6 +22991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21391,6 +23029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21426,6 +23067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21461,6 +23105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21496,6 +23143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21531,6 +23181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21566,6 +23219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21601,6 +23257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21636,6 +23295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21671,6 +23333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21706,6 +23371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21741,6 +23409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21776,6 +23447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21811,6 +23485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21846,6 +23523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21881,6 +23561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21916,6 +23599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21951,6 +23637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21986,6 +23675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22021,6 +23713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -22056,6 +23751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22091,6 +23789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -22126,6 +23827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -22161,6 +23865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22196,6 +23903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -22231,6 +23941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -22266,6 +23979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -22301,6 +24017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22336,6 +24055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22371,6 +24093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -22406,6 +24131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -22441,6 +24169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -22476,6 +24207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -22511,6 +24245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -22546,6 +24283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -22581,6 +24321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -22616,6 +24359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -22651,6 +24397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22686,6 +24435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22721,6 +24473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22756,6 +24511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22791,6 +24549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22826,6 +24587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22861,6 +24625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22896,6 +24663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22931,6 +24701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22966,6 +24739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -23001,6 +24777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -23036,6 +24815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -23071,6 +24853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -23106,6 +24891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -23141,6 +24929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -23176,6 +24967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -23211,6 +25005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -23246,6 +25043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -23281,6 +25081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -23316,6 +25119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -23351,6 +25157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -23386,6 +25195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23421,6 +25233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23456,6 +25271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23491,6 +25309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23526,6 +25347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -23561,6 +25385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -23596,6 +25423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23631,6 +25461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23666,6 +25499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23701,6 +25537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23736,6 +25575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23771,6 +25613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23806,6 +25651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23841,6 +25689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23876,6 +25727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23911,6 +25765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23946,6 +25803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23981,6 +25841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24016,6 +25879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24051,6 +25917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24086,6 +25955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24121,6 +25993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -24156,6 +26031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24191,6 +26069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24226,6 +26107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -24261,6 +26145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -24296,6 +26183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24331,6 +26221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24366,6 +26259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -24401,6 +26297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24436,6 +26335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -24471,6 +26373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -24506,6 +26411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24541,6 +26449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24576,6 +26487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24611,6 +26525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24646,6 +26563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24681,6 +26601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24716,6 +26639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24751,6 +26677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24786,6 +26715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24821,6 +26753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24856,6 +26791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24891,6 +26829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24926,6 +26867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24961,6 +26905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24996,6 +26943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -25031,6 +26981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25066,6 +27019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -25101,6 +27057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -25136,6 +27095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -25171,6 +27133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -25206,6 +27171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25241,6 +27209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25276,6 +27247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25311,6 +27285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25346,6 +27323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25381,6 +27361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25416,6 +27399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25451,6 +27437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25486,6 +27475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25521,6 +27513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25556,6 +27551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25591,6 +27589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25626,6 +27627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25661,6 +27665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25696,6 +27703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25731,6 +27741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25766,6 +27779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25801,6 +27817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25836,6 +27855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25871,6 +27893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25906,6 +27931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25941,6 +27969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25976,6 +28007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26011,6 +28045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26046,6 +28083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26081,6 +28121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26116,6 +28159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26151,6 +28197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26186,6 +28235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26221,6 +28273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26256,6 +28311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26291,6 +28349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26326,6 +28387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26361,6 +28425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26396,6 +28463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26431,6 +28501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26466,6 +28539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26501,6 +28577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26536,6 +28615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26571,6 +28653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26606,6 +28691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.3.2.sarif
+++ b/src/test-resources/w3citylights-axe-v4.3.2.sarif
@@ -2282,6 +2282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2318,6 +2320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2354,6 +2358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2390,6 +2396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2426,6 +2434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2462,6 +2472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2498,6 +2510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2534,6 +2548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2570,6 +2586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2606,6 +2624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2642,6 +2662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2678,6 +2700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2714,6 +2738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2750,6 +2776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2786,6 +2814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2822,6 +2852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2858,6 +2890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2894,6 +2928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2930,6 +2966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2966,6 +3004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3002,6 +3042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3038,6 +3080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3074,6 +3118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3110,6 +3156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3146,6 +3194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3182,6 +3232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3218,6 +3270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3254,6 +3308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3290,6 +3346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3326,6 +3384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3362,6 +3422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3398,6 +3460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3434,6 +3498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3470,6 +3536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3506,6 +3574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3542,6 +3612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3578,6 +3650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3614,6 +3688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3650,6 +3726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3686,6 +3764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3722,6 +3802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3758,6 +3840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3794,6 +3878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3830,6 +3916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3866,6 +3954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3902,6 +3992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3938,6 +4030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3974,6 +4068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -4010,6 +4106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4046,6 +4144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4082,6 +4182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4118,6 +4220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4154,6 +4258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4190,6 +4296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4226,6 +4334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4262,6 +4372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4298,6 +4410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4334,6 +4448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4370,6 +4486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4406,6 +4524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4442,6 +4562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4478,6 +4600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4514,6 +4638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4550,6 +4676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4586,6 +4714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4622,6 +4752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4658,6 +4790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4694,6 +4828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4730,6 +4866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4766,6 +4904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4802,6 +4942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4838,6 +4980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4874,6 +5018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4910,6 +5056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4946,6 +5094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4982,6 +5132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5018,6 +5170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5054,6 +5208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5090,6 +5246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5126,6 +5284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5162,6 +5322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5198,6 +5360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5234,6 +5398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5270,6 +5436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5306,6 +5474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5342,6 +5512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5378,6 +5550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5414,6 +5588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5450,6 +5626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5486,6 +5664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5522,6 +5702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5558,6 +5740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5594,6 +5778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5630,6 +5816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5666,6 +5854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5702,6 +5892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5738,6 +5930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5774,6 +5968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5810,6 +6006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5846,6 +6044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5882,6 +6082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5918,6 +6120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5954,6 +6158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5990,6 +6196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6026,6 +6234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6062,6 +6272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6098,6 +6310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6134,6 +6348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6170,6 +6386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6206,6 +6424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6242,6 +6462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6278,6 +6500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6314,6 +6538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6350,6 +6576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6386,6 +6614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6422,6 +6652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6458,6 +6690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6494,6 +6728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6530,6 +6766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6566,6 +6804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6602,6 +6842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6638,6 +6880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6674,6 +6918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6710,6 +6956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6746,6 +6994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6782,6 +7032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6818,6 +7070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6854,6 +7108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6890,6 +7146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6926,6 +7184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6962,6 +7222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6998,6 +7260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7034,6 +7298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7070,6 +7336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7106,6 +7374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7142,6 +7412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7178,6 +7450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7214,6 +7488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7250,6 +7526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7286,6 +7564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7322,6 +7602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7358,6 +7640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7394,6 +7678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7430,6 +7716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7466,6 +7754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7502,6 +7792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7538,6 +7830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7574,6 +7868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7610,6 +7906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7646,6 +7944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7682,6 +7982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7718,6 +8020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7754,6 +8058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7790,6 +8096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7826,6 +8134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7862,6 +8172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7898,6 +8210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7934,6 +8248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7970,6 +8286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8006,6 +8324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8042,6 +8362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8078,6 +8400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8114,6 +8438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8150,6 +8476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8186,6 +8514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8222,6 +8552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8258,6 +8590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8294,6 +8628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8330,6 +8666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8366,6 +8704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8402,6 +8742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8438,6 +8780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8474,6 +8818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8510,6 +8856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8546,6 +8894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8582,6 +8932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8618,6 +8970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8654,6 +9008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8690,6 +9046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8726,6 +9084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8762,6 +9122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8798,6 +9160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8834,6 +9198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8870,6 +9236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8906,6 +9274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8942,6 +9312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8978,6 +9350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9014,6 +9388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9050,6 +9426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9086,6 +9464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9122,6 +9502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9158,6 +9540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9194,6 +9578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9230,6 +9616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9266,6 +9654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9302,6 +9692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9338,6 +9730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9374,6 +9768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9410,6 +9806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9446,6 +9844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9482,6 +9882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9518,6 +9920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9554,6 +9958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9590,6 +9996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9626,6 +10034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9662,6 +10072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9698,6 +10110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9734,6 +10148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9770,6 +10186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9806,6 +10224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9842,6 +10262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9878,6 +10300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9914,6 +10338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9950,6 +10376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9986,6 +10414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10022,6 +10452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10058,6 +10490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10094,6 +10528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10130,6 +10566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10166,6 +10604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10202,6 +10642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10238,6 +10680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10274,6 +10718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10310,6 +10756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10346,6 +10794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10382,6 +10832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10418,6 +10870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10454,6 +10908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10490,6 +10946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10526,6 +10984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10562,6 +11022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10598,6 +11060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10634,6 +11098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10670,6 +11136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10706,6 +11174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10742,6 +11212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10778,6 +11250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10814,6 +11288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10850,6 +11326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10886,6 +11364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10922,6 +11402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10958,6 +11440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10994,6 +11478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11030,6 +11516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11066,6 +11554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11102,6 +11592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11138,6 +11630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11174,6 +11668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11210,6 +11706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11246,6 +11744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11282,6 +11782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11318,6 +11820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11354,6 +11858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11390,6 +11896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11426,6 +11934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11462,6 +11972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11498,6 +12010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11534,6 +12048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11570,6 +12086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11606,6 +12124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11642,6 +12162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11678,6 +12200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11714,6 +12238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11750,6 +12276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11786,6 +12314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11822,6 +12352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11858,6 +12390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11894,6 +12428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11930,6 +12466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11966,6 +12504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12002,6 +12542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12038,6 +12580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12074,6 +12618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12110,6 +12656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12146,6 +12694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12182,6 +12732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12218,6 +12770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12254,6 +12808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12290,6 +12846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12326,6 +12884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12362,6 +12922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12398,6 +12960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12434,6 +12998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12470,6 +13036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12506,6 +13074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12542,6 +13112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12578,6 +13150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12614,6 +13188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12650,6 +13226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12686,6 +13264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12722,6 +13302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12758,6 +13340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12794,6 +13378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12830,6 +13416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12866,6 +13454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12902,6 +13492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12938,6 +13530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12974,6 +13568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13010,6 +13606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13046,6 +13644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13082,6 +13682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13118,6 +13720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13154,6 +13758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13190,6 +13796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13226,6 +13834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13262,6 +13872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13298,6 +13910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13334,6 +13948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13370,6 +13986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13406,6 +14024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13442,6 +14062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13478,6 +14100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13514,6 +14138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13550,6 +14176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13586,6 +14214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13622,6 +14252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13658,6 +14290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13694,6 +14328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13730,6 +14366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13766,6 +14404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13802,6 +14442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13838,6 +14480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13874,6 +14518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -13910,6 +14556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13946,6 +14594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13982,6 +14632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -14018,6 +14670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -14054,6 +14708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -14090,6 +14746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -14126,6 +14784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -14162,6 +14822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -14198,6 +14860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -14234,6 +14898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -14270,6 +14936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -14306,6 +14974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -14342,6 +15012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -14378,6 +15050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -14414,6 +15088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -14450,6 +15126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -14486,6 +15164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -14522,6 +15202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -14558,6 +15240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -14594,6 +15278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -14630,6 +15316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -14666,6 +15354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -14702,6 +15392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -14738,6 +15430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14774,6 +15468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14810,6 +15506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -14846,6 +15544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -14882,6 +15582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14918,6 +15620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14954,6 +15658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14990,6 +15696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -15026,6 +15734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15062,6 +15772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -15098,6 +15810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15134,6 +15848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15170,6 +15886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15206,6 +15924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15242,6 +15962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15278,6 +16000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15314,6 +16038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15350,6 +16076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15386,6 +16114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15422,6 +16152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -15458,6 +16190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15494,6 +16228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -15530,6 +16266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15566,6 +16304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -15602,6 +16342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -15638,6 +16380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15674,6 +16418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -15710,6 +16456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15746,6 +16494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -15782,6 +16532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -15818,6 +16570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15854,6 +16608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15890,6 +16646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15926,6 +16684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15962,6 +16722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15998,6 +16760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -16034,6 +16798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -16070,6 +16836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -16106,6 +16874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -16142,6 +16912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16178,6 +16950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -16214,6 +16988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -16250,6 +17026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -16286,6 +17064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -16322,6 +17102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -16358,6 +17140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16394,6 +17178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -16430,6 +17216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -16466,6 +17254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -16502,6 +17292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -16538,6 +17330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -16574,6 +17368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -16610,6 +17406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -16646,6 +17444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -16682,6 +17482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -16718,6 +17520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -16754,6 +17558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -16790,6 +17596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -16826,6 +17634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16862,6 +17672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16898,6 +17710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16934,6 +17748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16970,6 +17786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -17006,6 +17824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -17042,6 +17862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -17078,6 +17900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -17114,6 +17938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -17150,6 +17976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -17186,6 +18014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -17222,6 +18052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -17258,6 +18090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17294,6 +18128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -17330,6 +18166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -17366,6 +18204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17402,6 +18242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17438,6 +18280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17474,6 +18318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17510,6 +18356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -17546,6 +18394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -17582,6 +18432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17618,6 +18470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17654,6 +18508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -17690,6 +18546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -17726,6 +18584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -17762,6 +18622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17798,6 +18660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17834,6 +18698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17870,6 +18736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17906,6 +18774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17942,6 +18812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17978,6 +18850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -18014,6 +18888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -18050,6 +18926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -18086,6 +18964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -18122,6 +19002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -18158,6 +19040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -18194,6 +19078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -18230,6 +19116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -18266,6 +19154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -18302,6 +19192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -18338,6 +19230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -18374,6 +19268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -18410,6 +19306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -18446,6 +19344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -18482,6 +19382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -18518,6 +19420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -18554,6 +19458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -18590,6 +19496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -18626,6 +19534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -18662,6 +19572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -18698,6 +19610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -18734,6 +19648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -18770,6 +19686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -18806,6 +19724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18842,6 +19762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18878,6 +19800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18914,6 +19838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -18950,6 +19876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18986,6 +19914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -19022,6 +19952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19058,6 +19990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19094,6 +20028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19130,6 +20066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -19166,6 +20104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -19202,6 +20142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -19238,6 +20180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -19274,6 +20218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -19310,6 +20256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -19346,6 +20294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -19382,6 +20332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19418,6 +20370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19454,6 +20408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -19490,6 +20446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -19526,6 +20484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -19562,6 +20522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19598,6 +20560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -19634,6 +20598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19670,6 +20636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19706,6 +20674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19742,6 +20712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19778,6 +20750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19814,6 +20788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19850,6 +20826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19886,6 +20864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19922,6 +20902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -19958,6 +20940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -19994,6 +20978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -20030,6 +21016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20066,6 +21054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20102,6 +21092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20138,6 +21130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20174,6 +21168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -20210,6 +21206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -20246,6 +21244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -20282,6 +21282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20318,6 +21320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20354,6 +21358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20390,6 +21396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20426,6 +21434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -20462,6 +21472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -20498,6 +21510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -20534,6 +21548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20570,6 +21586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20606,6 +21624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20642,6 +21662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20678,6 +21700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -20714,6 +21738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -20750,6 +21776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -20786,6 +21814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20822,6 +21852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20858,6 +21890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20894,6 +21928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20930,6 +21966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -20966,6 +22004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -21002,6 +22042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -21038,6 +22080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -21074,6 +22118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -21110,6 +22156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21146,6 +22194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -21182,6 +22232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -21218,6 +22270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21254,6 +22308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -21290,6 +22346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -21326,6 +22384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21362,6 +22422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -21398,6 +22460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21434,6 +22498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21470,6 +22536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -21506,6 +22574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21542,6 +22612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21578,6 +22650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21614,6 +22688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21650,6 +22726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21686,6 +22764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21722,6 +22802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21758,6 +22840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21794,6 +22878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21830,6 +22916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21866,6 +22954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21902,6 +22992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21938,6 +23030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21974,6 +23068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22010,6 +23106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22046,6 +23144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22082,6 +23182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22118,6 +23220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22154,6 +23258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22190,6 +23296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22226,6 +23334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22262,6 +23372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22298,6 +23410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22334,6 +23448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22370,6 +23486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22406,6 +23524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22442,6 +23562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22478,6 +23600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22514,6 +23638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22550,6 +23676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22586,6 +23714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -22622,6 +23752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22658,6 +23790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -22694,6 +23828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -22730,6 +23866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22766,6 +23904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -22802,6 +23942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -22838,6 +23980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -22874,6 +24018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22910,6 +24056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22946,6 +24094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -22982,6 +24132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -23018,6 +24170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -23054,6 +24208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -23090,6 +24246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -23126,6 +24284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -23162,6 +24322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -23198,6 +24360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -23234,6 +24398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23270,6 +24436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23306,6 +24474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23342,6 +24512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23378,6 +24550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -23414,6 +24588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -23450,6 +24626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -23486,6 +24664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23522,6 +24702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23558,6 +24740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -23594,6 +24778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -23630,6 +24816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -23666,6 +24854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -23702,6 +24892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -23738,6 +24930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -23774,6 +24968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -23810,6 +25006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -23846,6 +25044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -23882,6 +25082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -23918,6 +25120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -23954,6 +25158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -23990,6 +25196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -24026,6 +25234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -24062,6 +25272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24098,6 +25310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -24134,6 +25348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -24170,6 +25386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -24206,6 +25424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24242,6 +25462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -24278,6 +25500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -24314,6 +25538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -24350,6 +25576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -24386,6 +25614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -24422,6 +25652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24458,6 +25690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24494,6 +25728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24530,6 +25766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24566,6 +25804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24602,6 +25842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24638,6 +25880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24674,6 +25918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24710,6 +25956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24746,6 +25994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -24782,6 +26032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24818,6 +26070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24854,6 +26108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -24890,6 +26146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -24926,6 +26184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24962,6 +26222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24998,6 +26260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -25034,6 +26298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25070,6 +26336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -25106,6 +26374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -25142,6 +26412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25178,6 +26450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -25214,6 +26488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -25250,6 +26526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25286,6 +26564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -25322,6 +26602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -25358,6 +26640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -25394,6 +26678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -25430,6 +26716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -25466,6 +26754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -25502,6 +26792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25538,6 +26830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -25574,6 +26868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -25610,6 +26906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -25646,6 +26944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -25682,6 +26982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25718,6 +27020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -25754,6 +27058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -25790,6 +27096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -25826,6 +27134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -25862,6 +27172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25898,6 +27210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25934,6 +27248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25970,6 +27286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -26006,6 +27324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -26042,6 +27362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -26078,6 +27400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -26114,6 +27438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -26150,6 +27476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -26186,6 +27514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -26222,6 +27552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -26258,6 +27590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -26294,6 +27628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -26330,6 +27666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -26366,6 +27704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -26402,6 +27742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -26438,6 +27780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -26474,6 +27818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -26510,6 +27856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26546,6 +27894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26582,6 +27932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26618,6 +27970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26654,6 +28008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26690,6 +28046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26726,6 +28084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26762,6 +28122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26798,6 +28160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26834,6 +28198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26870,6 +28236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26906,6 +28274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26942,6 +28312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26978,6 +28350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27014,6 +28388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27050,6 +28426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27086,6 +28464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27122,6 +28502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27158,6 +28540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27194,6 +28578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -27230,6 +28616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -27266,6 +28654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -27302,6 +28692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.4.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.4.1.sarif
@@ -2268,8 +2268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2306,8 +2304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2344,8 +2340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2382,8 +2376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2420,8 +2412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2458,8 +2448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2496,8 +2484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2534,8 +2520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2572,8 +2556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2610,8 +2592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2648,8 +2628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2686,8 +2664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2724,8 +2700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2762,8 +2736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2800,8 +2772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2838,8 +2808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2876,8 +2844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2914,8 +2880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2952,8 +2916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2990,8 +2952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3028,8 +2988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3066,8 +3024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3104,8 +3060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3142,8 +3096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3180,8 +3132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3218,8 +3168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3256,8 +3204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3294,8 +3240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3332,8 +3276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3370,8 +3312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3408,8 +3348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3446,8 +3384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3484,8 +3420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3522,8 +3456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3560,8 +3492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3598,8 +3528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3636,8 +3564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3674,8 +3600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3712,8 +3636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3750,8 +3672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3788,8 +3708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3826,8 +3744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3864,8 +3780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3902,8 +3816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3940,8 +3852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3978,8 +3888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4016,8 +3924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -4054,8 +3960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -4092,8 +3996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4130,8 +4032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4168,8 +4068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4206,8 +4104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4244,8 +4140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4282,8 +4176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4320,8 +4212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4358,8 +4248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4396,8 +4284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4434,8 +4320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4472,8 +4356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4510,8 +4392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4548,8 +4428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4586,8 +4464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4624,8 +4500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4662,8 +4536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4700,8 +4572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4738,8 +4608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4776,8 +4644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4814,8 +4680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4852,8 +4716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4890,8 +4752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4928,8 +4788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4966,8 +4824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5004,8 +4860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5042,8 +4896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5080,8 +4932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5118,8 +4968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5156,8 +5004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5194,8 +5040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5232,8 +5076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5270,8 +5112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5308,8 +5148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5346,8 +5184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5384,8 +5220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5422,8 +5256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5460,8 +5292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5498,8 +5328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5536,8 +5364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5574,8 +5400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5612,8 +5436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5650,8 +5472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5688,8 +5508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5726,8 +5544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5764,8 +5580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5802,8 +5616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5840,8 +5652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5878,8 +5688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5916,8 +5724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5954,8 +5760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5992,8 +5796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -6030,8 +5832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -6068,8 +5868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -6106,8 +5904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6144,8 +5940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6182,8 +5976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6220,8 +6012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6258,8 +6048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6296,8 +6084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6334,8 +6120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6372,8 +6156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6410,8 +6192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6448,8 +6228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6486,8 +6264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6524,8 +6300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6562,8 +6336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6600,8 +6372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6638,8 +6408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6676,8 +6444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6714,8 +6480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6752,8 +6516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6790,8 +6552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6828,8 +6588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6866,8 +6624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6904,8 +6660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6942,8 +6696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6980,8 +6732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -7018,8 +6768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -7056,8 +6804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -7094,8 +6840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -7132,8 +6876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -7170,8 +6912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -7208,8 +6948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7246,8 +6984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7284,8 +7020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7322,8 +7056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7360,8 +7092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7398,8 +7128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7436,8 +7164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7474,8 +7200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7512,8 +7236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7550,8 +7272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7588,8 +7308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7626,8 +7344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7664,8 +7380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7702,8 +7416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7740,8 +7452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7778,8 +7488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7816,8 +7524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7854,8 +7560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7892,8 +7596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7930,8 +7632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7968,8 +7668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -8006,8 +7704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -8044,8 +7740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -8082,8 +7776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -8120,8 +7812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -8158,8 +7848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -8196,8 +7884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -8234,8 +7920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -8272,8 +7956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8310,8 +7992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8348,8 +8028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8386,8 +8064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8424,8 +8100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8462,8 +8136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8500,8 +8172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8538,8 +8208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8576,8 +8244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8614,8 +8280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8652,8 +8316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8690,8 +8352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8728,8 +8388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8766,8 +8424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8804,8 +8460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8842,8 +8496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8880,8 +8532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8918,8 +8568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8956,8 +8604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8994,8 +8640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -9032,8 +8676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -9070,8 +8712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -9108,8 +8748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -9146,8 +8784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -9184,8 +8820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -9222,8 +8856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -9260,8 +8892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -9298,8 +8928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9336,8 +8964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9374,8 +9000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9412,8 +9036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9450,8 +9072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9488,8 +9108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9526,8 +9144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9564,8 +9180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9602,8 +9216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9640,8 +9252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9678,8 +9288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9716,8 +9324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9754,8 +9360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9792,8 +9396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9830,8 +9432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9868,8 +9468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9906,8 +9504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9944,8 +9540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9982,8 +9576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10020,8 +9612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10058,8 +9648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10096,8 +9684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10134,8 +9720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10172,8 +9756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10210,8 +9792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10248,8 +9828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10286,8 +9864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10324,8 +9900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10362,8 +9936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10400,8 +9972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10438,8 +10008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10476,8 +10044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10514,8 +10080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10552,8 +10116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10590,8 +10152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10628,8 +10188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10666,8 +10224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10704,8 +10260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10742,8 +10296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10780,8 +10332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10818,8 +10368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10856,8 +10404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10894,8 +10440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10932,8 +10476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10970,8 +10512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11008,8 +10548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11046,8 +10584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -11084,8 +10620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -11122,8 +10656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11160,8 +10692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -11198,8 +10728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11236,8 +10764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -11274,8 +10800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11312,8 +10836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -11350,8 +10872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11388,8 +10908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11426,8 +10944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11464,8 +10980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11502,8 +11016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11540,8 +11052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11578,8 +11088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11616,8 +11124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11654,8 +11160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11692,8 +11196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11730,8 +11232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11768,8 +11268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11806,8 +11304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11844,8 +11340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11882,8 +11376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11920,8 +11412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11958,8 +11448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11996,8 +11484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -12034,8 +11520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12072,8 +11556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -12110,8 +11592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12148,8 +11628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -12186,8 +11664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -12224,8 +11700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -12262,8 +11736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -12300,8 +11772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -12338,8 +11808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -12376,8 +11844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -12414,8 +11880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -12452,8 +11916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -12490,8 +11952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -12528,8 +11988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12566,8 +12024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12604,8 +12060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12642,8 +12096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12680,8 +12132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12718,8 +12168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12756,8 +12204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12794,8 +12240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12832,8 +12276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12870,8 +12312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12908,8 +12348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12946,8 +12384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12984,8 +12420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13022,8 +12456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13060,8 +12492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13098,8 +12528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13136,8 +12564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -13174,8 +12600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -13212,8 +12636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -13250,8 +12672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -13288,8 +12708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -13326,8 +12744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -13364,8 +12780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -13402,8 +12816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -13440,8 +12852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -13478,8 +12888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -13516,8 +12924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -13554,8 +12960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -13592,8 +12996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13630,8 +13032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13668,8 +13068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13706,8 +13104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13744,8 +13140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13782,8 +13176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13820,8 +13212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13858,8 +13248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13896,8 +13284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13934,8 +13320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13972,8 +13356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -14010,8 +13392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14048,8 +13428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14086,8 +13464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -14124,8 +13500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -14162,8 +13536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -14200,8 +13572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -14238,8 +13608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -14276,8 +13644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -14314,8 +13680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -14352,8 +13716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -14390,8 +13752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14428,8 +13788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14466,8 +13824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14504,8 +13860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -14542,8 +13896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14580,8 +13932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -14618,8 +13968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -14656,8 +14004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -14694,8 +14040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -14732,8 +14076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -14770,8 +14112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -14808,8 +14148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -14846,8 +14184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -14884,8 +14220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -14922,8 +14256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -14960,8 +14292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -14998,8 +14328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -15036,8 +14364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -15074,8 +14400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -15112,8 +14436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -15150,8 +14472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -15188,8 +14508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -15226,8 +14544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -15264,8 +14580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -15302,8 +14616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -15340,8 +14652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -15378,8 +14688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -15416,8 +14724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15454,8 +14760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15492,8 +14796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -15530,8 +14832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -15568,8 +14868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15606,8 +14904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -15644,8 +14940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15682,8 +14976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -15720,8 +15012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15758,8 +15048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -15796,8 +15084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15834,8 +15120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15872,8 +15156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15910,8 +15192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15948,8 +15228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15986,8 +15264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16024,8 +15300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16062,8 +15336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -16100,8 +15372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -16138,8 +15408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -16176,8 +15444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16214,8 +15480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -16252,8 +15516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -16290,8 +15552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -16328,8 +15588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -16366,8 +15624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16404,8 +15660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -16442,8 +15696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16480,8 +15732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -16518,8 +15768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -16556,8 +15804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -16594,8 +15840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -16632,8 +15876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -16670,8 +15912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -16708,8 +15948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -16746,8 +15984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -16784,8 +16020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -16822,8 +16056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -16860,8 +16092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -16898,8 +16128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16936,8 +16164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -16974,8 +16200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -17012,8 +16236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -17050,8 +16272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -17088,8 +16308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -17126,8 +16344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -17164,8 +16380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -17202,8 +16416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -17240,8 +16452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -17278,8 +16488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -17316,8 +16524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -17354,8 +16560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -17392,8 +16596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -17430,8 +16632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -17468,8 +16668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -17506,8 +16704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -17544,8 +16740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -17582,8 +16776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -17620,8 +16812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -17658,8 +16848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -17696,8 +16884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -17734,8 +16920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -17772,8 +16956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -17810,8 +16992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -17848,8 +17028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -17886,8 +17064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -17924,8 +17100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -17962,8 +17136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -18000,8 +17172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -18038,8 +17208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -18076,8 +17244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18114,8 +17280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -18152,8 +17316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -18190,8 +17352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18228,8 +17388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18266,8 +17424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -18304,8 +17460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -18342,8 +17496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -18380,8 +17532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -18418,8 +17568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -18456,8 +17604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -18494,8 +17640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -18532,8 +17676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -18570,8 +17712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -18608,8 +17748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18646,8 +17784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -18684,8 +17820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -18722,8 +17856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -18760,8 +17892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -18798,8 +17928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -18836,8 +17964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -18874,8 +18000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -18912,8 +18036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -18950,8 +18072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -18988,8 +18108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -19026,8 +18144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -19064,8 +18180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -19102,8 +18216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -19140,8 +18252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -19178,8 +18288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -19216,8 +18324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -19254,8 +18360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -19292,8 +18396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -19330,8 +18432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -19368,8 +18468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -19406,8 +18504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -19444,8 +18540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -19482,8 +18576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -19520,8 +18612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -19558,8 +18648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -19596,8 +18684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -19634,8 +18720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -19672,8 +18756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -19710,8 +18792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -19748,8 +18828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -19786,8 +18864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -19824,8 +18900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -19862,8 +18936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19900,8 +18972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -19938,8 +19008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19976,8 +19044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20014,8 +19080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -20052,8 +19116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -20090,8 +19152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -20128,8 +19188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -20166,8 +19224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -20204,8 +19260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -20242,8 +19296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -20280,8 +19332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -20318,8 +19368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20356,8 +19404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20394,8 +19440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -20432,8 +19476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -20470,8 +19512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -20508,8 +19548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20546,8 +19584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -20584,8 +19620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -20622,8 +19656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -20660,8 +19692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -20698,8 +19728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20736,8 +19764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20774,8 +19800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -20812,8 +19836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -20850,8 +19872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20888,8 +19908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -20926,8 +19944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -20964,8 +19980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -21002,8 +20016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21040,8 +20052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21078,8 +20088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21116,8 +20124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21154,8 +20160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -21192,8 +20196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -21230,8 +20232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -21268,8 +20268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21306,8 +20304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21344,8 +20340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21382,8 +20376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21420,8 +20412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -21458,8 +20448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -21496,8 +20484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -21534,8 +20520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21572,8 +20556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21610,8 +20592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21648,8 +20628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -21686,8 +20664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -21724,8 +20700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -21762,8 +20736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -21800,8 +20772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -21838,8 +20808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21876,8 +20844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21914,8 +20880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21952,8 +20916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -21990,8 +20952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -22028,8 +20988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -22066,8 +21024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -22104,8 +21060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -22142,8 +21096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22180,8 +21132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -22218,8 +21168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -22256,8 +21204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22294,8 +21240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -22332,8 +21276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -22370,8 +21312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -22408,8 +21348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -22446,8 +21384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -22484,8 +21420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22522,8 +21456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -22560,8 +21492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22598,8 +21528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22636,8 +21564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22674,8 +21600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22712,8 +21636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -22750,8 +21672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22788,8 +21708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -22826,8 +21744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22864,8 +21780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22902,8 +21816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22940,8 +21852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22978,8 +21888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23016,8 +21924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -23054,8 +21960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23092,8 +21996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -23130,8 +22032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23168,8 +22068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -23206,8 +22104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23244,8 +22140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -23282,8 +22176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -23320,8 +22212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23358,8 +22248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23396,8 +22284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -23434,8 +22320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23472,8 +22356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -23510,8 +22392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23548,8 +22428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23586,8 +22464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -23624,8 +22500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23662,8 +22536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23700,8 +22572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -23738,8 +22608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -23776,8 +22644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -23814,8 +22680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -23852,8 +22716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23890,8 +22752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -23928,8 +22788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -23966,8 +22824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -24004,8 +22860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -24042,8 +22896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -24080,8 +22932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -24118,8 +22968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -24156,8 +23004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -24194,8 +23040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -24232,8 +23076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -24270,8 +23112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -24308,8 +23148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -24346,8 +23184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -24384,8 +23220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -24422,8 +23256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -24460,8 +23292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24498,8 +23328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -24536,8 +23364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -24574,8 +23400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -24612,8 +23436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -24650,8 +23472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24688,8 +23508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -24726,8 +23544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -24764,8 +23580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -24802,8 +23616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -24840,8 +23652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -24878,8 +23688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -24916,8 +23724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -24954,8 +23760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -24992,8 +23796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -25030,8 +23832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -25068,8 +23868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -25106,8 +23904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -25144,8 +23940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -25182,8 +23976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -25220,8 +24012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -25258,8 +24048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25296,8 +24084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -25334,8 +24120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -25372,8 +24156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -25410,8 +24192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25448,8 +24228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -25486,8 +24264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -25524,8 +24300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -25562,8 +24336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -25600,8 +24372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -25638,8 +24408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25676,8 +24444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25714,8 +24480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25752,8 +24516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25790,8 +24552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25828,8 +24588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25866,8 +24624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25904,8 +24660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25942,8 +24696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25980,8 +24732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -26018,8 +24768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -26056,8 +24804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -26094,8 +24840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -26132,8 +24876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -26170,8 +24912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -26208,8 +24948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -26246,8 +24984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -26284,8 +25020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -26322,8 +25056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -26360,8 +25092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -26398,8 +25128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -26436,8 +25164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -26474,8 +25200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -26512,8 +25236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -26550,8 +25272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -26588,8 +25308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -26626,8 +25344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -26664,8 +25380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -26702,8 +25416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -26740,8 +25452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -26778,8 +25488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -26816,8 +25524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -26854,8 +25560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -26892,8 +25596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -26930,8 +25632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -26968,8 +25668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -27006,8 +25704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -27044,8 +25740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -27082,8 +25776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -27120,8 +25812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -27158,8 +25848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -27196,8 +25884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -27234,8 +25920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -27272,8 +25956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -27310,8 +25992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -27348,8 +26028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -27386,8 +26064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -27424,8 +26100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -27462,8 +26136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -27500,8 +26172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -27538,8 +26208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -27576,8 +26244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -27614,8 +26280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -27652,8 +26316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -27690,8 +26352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -27728,8 +26388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -27766,8 +26424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -27804,8 +26460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -27842,8 +26496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -27880,8 +26532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27918,8 +26568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27956,8 +26604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27994,8 +26640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28032,8 +26676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28070,8 +26712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28108,8 +26748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28146,8 +26784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28184,8 +26820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -28222,8 +26856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -28260,8 +26892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28298,8 +26928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28336,8 +26964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28374,8 +27000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -28412,8 +27036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28450,8 +27072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -28488,8 +27108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28526,8 +27144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -28564,8 +27180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -28602,8 +27216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -28640,8 +27252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -28678,8 +27288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.4.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.4.1.sarif
@@ -2268,6 +2268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2304,6 +2306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2340,6 +2344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2376,6 +2382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2412,6 +2420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2448,6 +2458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2484,6 +2496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2520,6 +2534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2556,6 +2572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2592,6 +2610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2628,6 +2648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2664,6 +2686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2700,6 +2724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2736,6 +2762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2772,6 +2800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2808,6 +2838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2844,6 +2876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2880,6 +2914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2916,6 +2952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2952,6 +2990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2988,6 +3028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3024,6 +3066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3060,6 +3104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3096,6 +3142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3132,6 +3180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3168,6 +3218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3204,6 +3256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3240,6 +3294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3276,6 +3332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3312,6 +3370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3348,6 +3408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3384,6 +3446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3420,6 +3484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3456,6 +3522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3492,6 +3560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3528,6 +3598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3564,6 +3636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3600,6 +3674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3636,6 +3712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3672,6 +3750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3708,6 +3788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3744,6 +3826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3780,6 +3864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3816,6 +3902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3852,6 +3940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3888,6 +3978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3924,6 +4016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3960,6 +4054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3996,6 +4092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4032,6 +4130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4068,6 +4168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4104,6 +4206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4140,6 +4244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4176,6 +4282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4212,6 +4320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4248,6 +4358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4284,6 +4396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4320,6 +4434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4356,6 +4472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4392,6 +4510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4428,6 +4548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4464,6 +4586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4500,6 +4624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4536,6 +4662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4572,6 +4700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4608,6 +4738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4644,6 +4776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4680,6 +4814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4716,6 +4852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4752,6 +4890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4788,6 +4928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4824,6 +4966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4860,6 +5004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4896,6 +5042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4932,6 +5080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4968,6 +5118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5004,6 +5156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5040,6 +5194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5076,6 +5232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5112,6 +5270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5148,6 +5308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5184,6 +5346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5220,6 +5384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5256,6 +5422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5292,6 +5460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5328,6 +5498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5364,6 +5536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5400,6 +5574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5436,6 +5612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5472,6 +5650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5508,6 +5688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5544,6 +5726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5580,6 +5764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5616,6 +5802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5652,6 +5840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5688,6 +5878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5724,6 +5916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5760,6 +5954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5796,6 +5992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5832,6 +6030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5868,6 +6068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5904,6 +6106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5940,6 +6144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5976,6 +6182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6012,6 +6220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6048,6 +6258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6084,6 +6296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6120,6 +6334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6156,6 +6372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6192,6 +6410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6228,6 +6448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6264,6 +6486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6300,6 +6524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6336,6 +6562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6372,6 +6600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6408,6 +6638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6444,6 +6676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6480,6 +6714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6516,6 +6752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6552,6 +6790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6588,6 +6828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6624,6 +6866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6660,6 +6904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6696,6 +6942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6732,6 +6980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6768,6 +7018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6804,6 +7056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6840,6 +7094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6876,6 +7132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6912,6 +7170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6948,6 +7208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6984,6 +7246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7020,6 +7284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7056,6 +7322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7092,6 +7360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7128,6 +7398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7164,6 +7436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7200,6 +7474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7236,6 +7512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7272,6 +7550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7308,6 +7588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7344,6 +7626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7380,6 +7664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7416,6 +7702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7452,6 +7740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7488,6 +7778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7524,6 +7816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7560,6 +7854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7596,6 +7892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7632,6 +7930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7668,6 +7968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7704,6 +8006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7740,6 +8044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7776,6 +8082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7812,6 +8120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7848,6 +8158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7884,6 +8196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7920,6 +8234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7956,6 +8272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7992,6 +8310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8028,6 +8348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8064,6 +8386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8100,6 +8424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8136,6 +8462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8172,6 +8500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8208,6 +8538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8244,6 +8576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8280,6 +8614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8316,6 +8652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8352,6 +8690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8388,6 +8728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8424,6 +8766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8460,6 +8804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8496,6 +8842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8532,6 +8880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8568,6 +8918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8604,6 +8956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8640,6 +8994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8676,6 +9032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8712,6 +9070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8748,6 +9108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8784,6 +9146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8820,6 +9184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8856,6 +9222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8892,6 +9260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8928,6 +9298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8964,6 +9336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -9000,6 +9374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -9036,6 +9412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -9072,6 +9450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -9108,6 +9488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -9144,6 +9526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9180,6 +9564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9216,6 +9602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9252,6 +9640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9288,6 +9678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9324,6 +9716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9360,6 +9754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9396,6 +9792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9432,6 +9830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9468,6 +9868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9504,6 +9906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9540,6 +9944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9576,6 +9982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9612,6 +10020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9648,6 +10058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9684,6 +10096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9720,6 +10134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9756,6 +10172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9792,6 +10210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9828,6 +10248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9864,6 +10286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9900,6 +10324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9936,6 +10362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9972,6 +10400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10008,6 +10438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10044,6 +10476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10080,6 +10514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10116,6 +10552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -10152,6 +10590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -10188,6 +10628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10224,6 +10666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10260,6 +10704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10296,6 +10742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10332,6 +10780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10368,6 +10818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10404,6 +10856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10440,6 +10894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10476,6 +10932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10512,6 +10970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10548,6 +11008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10584,6 +11046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10620,6 +11084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10656,6 +11122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10692,6 +11160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10728,6 +11198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10764,6 +11236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10800,6 +11274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10836,6 +11312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10872,6 +11350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10908,6 +11388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10944,6 +11426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10980,6 +11464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11016,6 +11502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -11052,6 +11540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11088,6 +11578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11124,6 +11616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -11160,6 +11654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11196,6 +11692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11232,6 +11730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11268,6 +11768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11304,6 +11806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11340,6 +11844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11376,6 +11882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11412,6 +11920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11448,6 +11958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11484,6 +11996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11520,6 +12034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11556,6 +12072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11592,6 +12110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11628,6 +12148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11664,6 +12186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11700,6 +12224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11736,6 +12262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11772,6 +12300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11808,6 +12338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11844,6 +12376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11880,6 +12414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11916,6 +12452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11952,6 +12490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11988,6 +12528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -12024,6 +12566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -12060,6 +12604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -12096,6 +12642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -12132,6 +12680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -12168,6 +12718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -12204,6 +12756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -12240,6 +12794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12276,6 +12832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12312,6 +12870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12348,6 +12908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12384,6 +12946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12420,6 +12984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12456,6 +13022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12492,6 +13060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12528,6 +13098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12564,6 +13136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12600,6 +13174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12636,6 +13212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12672,6 +13250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12708,6 +13288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12744,6 +13326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12780,6 +13364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12816,6 +13402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12852,6 +13440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12888,6 +13478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12924,6 +13516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12960,6 +13554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12996,6 +13592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -13032,6 +13630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -13068,6 +13668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -13104,6 +13706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -13140,6 +13744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -13176,6 +13782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -13212,6 +13820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -13248,6 +13858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -13284,6 +13896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13320,6 +13934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13356,6 +13972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13392,6 +14010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13428,6 +14048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13464,6 +14086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13500,6 +14124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13536,6 +14162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13572,6 +14200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13608,6 +14238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13644,6 +14276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13680,6 +14314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13716,6 +14352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13752,6 +14390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13788,6 +14428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13824,6 +14466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13860,6 +14504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -13896,6 +14542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13932,6 +14580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13968,6 +14618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -14004,6 +14656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -14040,6 +14694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -14076,6 +14732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -14112,6 +14770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -14148,6 +14808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -14184,6 +14846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -14220,6 +14884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -14256,6 +14922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -14292,6 +14960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -14328,6 +14998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -14364,6 +15036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -14400,6 +15074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -14436,6 +15112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -14472,6 +15150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -14508,6 +15188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -14544,6 +15226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -14580,6 +15264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -14616,6 +15302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -14652,6 +15340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -14688,6 +15378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -14724,6 +15416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14760,6 +15454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14796,6 +15492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -14832,6 +15530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -14868,6 +15568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14904,6 +15606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14940,6 +15644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14976,6 +15682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -15012,6 +15720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15048,6 +15758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -15084,6 +15796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15120,6 +15834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15156,6 +15872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15192,6 +15910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15228,6 +15948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15264,6 +15986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15300,6 +16024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15336,6 +16062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15372,6 +16100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15408,6 +16138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -15444,6 +16176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15480,6 +16214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -15516,6 +16252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15552,6 +16290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -15588,6 +16328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -15624,6 +16366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15660,6 +16404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -15696,6 +16442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15732,6 +16480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -15768,6 +16518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -15804,6 +16556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15840,6 +16594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15876,6 +16632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15912,6 +16670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15948,6 +16708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15984,6 +16746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -16020,6 +16784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -16056,6 +16822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -16092,6 +16860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -16128,6 +16898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16164,6 +16936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -16200,6 +16974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -16236,6 +17012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -16272,6 +17050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -16308,6 +17088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -16344,6 +17126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16380,6 +17164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -16416,6 +17202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -16452,6 +17240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -16488,6 +17278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -16524,6 +17316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -16560,6 +17354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -16596,6 +17392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -16632,6 +17430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -16668,6 +17468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -16704,6 +17506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -16740,6 +17544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -16776,6 +17582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -16812,6 +17620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16848,6 +17658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16884,6 +17696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16920,6 +17734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16956,6 +17772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -16992,6 +17810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -17028,6 +17848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -17064,6 +17886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -17100,6 +17924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -17136,6 +17962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -17172,6 +18000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -17208,6 +18038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -17244,6 +18076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17280,6 +18114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -17316,6 +18152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -17352,6 +18190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17388,6 +18228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17424,6 +18266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17460,6 +18304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17496,6 +18342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -17532,6 +18380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -17568,6 +18418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17604,6 +18456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17640,6 +18494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -17676,6 +18532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -17712,6 +18570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -17748,6 +18608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17784,6 +18646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17820,6 +18684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17856,6 +18722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17892,6 +18760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17928,6 +18798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17964,6 +18836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -18000,6 +18874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -18036,6 +18912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -18072,6 +18950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -18108,6 +18988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -18144,6 +19026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -18180,6 +19064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -18216,6 +19102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -18252,6 +19140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -18288,6 +19178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -18324,6 +19216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -18360,6 +19254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -18396,6 +19292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -18432,6 +19330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -18468,6 +19368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -18504,6 +19406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -18540,6 +19444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -18576,6 +19482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -18612,6 +19520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -18648,6 +19558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -18684,6 +19596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -18720,6 +19634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -18756,6 +19672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -18792,6 +19710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18828,6 +19748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18864,6 +19786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18900,6 +19824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -18936,6 +19862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18972,6 +19900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -19008,6 +19938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19044,6 +19976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19080,6 +20014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19116,6 +20052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -19152,6 +20090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -19188,6 +20128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -19224,6 +20166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -19260,6 +20204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -19296,6 +20242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -19332,6 +20280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -19368,6 +20318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19404,6 +20356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19440,6 +20394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -19476,6 +20432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -19512,6 +20470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -19548,6 +20508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19584,6 +20546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -19620,6 +20584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19656,6 +20622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19692,6 +20660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19728,6 +20698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19764,6 +20736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19800,6 +20774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19836,6 +20812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19872,6 +20850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19908,6 +20888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -19944,6 +20926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -19980,6 +20964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -20016,6 +21002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20052,6 +21040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20088,6 +21078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20124,6 +21116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20160,6 +21154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -20196,6 +21192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -20232,6 +21230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -20268,6 +21268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20304,6 +21306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20340,6 +21344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20376,6 +21382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20412,6 +21420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -20448,6 +21458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -20484,6 +21496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -20520,6 +21534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20556,6 +21572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20592,6 +21610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20628,6 +21648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20664,6 +21686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -20700,6 +21724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -20736,6 +21762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -20772,6 +21800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20808,6 +21838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20844,6 +21876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20880,6 +21914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20916,6 +21952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -20952,6 +21990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -20988,6 +22028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -21024,6 +22066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -21060,6 +22104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -21096,6 +22142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21132,6 +22180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -21168,6 +22218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -21204,6 +22256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21240,6 +22294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -21276,6 +22332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -21312,6 +22370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21348,6 +22408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -21384,6 +22446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21420,6 +22484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21456,6 +22522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -21492,6 +22560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21528,6 +22598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21564,6 +22636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21600,6 +22674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21636,6 +22712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21672,6 +22750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21708,6 +22788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21744,6 +22826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21780,6 +22864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21816,6 +22902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21852,6 +22940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21888,6 +22978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21924,6 +23016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21960,6 +23054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21996,6 +23092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22032,6 +23130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22068,6 +23168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22104,6 +23206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22140,6 +23244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22176,6 +23282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22212,6 +23320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22248,6 +23358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22284,6 +23396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22320,6 +23434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22356,6 +23472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22392,6 +23510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22428,6 +23548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22464,6 +23586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22500,6 +23624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22536,6 +23662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22572,6 +23700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -22608,6 +23738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22644,6 +23776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -22680,6 +23814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -22716,6 +23852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22752,6 +23890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -22788,6 +23928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -22824,6 +23966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -22860,6 +24004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22896,6 +24042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22932,6 +24080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -22968,6 +24118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -23004,6 +24156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -23040,6 +24194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -23076,6 +24232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -23112,6 +24270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -23148,6 +24308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -23184,6 +24346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -23220,6 +24384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23256,6 +24422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23292,6 +24460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23328,6 +24498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23364,6 +24536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -23400,6 +24574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -23436,6 +24612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -23472,6 +24650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23508,6 +24688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23544,6 +24726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -23580,6 +24764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -23616,6 +24802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -23652,6 +24840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -23688,6 +24878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -23724,6 +24916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -23760,6 +24954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -23796,6 +24992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -23832,6 +25030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -23868,6 +25068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -23904,6 +25106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -23940,6 +25144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -23976,6 +25182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -24012,6 +25220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -24048,6 +25258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24084,6 +25296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -24120,6 +25334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -24156,6 +25372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -24192,6 +25410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24228,6 +25448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -24264,6 +25486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -24300,6 +25524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -24336,6 +25562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -24372,6 +25600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -24408,6 +25638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24444,6 +25676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24480,6 +25714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24516,6 +25752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24552,6 +25790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24588,6 +25828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24624,6 +25866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24660,6 +25904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24696,6 +25942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24732,6 +25980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -24768,6 +26018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24804,6 +26056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24840,6 +26094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -24876,6 +26132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -24912,6 +26170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24948,6 +26208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24984,6 +26246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -25020,6 +26284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25056,6 +26322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -25092,6 +26360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -25128,6 +26398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25164,6 +26436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -25200,6 +26474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -25236,6 +26512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25272,6 +26550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -25308,6 +26588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -25344,6 +26626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -25380,6 +26664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -25416,6 +26702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -25452,6 +26740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -25488,6 +26778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25524,6 +26816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -25560,6 +26854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -25596,6 +26892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -25632,6 +26930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -25668,6 +26968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25704,6 +27006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -25740,6 +27044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -25776,6 +27082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -25812,6 +27120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -25848,6 +27158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25884,6 +27196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25920,6 +27234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25956,6 +27272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25992,6 +27310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -26028,6 +27348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -26064,6 +27386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -26100,6 +27424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -26136,6 +27462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -26172,6 +27500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -26208,6 +27538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -26244,6 +27576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -26280,6 +27614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -26316,6 +27652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -26352,6 +27690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -26388,6 +27728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -26424,6 +27766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -26460,6 +27804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -26496,6 +27842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26532,6 +27880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26568,6 +27918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26604,6 +27956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26640,6 +27994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26676,6 +28032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26712,6 +28070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26748,6 +28108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26784,6 +28146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26820,6 +28184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26856,6 +28222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26892,6 +28260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26928,6 +28298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26964,6 +28336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27000,6 +28374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27036,6 +28412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27072,6 +28450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27108,6 +28488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27144,6 +28526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27180,6 +28564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -27216,6 +28602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -27252,6 +28640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -27288,6 +28678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.4.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.4.1.sarif
@@ -2267,6 +2267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2302,6 +2305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2337,6 +2343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2372,6 +2381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2407,6 +2419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2442,6 +2457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2477,6 +2495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2512,6 +2533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2547,6 +2571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2582,6 +2609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2617,6 +2647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2652,6 +2685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2687,6 +2723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2722,6 +2761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2757,6 +2799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2792,6 +2837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2827,6 +2875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2862,6 +2913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2897,6 +2951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2932,6 +2989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2967,6 +3027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3002,6 +3065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3037,6 +3103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3072,6 +3141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3107,6 +3179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3142,6 +3217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3177,6 +3255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3212,6 +3293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3247,6 +3331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3282,6 +3369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3317,6 +3407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3352,6 +3445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3387,6 +3483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3422,6 +3521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3457,6 +3559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3492,6 +3597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3527,6 +3635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3562,6 +3673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3597,6 +3711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3632,6 +3749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3667,6 +3787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3702,6 +3825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3737,6 +3863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3772,6 +3901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3807,6 +3939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3842,6 +3977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3877,6 +4015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3912,6 +4053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3947,6 +4091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3982,6 +4129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4017,6 +4167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4052,6 +4205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4087,6 +4243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4122,6 +4281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4157,6 +4319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4192,6 +4357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4227,6 +4395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4262,6 +4433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4297,6 +4471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4332,6 +4509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4367,6 +4547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4402,6 +4585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4437,6 +4623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4472,6 +4661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4507,6 +4699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4542,6 +4737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4577,6 +4775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4612,6 +4813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4647,6 +4851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4682,6 +4889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4717,6 +4927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4752,6 +4965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4787,6 +5003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4822,6 +5041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4857,6 +5079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4892,6 +5117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4927,6 +5155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4962,6 +5193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4997,6 +5231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5032,6 +5269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5067,6 +5307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5102,6 +5345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5137,6 +5383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5172,6 +5421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5207,6 +5459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5242,6 +5497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5277,6 +5535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5312,6 +5573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5347,6 +5611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5382,6 +5649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5417,6 +5687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5452,6 +5725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5487,6 +5763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5522,6 +5801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5557,6 +5839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5592,6 +5877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5627,6 +5915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5662,6 +5953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5697,6 +5991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5732,6 +6029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5767,6 +6067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5802,6 +6105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5837,6 +6143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5872,6 +6181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5907,6 +6219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5942,6 +6257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5977,6 +6295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6012,6 +6333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6047,6 +6371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6082,6 +6409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6117,6 +6447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6152,6 +6485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6187,6 +6523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6222,6 +6561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6257,6 +6599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6292,6 +6637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6327,6 +6675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6362,6 +6713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -6397,6 +6751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6432,6 +6789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6467,6 +6827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6502,6 +6865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6537,6 +6903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6572,6 +6941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6607,6 +6979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6642,6 +7017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6677,6 +7055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6712,6 +7093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6747,6 +7131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6782,6 +7169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6817,6 +7207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6852,6 +7245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6887,6 +7283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6922,6 +7321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6957,6 +7359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6992,6 +7397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7027,6 +7435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7062,6 +7473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7097,6 +7511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7132,6 +7549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7167,6 +7587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7202,6 +7625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -7237,6 +7663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7272,6 +7701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7307,6 +7739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7342,6 +7777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7377,6 +7815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7412,6 +7853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7447,6 +7891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7482,6 +7929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7517,6 +7967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7552,6 +8005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7587,6 +8043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7622,6 +8081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7657,6 +8119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7692,6 +8157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7727,6 +8195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7762,6 +8233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7797,6 +8271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7832,6 +8309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7867,6 +8347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7902,6 +8385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7937,6 +8423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7972,6 +8461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8007,6 +8499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8042,6 +8537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8077,6 +8575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8112,6 +8613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8147,6 +8651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8182,6 +8689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -8217,6 +8727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -8252,6 +8765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -8287,6 +8803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -8322,6 +8841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -8357,6 +8879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -8392,6 +8917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -8427,6 +8955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -8462,6 +8993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -8497,6 +9031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -8532,6 +9069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -8567,6 +9107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -8602,6 +9145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -8637,6 +9183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -8672,6 +9221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -8707,6 +9259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -8742,6 +9297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -8777,6 +9335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -8812,6 +9373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -8847,6 +9411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -8882,6 +9449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -8917,6 +9487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -8952,6 +9525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -8987,6 +9563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -9022,6 +9601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -9057,6 +9639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9092,6 +9677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -9127,6 +9715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -9162,6 +9753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -9197,6 +9791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -9232,6 +9829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -9267,6 +9867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -9302,6 +9905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -9337,6 +9943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -9372,6 +9981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -9407,6 +10019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -9442,6 +10057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -9477,6 +10095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -9512,6 +10133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -9547,6 +10171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -9582,6 +10209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9617,6 +10247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9652,6 +10285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9687,6 +10323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9722,6 +10361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9757,6 +10399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9792,6 +10437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9827,6 +10475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9862,6 +10513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9897,6 +10551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -9932,6 +10589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -9967,6 +10627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10002,6 +10665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -10037,6 +10703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10072,6 +10741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -10107,6 +10779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -10142,6 +10817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -10177,6 +10855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -10212,6 +10893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -10247,6 +10931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -10282,6 +10969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10317,6 +11007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10352,6 +11045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -10387,6 +11083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -10422,6 +11121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10457,6 +11159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -10492,6 +11197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10527,6 +11235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -10562,6 +11273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10597,6 +11311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -10632,6 +11349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10667,6 +11387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10702,6 +11425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10737,6 +11463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10772,6 +11501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -10807,6 +11539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10842,6 +11577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10877,6 +11615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -10912,6 +11653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10947,6 +11691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10982,6 +11729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -11017,6 +11767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -11052,6 +11805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -11087,6 +11843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11122,6 +11881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -11157,6 +11919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -11192,6 +11957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -11227,6 +11995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -11262,6 +12033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11297,6 +12071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -11332,6 +12109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -11367,6 +12147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -11402,6 +12185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11437,6 +12223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11472,6 +12261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11507,6 +12299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11542,6 +12337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11577,6 +12375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11612,6 +12413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11647,6 +12451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11682,6 +12489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11717,6 +12527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11752,6 +12565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11787,6 +12603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11822,6 +12641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11857,6 +12679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11892,6 +12717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11927,6 +12755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11962,6 +12793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11997,6 +12831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -12032,6 +12869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12067,6 +12907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -12102,6 +12945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12137,6 +12983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12172,6 +13021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12207,6 +13059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12242,6 +13097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12277,6 +13135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12312,6 +13173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12347,6 +13211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12382,6 +13249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12417,6 +13287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12452,6 +13325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12487,6 +13363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12522,6 +13401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12557,6 +13439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12592,6 +13477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12627,6 +13515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12662,6 +13553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12697,6 +13591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12732,6 +13629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12767,6 +13667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12802,6 +13705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12837,6 +13743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12872,6 +13781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12907,6 +13819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12942,6 +13857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12977,6 +13895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -13012,6 +13933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13047,6 +13971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13082,6 +14009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13117,6 +14047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13152,6 +14085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13187,6 +14123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13222,6 +14161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13257,6 +14199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13292,6 +14237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13327,6 +14275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13362,6 +14313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13397,6 +14351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13432,6 +14389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13467,6 +14427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13502,6 +14465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13537,6 +14503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -13572,6 +14541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13607,6 +14579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13642,6 +14617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -13677,6 +14655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -13712,6 +14693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -13747,6 +14731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -13782,6 +14769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -13817,6 +14807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -13852,6 +14845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -13887,6 +14883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -13922,6 +14921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -13957,6 +14959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -13992,6 +14997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -14027,6 +15035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -14062,6 +15073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -14097,6 +15111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -14132,6 +15149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -14167,6 +15187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -14202,6 +15225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -14237,6 +15263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -14272,6 +15301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -14307,6 +15339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -14342,6 +15377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -14377,6 +15415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14412,6 +15453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14447,6 +15491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -14482,6 +15529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -14517,6 +15567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14552,6 +15605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14587,6 +15643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14622,6 +15681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -14657,6 +15719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14692,6 +15757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -14727,6 +15795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14762,6 +15833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -14797,6 +15871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14832,6 +15909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14867,6 +15947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14902,6 +15985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14937,6 +16023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14972,6 +16061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15007,6 +16099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15042,6 +16137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -15077,6 +16175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15112,6 +16213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -15147,6 +16251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15182,6 +16289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -15217,6 +16327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -15252,6 +16365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15287,6 +16403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -15322,6 +16441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15357,6 +16479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -15392,6 +16517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -15427,6 +16555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15462,6 +16593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15497,6 +16631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15532,6 +16669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15567,6 +16707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15602,6 +16745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -15637,6 +16783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -15672,6 +16821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -15707,6 +16859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -15742,6 +16897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -15777,6 +16935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -15812,6 +16973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -15847,6 +17011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -15882,6 +17049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -15917,6 +17087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -15952,6 +17125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -15987,6 +17163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -16022,6 +17201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -16057,6 +17239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -16092,6 +17277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -16127,6 +17315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -16162,6 +17353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -16197,6 +17391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -16232,6 +17429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -16267,6 +17467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -16302,6 +17505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -16337,6 +17543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -16372,6 +17581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -16407,6 +17619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16442,6 +17657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16477,6 +17695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16512,6 +17733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16547,6 +17771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -16582,6 +17809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -16617,6 +17847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -16652,6 +17885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -16687,6 +17923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -16722,6 +17961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -16757,6 +17999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -16792,6 +18037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -16827,6 +18075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16862,6 +18113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -16897,6 +18151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -16932,6 +18189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16967,6 +18227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17002,6 +18265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17037,6 +18303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17072,6 +18341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -17107,6 +18379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -17142,6 +18417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17177,6 +18455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17212,6 +18493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -17247,6 +18531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -17282,6 +18569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -17317,6 +18607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17352,6 +18645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17387,6 +18683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17422,6 +18721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17457,6 +18759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17492,6 +18797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17527,6 +18835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -17562,6 +18873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -17597,6 +18911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -17632,6 +18949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -17667,6 +18987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -17702,6 +19025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -17737,6 +19063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -17772,6 +19101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -17807,6 +19139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -17842,6 +19177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -17877,6 +19215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -17912,6 +19253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -17947,6 +19291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -17982,6 +19329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -18017,6 +19367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -18052,6 +19405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -18087,6 +19443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -18122,6 +19481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -18157,6 +19519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -18192,6 +19557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -18227,6 +19595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -18262,6 +19633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -18297,6 +19671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -18332,6 +19709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18367,6 +19747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18402,6 +19785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18437,6 +19823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -18472,6 +19861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18507,6 +19899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -18542,6 +19937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18577,6 +19975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18612,6 +20013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18647,6 +20051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -18682,6 +20089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -18717,6 +20127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -18752,6 +20165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -18787,6 +20203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -18822,6 +20241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -18857,6 +20279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -18892,6 +20317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18927,6 +20355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18962,6 +20393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18997,6 +20431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -19032,6 +20469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -19067,6 +20507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19102,6 +20545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -19137,6 +20583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19172,6 +20621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19207,6 +20659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19242,6 +20697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19277,6 +20735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19312,6 +20773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19347,6 +20811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19382,6 +20849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19417,6 +20887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -19452,6 +20925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -19487,6 +20963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -19522,6 +21001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19557,6 +21039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19592,6 +21077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19627,6 +21115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19662,6 +21153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -19697,6 +21191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -19732,6 +21229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -19767,6 +21267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19802,6 +21305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19837,6 +21343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19872,6 +21381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19907,6 +21419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19942,6 +21457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19977,6 +21495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -20012,6 +21533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20047,6 +21571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20082,6 +21609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20117,6 +21647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20152,6 +21685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -20187,6 +21723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -20222,6 +21761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -20257,6 +21799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20292,6 +21837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20327,6 +21875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20362,6 +21913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20397,6 +21951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -20432,6 +21989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -20467,6 +22027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -20502,6 +22065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -20537,6 +22103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -20572,6 +22141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20607,6 +22179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -20642,6 +22217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -20677,6 +22255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20712,6 +22293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -20747,6 +22331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -20782,6 +22369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20817,6 +22407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20852,6 +22445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20887,6 +22483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20922,6 +22521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20957,6 +22559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20992,6 +22597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21027,6 +22635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21062,6 +22673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21097,6 +22711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21132,6 +22749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21167,6 +22787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21202,6 +22825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21237,6 +22863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21272,6 +22901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21307,6 +22939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21342,6 +22977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21377,6 +23015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21412,6 +23053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21447,6 +23091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21482,6 +23129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21517,6 +23167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21552,6 +23205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21587,6 +23243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21622,6 +23281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21657,6 +23319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21692,6 +23357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21727,6 +23395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21762,6 +23433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21797,6 +23471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21832,6 +23509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21867,6 +23547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21902,6 +23585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21937,6 +23623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21972,6 +23661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22007,6 +23699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -22042,6 +23737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22077,6 +23775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -22112,6 +23813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -22147,6 +23851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22182,6 +23889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -22217,6 +23927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -22252,6 +23965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -22287,6 +24003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22322,6 +24041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22357,6 +24079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -22392,6 +24117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -22427,6 +24155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -22462,6 +24193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -22497,6 +24231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -22532,6 +24269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -22567,6 +24307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -22602,6 +24345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -22637,6 +24383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22672,6 +24421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22707,6 +24459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22742,6 +24497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22777,6 +24535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22812,6 +24573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22847,6 +24611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22882,6 +24649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22917,6 +24687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22952,6 +24725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22987,6 +24763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -23022,6 +24801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -23057,6 +24839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -23092,6 +24877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -23127,6 +24915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -23162,6 +24953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -23197,6 +24991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -23232,6 +25029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -23267,6 +25067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -23302,6 +25105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -23337,6 +25143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -23372,6 +25181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23407,6 +25219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23442,6 +25257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23477,6 +25295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23512,6 +25333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -23547,6 +25371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -23582,6 +25409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23617,6 +25447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23652,6 +25485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23687,6 +25523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23722,6 +25561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23757,6 +25599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23792,6 +25637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23827,6 +25675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23862,6 +25713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23897,6 +25751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23932,6 +25789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23967,6 +25827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24002,6 +25865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24037,6 +25903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24072,6 +25941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24107,6 +25979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -24142,6 +26017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24177,6 +26055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24212,6 +26093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -24247,6 +26131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -24282,6 +26169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24317,6 +26207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24352,6 +26245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -24387,6 +26283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24422,6 +26321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -24457,6 +26359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -24492,6 +26397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24527,6 +26435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24562,6 +26473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24597,6 +26511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24632,6 +26549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24667,6 +26587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24702,6 +26625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24737,6 +26663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24772,6 +26701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24807,6 +26739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24842,6 +26777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24877,6 +26815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24912,6 +26853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24947,6 +26891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24982,6 +26929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -25017,6 +26967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25052,6 +27005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -25087,6 +27043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -25122,6 +27081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -25157,6 +27119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -25192,6 +27157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25227,6 +27195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25262,6 +27233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25297,6 +27271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25332,6 +27309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25367,6 +27347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25402,6 +27385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25437,6 +27423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25472,6 +27461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25507,6 +27499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25542,6 +27537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25577,6 +27575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25612,6 +27613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25647,6 +27651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25682,6 +27689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25717,6 +27727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25752,6 +27765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<noscript><p><img src=\"//www.w3.org/analytics/piwik/piwik.php?idsite=328\"\n      style=\"border:0;\" alt=\"\" /></p></noscript>"
                   }
@@ -25787,6 +27803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25822,6 +27841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25857,6 +27879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25892,6 +27917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25927,6 +27955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25962,6 +27993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25997,6 +28031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26032,6 +28069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26067,6 +28107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26102,6 +28145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26137,6 +28183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26172,6 +28221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26207,6 +28259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26242,6 +28297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26277,6 +28335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26312,6 +28373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26347,6 +28411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26382,6 +28449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26417,6 +28487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26452,6 +28525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26487,6 +28563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26522,6 +28601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26557,6 +28639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -26592,6 +28677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.6.3.sarif
+++ b/src/test-resources/w3citylights-axe-v4.6.3.sarif
@@ -2207,6 +2207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2242,6 +2245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2277,6 +2283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2312,6 +2321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2347,6 +2359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2382,6 +2397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2417,6 +2435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2452,6 +2473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2487,6 +2511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2522,6 +2549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2557,6 +2587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2592,6 +2625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2627,6 +2663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2662,6 +2701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2697,6 +2739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2732,6 +2777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2767,6 +2815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2802,6 +2853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2837,6 +2891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2872,6 +2929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2907,6 +2967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2942,6 +3005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2977,6 +3043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3012,6 +3081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3047,6 +3119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3082,6 +3157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3117,6 +3195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3152,6 +3233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3187,6 +3271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3222,6 +3309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3257,6 +3347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3292,6 +3385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3327,6 +3423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3362,6 +3461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3397,6 +3499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3432,6 +3537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3467,6 +3575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3502,6 +3613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3537,6 +3651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3572,6 +3689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3607,6 +3727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3642,6 +3765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3677,6 +3803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3712,6 +3841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3747,6 +3879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3782,6 +3917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3817,6 +3955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3852,6 +3993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3887,6 +4031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3922,6 +4069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -3957,6 +4107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -3992,6 +4145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4027,6 +4183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4062,6 +4221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4097,6 +4259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4132,6 +4297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4167,6 +4335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4202,6 +4373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4237,6 +4411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4272,6 +4449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4307,6 +4487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4342,6 +4525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4377,6 +4563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4412,6 +4601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4447,6 +4639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4482,6 +4677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4517,6 +4715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4552,6 +4753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4587,6 +4791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4622,6 +4829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4657,6 +4867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4692,6 +4905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4727,6 +4943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4762,6 +4981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4797,6 +5019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4832,6 +5057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4867,6 +5095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4902,6 +5133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -4937,6 +5171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -4972,6 +5209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5007,6 +5247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5042,6 +5285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5077,6 +5323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5112,6 +5361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5147,6 +5399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5182,6 +5437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5217,6 +5475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5252,6 +5513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5287,6 +5551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5322,6 +5589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5357,6 +5627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5392,6 +5665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5427,6 +5703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5462,6 +5741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5497,6 +5779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5532,6 +5817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5567,6 +5855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5602,6 +5893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5637,6 +5931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5672,6 +5969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5707,6 +6007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5742,6 +6045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5777,6 +6083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5812,6 +6121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5847,6 +6159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5882,6 +6197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -5917,6 +6235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5952,6 +6273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -5987,6 +6311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6022,6 +6349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6057,6 +6387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6092,6 +6425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6127,6 +6463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6162,6 +6501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6197,6 +6539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6232,6 +6577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6267,6 +6615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6302,6 +6653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6337,6 +6691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6372,6 +6729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6407,6 +6767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6442,6 +6805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6477,6 +6843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6512,6 +6881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6547,6 +6919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6582,6 +6957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6617,6 +6995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6652,6 +7033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6687,6 +7071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6722,6 +7109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6757,6 +7147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6792,6 +7185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6827,6 +7223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6862,6 +7261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -6897,6 +7299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -6932,6 +7337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -6967,6 +7375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7002,6 +7413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7037,6 +7451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7072,6 +7489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7107,6 +7527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7142,6 +7565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7177,6 +7603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7212,6 +7641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7247,6 +7679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7282,6 +7717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7317,6 +7755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7352,6 +7793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7387,6 +7831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7422,6 +7869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7457,6 +7907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7492,6 +7945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7527,6 +7983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7562,6 +8021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7597,6 +8059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7632,6 +8097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7667,6 +8135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7702,6 +8173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7737,6 +8211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7772,6 +8249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7807,6 +8287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -7842,6 +8325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -7877,6 +8363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -7912,6 +8401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -7947,6 +8439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -7982,6 +8477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8017,6 +8515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8052,6 +8553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -8087,6 +8591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -8122,6 +8629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8157,6 +8667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8192,6 +8705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8227,6 +8743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8262,6 +8781,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8297,6 +8819,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8332,6 +8857,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8367,6 +8895,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -8402,6 +8933,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -8437,6 +8971,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8472,6 +9009,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -8507,6 +9047,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8542,6 +9085,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -8577,6 +9123,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8612,6 +9161,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -8647,6 +9199,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -8682,6 +9237,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -8717,6 +9275,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -8752,6 +9313,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8787,6 +9351,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8822,6 +9389,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -8857,6 +9427,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -8892,6 +9465,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8927,6 +9503,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -8962,6 +9541,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8997,6 +9579,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -9032,6 +9617,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9067,6 +9655,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -9102,6 +9693,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9137,6 +9731,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9172,6 +9769,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9207,6 +9807,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9242,6 +9845,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9277,6 +9883,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9312,6 +9921,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9347,6 +9959,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9382,6 +9997,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9417,6 +10035,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9452,6 +10073,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9487,6 +10111,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9522,6 +10149,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -9557,6 +10187,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9592,6 +10225,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -9627,6 +10263,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9662,6 +10301,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -9697,6 +10339,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -9732,6 +10377,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9767,6 +10415,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -9802,6 +10453,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9837,6 +10491,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -9872,6 +10529,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -9907,6 +10567,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -9942,6 +10605,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -9977,6 +10643,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10012,6 +10681,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10047,6 +10719,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10082,6 +10757,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10117,6 +10795,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10152,6 +10833,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10187,6 +10871,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10222,6 +10909,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10257,6 +10947,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10292,6 +10985,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10327,6 +11023,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10362,6 +11061,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10397,6 +11099,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10432,6 +11137,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10467,6 +11175,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10502,6 +11213,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -10537,6 +11251,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -10572,6 +11289,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -10607,6 +11327,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -10642,6 +11365,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -10677,6 +11403,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -10712,6 +11441,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -10747,6 +11479,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -10782,6 +11517,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -10817,6 +11555,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -10852,6 +11593,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -10887,6 +11631,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -10922,6 +11669,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -10957,6 +11707,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -10992,6 +11745,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11027,6 +11783,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11062,6 +11821,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11097,6 +11859,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11132,6 +11897,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11167,6 +11935,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11202,6 +11973,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11237,6 +12011,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11272,6 +12049,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11307,6 +12087,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11342,6 +12125,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11377,6 +12163,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -11412,6 +12201,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -11447,6 +12239,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -11482,6 +12277,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -11517,6 +12315,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -11552,6 +12353,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -11587,6 +12391,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -11622,6 +12429,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -11657,6 +12467,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -11692,6 +12505,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -11727,6 +12543,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -11762,6 +12581,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -11797,6 +12619,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11832,6 +12657,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11867,6 +12695,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11902,6 +12733,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11937,6 +12771,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11972,6 +12809,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12007,6 +12847,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12042,6 +12885,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12077,6 +12923,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12112,6 +12961,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12147,6 +12999,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12182,6 +13037,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12217,6 +13075,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12252,6 +13113,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12287,6 +13151,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12322,6 +13189,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12357,6 +13227,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -12392,6 +13265,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -12427,6 +13303,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -12462,6 +13341,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -12497,6 +13379,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -12532,6 +13417,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -12567,6 +13455,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -12602,6 +13493,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12637,6 +13531,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -12672,6 +13569,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12707,6 +13607,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -12742,6 +13645,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -12777,6 +13683,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -12812,6 +13721,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -12847,6 +13759,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -12882,6 +13797,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -12917,6 +13835,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -12952,6 +13873,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -12987,6 +13911,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -13022,6 +13949,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -13057,6 +13987,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -13092,6 +14025,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -13127,6 +14063,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -13162,6 +14101,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -13197,6 +14139,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -13232,6 +14177,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -13267,6 +14215,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -13302,6 +14253,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -13337,6 +14291,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -13372,6 +14329,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -13407,6 +14367,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -13442,6 +14405,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -13477,6 +14443,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13512,6 +14481,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13547,6 +14519,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -13582,6 +14557,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -13617,6 +14595,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13652,6 +14633,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -13687,6 +14671,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13722,6 +14709,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -13757,6 +14747,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13792,6 +14785,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -13827,6 +14823,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13862,6 +14861,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -13897,6 +14899,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -13932,6 +14937,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -13967,6 +14975,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14002,6 +15013,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14037,6 +15051,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14072,6 +15089,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14107,6 +15127,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -14142,6 +15165,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -14177,6 +15203,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14212,6 +15241,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -14247,6 +15279,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14282,6 +15317,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -14317,6 +15355,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -14352,6 +15393,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14387,6 +15431,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -14422,6 +15469,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14457,6 +15507,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -14492,6 +15545,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14527,6 +15583,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -14562,6 +15621,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -14597,6 +15659,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -14632,6 +15697,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -14667,6 +15735,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -14702,6 +15773,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -14737,6 +15811,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -14772,6 +15849,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -14807,6 +15887,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -14842,6 +15925,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -14877,6 +15963,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -14912,6 +16001,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -14947,6 +16039,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -14982,6 +16077,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -15017,6 +16115,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -15052,6 +16153,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -15087,6 +16191,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -15122,6 +16229,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -15157,6 +16267,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -15192,6 +16305,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -15227,6 +16343,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -15262,6 +16381,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -15297,6 +16419,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -15332,6 +16457,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -15367,6 +16495,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -15402,6 +16533,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15437,6 +16571,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15472,6 +16609,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15507,6 +16647,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15542,6 +16685,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15577,6 +16723,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15612,6 +16761,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -15647,6 +16799,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -15682,6 +16837,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -15717,6 +16875,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -15752,6 +16913,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -15787,6 +16951,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -15822,6 +16989,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -15857,6 +17027,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -15892,6 +17065,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -15927,6 +17103,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -15962,6 +17141,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -15997,6 +17179,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -16032,6 +17217,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16067,6 +17255,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -16102,6 +17293,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -16137,6 +17331,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16172,6 +17369,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16207,6 +17407,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16242,6 +17445,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16277,6 +17483,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -16312,6 +17521,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16347,6 +17559,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16382,6 +17597,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16417,6 +17635,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16452,6 +17673,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16487,6 +17711,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16522,6 +17749,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16557,6 +17787,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -16592,6 +17825,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -16627,6 +17863,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -16662,6 +17901,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -16697,6 +17939,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -16732,6 +17977,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -16767,6 +18015,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -16802,6 +18053,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -16837,6 +18091,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -16872,6 +18129,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -16907,6 +18167,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -16942,6 +18205,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -16977,6 +18243,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -17012,6 +18281,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -17047,6 +18319,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -17082,6 +18357,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -17117,6 +18395,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -17152,6 +18433,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -17187,6 +18471,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -17222,6 +18509,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -17257,6 +18547,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17292,6 +18585,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17327,6 +18623,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17362,6 +18661,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17397,6 +18699,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17432,6 +18737,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17467,6 +18775,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17502,6 +18813,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17537,6 +18851,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -17572,6 +18889,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -17607,6 +18927,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -17642,6 +18965,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -17677,6 +19003,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17712,6 +19041,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -17747,6 +19079,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -17782,6 +19117,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17817,6 +19155,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -17852,6 +19193,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -17887,6 +19231,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -17922,6 +19269,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -17957,6 +19307,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -17992,6 +19345,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -18027,6 +19383,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -18062,6 +19421,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -18097,6 +19459,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18132,6 +19497,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18167,6 +19535,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18202,6 +19573,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18237,6 +19611,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18272,6 +19649,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18307,6 +19687,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18342,6 +19725,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18377,6 +19763,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18412,6 +19801,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18447,6 +19839,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18482,6 +19877,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18517,6 +19915,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -18552,6 +19953,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -18587,6 +19991,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18622,6 +20029,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -18657,6 +20067,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -18692,6 +20105,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -18727,6 +20143,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -18762,6 +20181,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18797,6 +20219,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18832,6 +20257,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -18867,6 +20295,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -18902,6 +20333,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -18937,6 +20371,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -18972,6 +20409,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19007,6 +20447,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19042,6 +20485,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19077,6 +20523,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19112,6 +20561,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19147,6 +20599,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19182,6 +20637,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19217,6 +20675,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19252,6 +20713,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19287,6 +20751,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19322,6 +20789,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19357,6 +20827,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19392,6 +20865,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19427,6 +20903,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19462,6 +20941,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19497,6 +20979,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19532,6 +21017,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19567,6 +21055,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -19602,6 +21093,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -19637,6 +21131,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -19672,6 +21169,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -19707,6 +21207,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -19742,6 +21245,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -19777,6 +21283,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19812,6 +21321,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -19847,6 +21359,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -19882,6 +21397,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -19917,6 +21435,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -19952,6 +21473,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -19987,6 +21511,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20022,6 +21549,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20057,6 +21587,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20092,6 +21625,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20127,6 +21663,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20162,6 +21701,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20197,6 +21739,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20232,6 +21777,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20267,6 +21815,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20302,6 +21853,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20337,6 +21891,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20372,6 +21929,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20407,6 +21967,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20442,6 +22005,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20477,6 +22043,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20512,6 +22081,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20547,6 +22119,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20582,6 +22157,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20617,6 +22195,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20652,6 +22233,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20687,6 +22271,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20722,6 +22309,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -20757,6 +22347,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20792,6 +22385,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -20827,6 +22423,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -20862,6 +22461,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20897,6 +22499,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -20932,6 +22537,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -20967,6 +22575,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21002,6 +22613,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21037,6 +22651,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21072,6 +22689,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21107,6 +22727,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21142,6 +22765,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21177,6 +22803,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21212,6 +22841,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21247,6 +22879,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21282,6 +22917,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21317,6 +22955,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21352,6 +22993,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21387,6 +23031,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21422,6 +23069,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -21457,6 +23107,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -21492,6 +23145,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21527,6 +23183,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21562,6 +23221,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -21597,6 +23259,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -21632,6 +23297,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -21667,6 +23335,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -21702,6 +23373,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -21737,6 +23411,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -21772,6 +23449,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -21807,6 +23487,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -21842,6 +23525,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -21877,6 +23563,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -21912,6 +23601,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -21947,6 +23639,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -21982,6 +23677,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22017,6 +23715,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22052,6 +23753,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22087,6 +23791,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22122,6 +23829,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22157,6 +23867,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22192,6 +23905,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22227,6 +23943,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22262,6 +23981,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22297,6 +24019,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22332,6 +24057,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22367,6 +24095,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22402,6 +24133,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -22437,6 +24171,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -22472,6 +24209,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -22507,6 +24247,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -22542,6 +24285,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -22577,6 +24323,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22612,6 +24361,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22647,6 +24399,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22682,6 +24437,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22717,6 +24475,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -22752,6 +24513,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -22787,6 +24551,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22822,6 +24589,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22857,6 +24627,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -22892,6 +24665,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -22927,6 +24703,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -22962,6 +24741,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -22997,6 +24779,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23032,6 +24817,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23067,6 +24855,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23102,6 +24893,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23137,6 +24931,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23172,6 +24969,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23207,6 +25007,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23242,6 +25045,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23277,6 +25083,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23312,6 +25121,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23347,6 +25159,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23382,6 +25197,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23417,6 +25235,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -23452,6 +25273,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -23487,6 +25311,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23522,6 +25349,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -23557,6 +25387,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -23592,6 +25425,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -23627,6 +25463,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -23662,6 +25501,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -23697,6 +25539,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23732,6 +25577,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -23767,6 +25615,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -23802,6 +25653,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23837,6 +25691,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -23872,6 +25729,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -23907,6 +25767,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -23942,6 +25805,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -23977,6 +25843,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24012,6 +25881,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24047,6 +25919,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24082,6 +25957,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24117,6 +25995,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24152,6 +26033,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24187,6 +26071,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24222,6 +26109,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24257,6 +26147,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24292,6 +26185,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24327,6 +26223,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24362,6 +26261,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -24397,6 +26299,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24432,6 +26337,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24467,6 +26375,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24502,6 +26413,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24537,6 +26451,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24572,6 +26489,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24607,6 +26527,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -24642,6 +26565,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -24677,6 +26603,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -24712,6 +26641,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -24747,6 +26679,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -24782,6 +26717,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -24817,6 +26755,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -24852,6 +26793,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -24887,6 +26831,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -24922,6 +26869,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -24957,6 +26907,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -24992,6 +26945,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25027,6 +26983,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25062,6 +27021,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25097,6 +27059,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25132,6 +27097,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25167,6 +27135,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25202,6 +27173,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25237,6 +27211,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25272,6 +27249,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25307,6 +27287,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25342,6 +27325,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25377,6 +27363,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25412,6 +27401,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25447,6 +27439,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25482,6 +27477,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25517,6 +27515,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25552,6 +27553,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25587,6 +27591,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25622,6 +27629,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25657,6 +27667,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -25692,6 +27705,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -25727,6 +27743,9 @@
                   "index": 0
                 },
                 "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.6.3.sarif
+++ b/src/test-resources/w3citylights-axe-v4.6.3.sarif
@@ -2208,6 +2208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2244,6 +2246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2280,6 +2284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2316,6 +2322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2352,6 +2360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2388,6 +2398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2424,6 +2436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2460,6 +2474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2496,6 +2512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2532,6 +2550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2568,6 +2588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2604,6 +2626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2640,6 +2664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2676,6 +2702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2712,6 +2740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2748,6 +2778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2784,6 +2816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2820,6 +2854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2856,6 +2892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2892,6 +2930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2928,6 +2968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -2964,6 +3006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3000,6 +3044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3036,6 +3082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3072,6 +3120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3108,6 +3158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3144,6 +3196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3180,6 +3234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3216,6 +3272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3252,6 +3310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3288,6 +3348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3324,6 +3386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3360,6 +3424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3396,6 +3462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3432,6 +3500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3468,6 +3538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3504,6 +3576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3540,6 +3614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3576,6 +3652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3612,6 +3690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3648,6 +3728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3684,6 +3766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3720,6 +3804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3756,6 +3842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3792,6 +3880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3828,6 +3918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3864,6 +3956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3900,6 +3994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -3936,6 +4032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -3972,6 +4070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4008,6 +4108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4044,6 +4146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4080,6 +4184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4116,6 +4222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4152,6 +4260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4188,6 +4298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4224,6 +4336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4260,6 +4374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4296,6 +4412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4332,6 +4450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4368,6 +4488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4404,6 +4526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4440,6 +4564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4476,6 +4602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4512,6 +4640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4548,6 +4678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4584,6 +4716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4620,6 +4754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4656,6 +4792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4692,6 +4830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4728,6 +4868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4764,6 +4906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4800,6 +4944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4836,6 +4982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4872,6 +5020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4908,6 +5058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -4944,6 +5096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -4980,6 +5134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5016,6 +5172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5052,6 +5210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5088,6 +5248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5124,6 +5286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5160,6 +5324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5196,6 +5362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5232,6 +5400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5268,6 +5438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5304,6 +5476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5340,6 +5514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5376,6 +5552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5412,6 +5590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5448,6 +5628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5484,6 +5666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5520,6 +5704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5556,6 +5742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5592,6 +5780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5628,6 +5818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5664,6 +5856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5700,6 +5894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5736,6 +5932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5772,6 +5970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -5808,6 +6008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -5844,6 +6046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5880,6 +6084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5916,6 +6122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -5952,6 +6160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -5988,6 +6198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6024,6 +6236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6060,6 +6274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6096,6 +6312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6132,6 +6350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6168,6 +6388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6204,6 +6426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6240,6 +6464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6276,6 +6502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6312,6 +6540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6348,6 +6578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6384,6 +6616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6420,6 +6654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6456,6 +6692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6492,6 +6730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6528,6 +6768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6564,6 +6806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6600,6 +6844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6636,6 +6882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6672,6 +6920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6708,6 +6958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6744,6 +6996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -6780,6 +7034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -6816,6 +7072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -6852,6 +7110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6888,6 +7148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -6924,6 +7186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -6960,6 +7224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -6996,6 +7262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7032,6 +7300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7068,6 +7338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7104,6 +7376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7140,6 +7414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7176,6 +7452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7212,6 +7490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7248,6 +7528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7284,6 +7566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7320,6 +7604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7356,6 +7642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7392,6 +7680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7428,6 +7718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7464,6 +7756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7500,6 +7794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7536,6 +7832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7572,6 +7870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7608,6 +7908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7644,6 +7946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7680,6 +7984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -7716,6 +8022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -7752,6 +8060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -7788,6 +8098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -7824,6 +8136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -7860,6 +8174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -7896,6 +8212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -7932,6 +8250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -7968,6 +8288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8004,6 +8326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8040,6 +8364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8076,6 +8402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8112,6 +8440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8148,6 +8478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8184,6 +8516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8220,6 +8554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -8256,6 +8592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -8292,6 +8630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8328,6 +8668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8364,6 +8706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8400,6 +8744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8436,6 +8782,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8472,6 +8820,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8508,6 +8858,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8544,6 +8896,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -8580,6 +8934,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -8616,6 +8972,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8652,6 +9010,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -8688,6 +9048,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -8724,6 +9086,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -8760,6 +9124,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8796,6 +9162,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -8832,6 +9200,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -8868,6 +9238,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -8904,6 +9276,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -8940,6 +9314,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -8976,6 +9352,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9012,6 +9390,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -9048,6 +9428,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -9084,6 +9466,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9120,6 +9504,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -9156,6 +9542,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9192,6 +9580,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -9228,6 +9618,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9264,6 +9656,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -9300,6 +9694,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9336,6 +9732,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9372,6 +9770,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9408,6 +9808,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9444,6 +9846,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9480,6 +9884,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9516,6 +9922,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9552,6 +9960,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9588,6 +9998,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9624,6 +10036,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9660,6 +10074,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -9696,6 +10112,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9732,6 +10150,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -9768,6 +10188,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9804,6 +10226,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -9840,6 +10264,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9876,6 +10302,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -9912,6 +10340,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -9948,6 +10378,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9984,6 +10416,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -10020,6 +10454,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10056,6 +10492,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -10092,6 +10530,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10128,6 +10568,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10164,6 +10606,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10200,6 +10644,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10236,6 +10682,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10272,6 +10720,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10308,6 +10758,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10344,6 +10796,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10380,6 +10834,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10416,6 +10872,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10452,6 +10910,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10488,6 +10948,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10524,6 +10986,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -10560,6 +11024,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -10596,6 +11062,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -10632,6 +11100,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -10668,6 +11138,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -10704,6 +11176,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -10740,6 +11214,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -10776,6 +11252,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -10812,6 +11290,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -10848,6 +11328,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -10884,6 +11366,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -10920,6 +11404,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -10956,6 +11442,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -10992,6 +11480,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11028,6 +11518,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11064,6 +11556,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11100,6 +11594,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11136,6 +11632,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11172,6 +11670,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11208,6 +11708,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11244,6 +11746,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11280,6 +11784,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11316,6 +11822,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11352,6 +11860,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11388,6 +11898,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11424,6 +11936,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11460,6 +11974,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -11496,6 +12012,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -11532,6 +12050,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -11568,6 +12088,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -11604,6 +12126,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -11640,6 +12164,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -11676,6 +12202,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -11712,6 +12240,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -11748,6 +12278,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -11784,6 +12316,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -11820,6 +12354,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -11856,6 +12392,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -11892,6 +12430,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -11928,6 +12468,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -11964,6 +12506,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12000,6 +12544,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12036,6 +12582,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12072,6 +12620,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12108,6 +12658,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12144,6 +12696,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12180,6 +12734,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12216,6 +12772,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12252,6 +12810,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12288,6 +12848,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12324,6 +12886,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12360,6 +12924,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12396,6 +12962,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -12432,6 +13000,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -12468,6 +13038,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12504,6 +13076,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -12540,6 +13114,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -12576,6 +13152,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -12612,6 +13190,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -12648,6 +13228,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -12684,6 +13266,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -12720,6 +13304,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -12756,6 +13342,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -12792,6 +13380,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -12828,6 +13418,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -12864,6 +13456,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -12900,6 +13494,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -12936,6 +13532,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -12972,6 +13570,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13008,6 +13608,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13044,6 +13646,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -13080,6 +13684,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -13116,6 +13722,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -13152,6 +13760,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -13188,6 +13798,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -13224,6 +13836,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -13260,6 +13874,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -13296,6 +13912,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -13332,6 +13950,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -13368,6 +13988,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -13404,6 +14026,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -13440,6 +14064,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -13476,6 +14102,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -13512,6 +14140,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -13548,6 +14178,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -13584,6 +14216,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -13620,6 +14254,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -13656,6 +14292,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -13692,6 +14330,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -13728,6 +14368,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -13764,6 +14406,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -13800,6 +14444,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13836,6 +14482,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13872,6 +14520,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -13908,6 +14558,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -13944,6 +14596,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -13980,6 +14634,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14016,6 +14672,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14052,6 +14710,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -14088,6 +14748,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14124,6 +14786,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -14160,6 +14824,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14196,6 +14862,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -14232,6 +14900,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14268,6 +14938,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14304,6 +14976,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14340,6 +15014,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14376,6 +15052,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14412,6 +15090,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -14448,6 +15128,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -14484,6 +15166,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -14520,6 +15204,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14556,6 +15242,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -14592,6 +15280,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14628,6 +15318,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -14664,6 +15356,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -14700,6 +15394,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14736,6 +15432,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -14772,6 +15470,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -14808,6 +15508,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -14844,6 +15546,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -14880,6 +15584,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -14916,6 +15622,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -14952,6 +15660,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -14988,6 +15698,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15024,6 +15736,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15060,6 +15774,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15096,6 +15812,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15132,6 +15850,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15168,6 +15888,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -15204,6 +15926,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -15240,6 +15964,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -15276,6 +16002,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -15312,6 +16040,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -15348,6 +16078,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -15384,6 +16116,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -15420,6 +16154,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -15456,6 +16192,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -15492,6 +16230,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -15528,6 +16268,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -15564,6 +16306,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -15600,6 +16344,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -15636,6 +16382,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -15672,6 +16420,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -15708,6 +16458,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -15744,6 +16496,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -15780,6 +16534,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -15816,6 +16572,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -15852,6 +16610,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -15888,6 +16648,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -15924,6 +16686,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -15960,6 +16724,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -15996,6 +16762,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16032,6 +16800,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16068,6 +16838,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16104,6 +16876,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16140,6 +16914,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -16176,6 +16952,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -16212,6 +16990,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -16248,6 +17028,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -16284,6 +17066,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -16320,6 +17104,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -16356,6 +17142,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -16392,6 +17180,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -16428,6 +17218,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16464,6 +17256,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -16500,6 +17294,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -16536,6 +17332,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -16572,6 +17370,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16608,6 +17408,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16644,6 +17446,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16680,6 +17484,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -16716,6 +17522,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -16752,6 +17560,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -16788,6 +17598,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -16824,6 +17636,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -16860,6 +17674,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -16896,6 +17712,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -16932,6 +17750,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -16968,6 +17788,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17004,6 +17826,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17040,6 +17864,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17076,6 +17902,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17112,6 +17940,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17148,6 +17978,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -17184,6 +18016,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -17220,6 +18054,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -17256,6 +18092,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -17292,6 +18130,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -17328,6 +18168,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -17364,6 +18206,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -17400,6 +18244,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -17436,6 +18282,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -17472,6 +18320,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -17508,6 +18358,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -17544,6 +18396,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -17580,6 +18434,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -17616,6 +18472,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -17652,6 +18510,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -17688,6 +18548,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -17724,6 +18586,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -17760,6 +18624,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -17796,6 +18662,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -17832,6 +18700,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -17868,6 +18738,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -17904,6 +18776,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -17940,6 +18814,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -17976,6 +18852,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18012,6 +18890,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18048,6 +18928,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18084,6 +18966,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -18120,6 +19004,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18156,6 +19042,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -18192,6 +19080,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18228,6 +19118,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18264,6 +19156,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -18300,6 +19194,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -18336,6 +19232,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -18372,6 +19270,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -18408,6 +19308,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -18444,6 +19346,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -18480,6 +19384,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -18516,6 +19422,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -18552,6 +19460,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18588,6 +19498,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18624,6 +19536,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -18660,6 +19574,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -18696,6 +19612,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -18732,6 +19650,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18768,6 +19688,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -18804,6 +19726,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -18840,6 +19764,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -18876,6 +19802,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -18912,6 +19840,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -18948,6 +19878,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -18984,6 +19916,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19020,6 +19954,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19056,6 +19992,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19092,6 +20030,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -19128,6 +20068,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -19164,6 +20106,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -19200,6 +20144,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19236,6 +20182,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19272,6 +20220,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19308,6 +20258,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19344,6 +20296,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -19380,6 +20334,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -19416,6 +20372,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -19452,6 +20410,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19488,6 +20448,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19524,6 +20486,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19560,6 +20524,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19596,6 +20562,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -19632,6 +20600,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -19668,6 +20638,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -19704,6 +20676,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19740,6 +20714,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19776,6 +20752,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19812,6 +20790,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -19848,6 +20828,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -19884,6 +20866,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -19920,6 +20904,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -19956,6 +20942,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -19992,6 +20980,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20028,6 +21018,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20064,6 +21056,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -20100,6 +21094,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -20136,6 +21132,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -20172,6 +21170,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -20208,6 +21208,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -20244,6 +21246,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -20280,6 +21284,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20316,6 +21322,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -20352,6 +21360,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -20388,6 +21398,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20424,6 +21436,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -20460,6 +21474,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -20496,6 +21512,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -20532,6 +21550,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -20568,6 +21588,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20604,6 +21626,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20640,6 +21664,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -20676,6 +21702,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20712,6 +21740,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20748,6 +21778,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20784,6 +21816,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20820,6 +21854,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -20856,6 +21892,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20892,6 +21930,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -20928,6 +21968,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -20964,6 +22006,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21000,6 +22044,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21036,6 +22082,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21072,6 +22120,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21108,6 +22158,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21144,6 +22196,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21180,6 +22234,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21216,6 +22272,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21252,6 +22310,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -21288,6 +22348,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21324,6 +22386,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -21360,6 +22424,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -21396,6 +22462,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21432,6 +22500,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21468,6 +22538,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -21504,6 +22576,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21540,6 +22614,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21576,6 +22652,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21612,6 +22690,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21648,6 +22728,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -21684,6 +22766,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21720,6 +22804,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -21756,6 +22842,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -21792,6 +22880,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -21828,6 +22918,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21864,6 +22956,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -21900,6 +22994,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -21936,6 +23032,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -21972,6 +23070,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -22008,6 +23108,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -22044,6 +23146,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22080,6 +23184,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22116,6 +23222,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -22152,6 +23260,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -22188,6 +23298,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -22224,6 +23336,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -22260,6 +23374,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -22296,6 +23412,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -22332,6 +23450,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -22368,6 +23488,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -22404,6 +23526,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -22440,6 +23564,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -22476,6 +23602,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -22512,6 +23640,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -22548,6 +23678,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -22584,6 +23716,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -22620,6 +23754,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -22656,6 +23792,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22692,6 +23830,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -22728,6 +23868,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -22764,6 +23906,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -22800,6 +23944,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -22836,6 +23982,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -22872,6 +24020,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -22908,6 +24058,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -22944,6 +24096,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -22980,6 +24134,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -23016,6 +24172,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -23052,6 +24210,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -23088,6 +24248,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -23124,6 +24286,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -23160,6 +24324,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23196,6 +24362,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23232,6 +24400,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23268,6 +24438,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23304,6 +24476,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -23340,6 +24514,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -23376,6 +24552,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23412,6 +24590,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23448,6 +24628,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23484,6 +24666,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -23520,6 +24704,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -23556,6 +24742,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -23592,6 +24780,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -23628,6 +24818,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -23664,6 +24856,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -23700,6 +24894,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -23736,6 +24932,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -23772,6 +24970,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -23808,6 +25008,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -23844,6 +25046,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -23880,6 +25084,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -23916,6 +25122,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -23952,6 +25160,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -23988,6 +25198,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24024,6 +25236,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -24060,6 +25274,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -24096,6 +25312,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -24132,6 +25350,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -24168,6 +25388,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -24204,6 +25426,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24240,6 +25464,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -24276,6 +25502,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -24312,6 +25540,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24348,6 +25578,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -24384,6 +25616,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -24420,6 +25654,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24456,6 +25692,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -24492,6 +25730,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -24528,6 +25768,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -24564,6 +25806,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -24600,6 +25844,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -24636,6 +25882,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -24672,6 +25920,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -24708,6 +25958,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -24744,6 +25996,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -24780,6 +26034,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -24816,6 +26072,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -24852,6 +26110,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24888,6 +26148,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -24924,6 +26186,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -24960,6 +26224,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -24996,6 +26262,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -25032,6 +26300,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25068,6 +26338,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -25104,6 +26376,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -25140,6 +26414,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -25176,6 +26452,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -25212,6 +26490,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -25248,6 +26528,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25284,6 +26566,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25320,6 +26604,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25356,6 +26642,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25392,6 +26680,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -25428,6 +26718,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -25464,6 +26756,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -25500,6 +26794,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -25536,6 +26832,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -25572,6 +26870,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -25608,6 +26908,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -25644,6 +26946,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -25680,6 +26984,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25716,6 +27022,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25752,6 +27060,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25788,6 +27098,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -25824,6 +27136,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25860,6 +27174,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -25896,6 +27212,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25932,6 +27250,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -25968,6 +27288,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26004,6 +27326,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26040,6 +27364,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26076,6 +27402,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26112,6 +27440,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26148,6 +27478,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -26184,6 +27516,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26220,6 +27554,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -26256,6 +27592,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26292,6 +27630,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -26328,6 +27668,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -26364,6 +27706,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -26400,6 +27744,8 @@
                 },
                 "region": {
                   "startLine": 1,
+                  "startColumn": 1,
+                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }

--- a/src/test-resources/w3citylights-axe-v4.6.3.sarif
+++ b/src/test-resources/w3citylights-axe-v4.6.3.sarif
@@ -2208,8 +2208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -2246,8 +2244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -2284,8 +2280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -2322,8 +2316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2360,8 +2352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -2398,8 +2388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -2436,8 +2424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -2474,8 +2460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -2512,8 +2496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -2550,8 +2532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -2588,8 +2568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -2626,8 +2604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2664,8 +2640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2702,8 +2676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -2740,8 +2712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -2778,8 +2748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2816,8 +2784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -2854,8 +2820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2892,8 +2856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -2930,8 +2892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -2968,8 +2928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -3006,8 +2964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3044,8 +3000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3082,8 +3036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3120,8 +3072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3158,8 +3108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -3196,8 +3144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -3234,8 +3180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -3272,8 +3216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3310,8 +3252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -3348,8 +3288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -3386,8 +3324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -3424,8 +3360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -3462,8 +3396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3500,8 +3432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -3538,8 +3468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -3576,8 +3504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -3614,8 +3540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -3652,8 +3576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -3690,8 +3612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -3728,8 +3648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -3766,8 +3684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3804,8 +3720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3842,8 +3756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -3880,8 +3792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -3918,8 +3828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -3956,8 +3864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -3994,8 +3900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -4032,8 +3936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -4070,8 +3972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4108,8 +4008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left.gif\"><img src=\"./img/border_left.gif\" width=\"10px\"></td>"
                   }
@@ -4146,8 +4044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -4184,8 +4080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" bgcolor=\"#E4E4E4\" valign=\"TOP\">"
                   }
@@ -4222,8 +4116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4260,8 +4152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -4298,8 +4188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -4336,8 +4224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4374,8 +4260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -4412,8 +4296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -4450,8 +4332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -4488,8 +4368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"20px\"><img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\"></td>"
                   }
@@ -4526,8 +4404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" valign=\"TOP\">"
                   }
@@ -4564,8 +4440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -4602,8 +4476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right.gif\"><img src=\"./img/border_right.gif\" width=\"10px\"></td>"
                   }
@@ -4640,8 +4512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"10px\">"
                   }
@@ -4678,8 +4548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -4716,8 +4584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -4754,8 +4620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<body text=\"#000000\" bgcolor=\"#D7D7CD\" leftmargin=\"0px\" topmargin=\"0px\" marginwidth=\"0px\" marginheight=\"0px\" link=\"#226C8E\" vlink=\"#226C8E\" alink=\"#226C8E\">"
                   }
@@ -4792,8 +4656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4830,8 +4692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4868,8 +4728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -4906,8 +4764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4944,8 +4800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -4982,8 +4836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -5020,8 +4872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5058,8 +4908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -5096,8 +4944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -5134,8 +4980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -5172,8 +5016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -5210,8 +5052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subline\">Improving a Web site using Web Content Accessibility Guidelines (WCAG) 2.0</p>"
                   }
@@ -5248,8 +5088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -5286,8 +5124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -5324,8 +5160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -5362,8 +5196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -5400,8 +5232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -5438,8 +5268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -5476,8 +5304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -5514,8 +5340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -5552,8 +5376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -5590,8 +5412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -5628,8 +5448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -5666,8 +5484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -5704,8 +5520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -5742,8 +5556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -5780,8 +5592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -5818,8 +5628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -5856,8 +5664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"headline\">Welcome to CityLights</p>"
                   }
@@ -5894,8 +5700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>Citylights is the new portal for visitors and residents. Find out what's on, book tickets, and get the latest news.</p>"
                   }
@@ -5932,8 +5736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -5970,8 +5772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -6008,8 +5808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -6046,8 +5844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6084,8 +5880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6122,8 +5916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6160,8 +5952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"subheadline\">Elsewhere on the Web</p>"
                   }
@@ -6198,8 +5988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6236,8 +6024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -6274,8 +6060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6312,8 +6096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -6350,8 +6132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -6388,8 +6168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -6426,8 +6204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6464,8 +6240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -6502,8 +6276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -6540,8 +6312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -6578,8 +6348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -6616,8 +6384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -6654,8 +6420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -6692,8 +6456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -6730,8 +6492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -6768,8 +6528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -6806,8 +6564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -6844,8 +6600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -6882,8 +6636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -6920,8 +6672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -6958,8 +6708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -6996,8 +6744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -7034,8 +6780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -7072,8 +6816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -7110,8 +6852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7148,8 +6888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -7186,8 +6924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -7224,8 +6960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -7262,8 +6996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -7300,8 +7032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -7338,8 +7068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -7376,8 +7104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -7414,8 +7140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -7452,8 +7176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -7490,8 +7212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -7528,8 +7248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -7566,8 +7284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -7604,8 +7320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -7642,8 +7356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -7680,8 +7392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -7718,8 +7428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -7756,8 +7464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -7794,8 +7500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -7832,8 +7536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -7870,8 +7572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -7908,8 +7608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -7946,8 +7644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -7984,8 +7680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"logos\"><a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a><a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a></p>"
                   }
@@ -8022,8 +7716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"mnav\" class=\"inaccessible\">"
                   }
@@ -8060,8 +7752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -8098,8 +7788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p class=\"skip\" id=\"startcontent\">Demo starts here</p>"
                   }
@@ -8136,8 +7824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -8174,8 +7860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -8212,8 +7896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -8250,8 +7932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -8288,8 +7968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -8326,8 +8004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -8364,8 +8040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -8402,8 +8076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-footer\" class=\"meta\">"
                   }
@@ -8440,8 +8112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8478,8 +8148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -8516,8 +8184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<h1><span class=\"subhead\">Inaccessible Home Page</span><span class=\"hidden\"> -</span> Before and After Demonstration</h1>"
                   }
@@ -8554,8 +8220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -8592,8 +8256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -8630,8 +8292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -8668,8 +8328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8706,8 +8364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8744,8 +8400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -8782,8 +8436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8820,8 +8472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8858,8 +8508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -8896,8 +8544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -8934,8 +8580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -8972,8 +8616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9010,8 +8652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -9048,8 +8688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -9086,8 +8724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -9124,8 +8760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -9162,8 +8796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -9200,8 +8832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -9238,8 +8868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -9276,8 +8904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -9314,8 +8940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9352,8 +8976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9390,8 +9012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -9428,8 +9048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -9466,8 +9084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9504,8 +9120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -9542,8 +9156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9580,8 +9192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -9618,8 +9228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9656,8 +9264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -9694,8 +9300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -9732,8 +9336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -9770,8 +9372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9808,8 +9408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9846,8 +9444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -9884,8 +9480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9922,8 +9516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9960,8 +9552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -9998,8 +9588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10036,8 +9624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10074,8 +9660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -10112,8 +9696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -10150,8 +9732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -10188,8 +9768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10226,8 +9804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -10264,8 +9840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -10302,8 +9876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -10340,8 +9912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -10378,8 +9948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10416,8 +9984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -10454,8 +10020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -10492,8 +10056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -10530,8 +10092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -10568,8 +10128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -10606,8 +10164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -10644,8 +10200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -10682,8 +10236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -10720,8 +10272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -10758,8 +10308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -10796,8 +10344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -10834,8 +10380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -10872,8 +10416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -10910,8 +10452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -10948,8 +10488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -10986,8 +10524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -11024,8 +10560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -11062,8 +10596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -11100,8 +10632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -11138,8 +10668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -11176,8 +10704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -11214,8 +10740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -11252,8 +10776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -11290,8 +10812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -11328,8 +10848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -11366,8 +10884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -11404,8 +10920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -11442,8 +10956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -11480,8 +10992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -11518,8 +11028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -11556,8 +11064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -11594,8 +11100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -11632,8 +11136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -11670,8 +11172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -11708,8 +11208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -11746,8 +11244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -11784,8 +11280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -11822,8 +11316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11860,8 +11352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -11898,8 +11388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11936,8 +11424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -11974,8 +11460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12012,8 +11496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12050,8 +11532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12088,8 +11568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12126,8 +11604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12164,8 +11640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -12202,8 +11676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -12240,8 +11712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -12278,8 +11748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -12316,8 +11784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -12354,8 +11820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -12392,8 +11856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -12430,8 +11892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -12468,8 +11928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -12506,8 +11964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -12544,8 +12000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -12582,8 +12036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -12620,8 +12072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -12658,8 +12108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -12696,8 +12144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -12734,8 +12180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -12772,8 +12216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -12810,8 +12252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -12848,8 +12288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -12886,8 +12324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -12924,8 +12360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -12962,8 +12396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -13000,8 +12432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -13038,8 +12468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13076,8 +12504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -13114,8 +12540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -13152,8 +12576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -13190,8 +12612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -13228,8 +12648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -13266,8 +12684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -13304,8 +12720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -13342,8 +12756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -13380,8 +12792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -13418,8 +12828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -13456,8 +12864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -13494,8 +12900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13532,8 +12936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -13570,8 +12972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -13608,8 +13008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -13646,8 +13044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -13684,8 +13080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -13722,8 +13116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -13760,8 +13152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -13798,8 +13188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -13836,8 +13224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -13874,8 +13260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -13912,8 +13296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -13950,8 +13332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -13988,8 +13368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -14026,8 +13404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -14064,8 +13440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -14102,8 +13476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -14140,8 +13512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -14178,8 +13548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -14216,8 +13584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -14254,8 +13620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -14292,8 +13656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -14330,8 +13692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -14368,8 +13728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -14406,8 +13764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -14444,8 +13800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14482,8 +13836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14520,8 +13872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -14558,8 +13908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -14596,8 +13944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14634,8 +13980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -14672,8 +14016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14710,8 +14052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -14748,8 +14088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14786,8 +14124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -14824,8 +14160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -14862,8 +14196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -14900,8 +14232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14938,8 +14268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -14976,8 +14304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -15014,8 +14340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15052,8 +14376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15090,8 +14412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -15128,8 +14448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -15166,8 +14484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -15204,8 +14520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15242,8 +14556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -15280,8 +14592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -15318,8 +14628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -15356,8 +14664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -15394,8 +14700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15432,8 +14736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -15470,8 +14772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -15508,8 +14808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -15546,8 +14844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<html>"
                   }
@@ -15584,8 +14880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -15622,8 +14916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -15660,8 +14952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -15698,8 +14988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"meta-header\">"
                   }
@@ -15736,8 +15024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p id=\"skipnav\"><a href=\"#page\">Skip to inaccessible demo page</a></p>"
                   }
@@ -15774,8 +15060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -15812,8 +15096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\" title=\"W3C Home\"><img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\"></a>"
                   }
@@ -15850,8 +15132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"W3C logo\" src=\"../img/w3c.png\" height=\"48\" width=\"72\">"
                   }
@@ -15888,8 +15168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/\" title=\"WAI Home\"><img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\"></a>"
                   }
@@ -15926,8 +15204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img alt=\"Web Accessibility Initiative (WAI) logo\" src=\"../img/wai.png\" height=\"48\">"
                   }
@@ -15964,8 +15240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"subhead\">Inaccessible Home Page</span>"
                   }
@@ -16002,8 +15276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\"> -</span>"
                   }
@@ -16040,8 +15312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16078,8 +15348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"first\"><a href=\"../Overview.html\">Overview</a></li>"
                   }
@@ -16116,8 +15384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../Overview.html\">Overview</a>"
                   }
@@ -16154,8 +15420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"current first\">"
                   }
@@ -16192,8 +15456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Current location: </span>"
                   }
@@ -16230,8 +15492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"subnav\">"
                   }
@@ -16268,8 +15528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<ul>"
                   }
@@ -16306,8 +15564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"inaccessible\"><strong>Inaccessible:</strong><a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a><a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a></li>"
                   }
@@ -16344,8 +15600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Inaccessible:</strong>"
                   }
@@ -16382,8 +15636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -16420,8 +15672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible </span>"
                   }
@@ -16458,8 +15708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./reports/home.html\" class=\"report\"><span class=\"hidden\">Inaccessible Home Page </span> Report</a>"
                   }
@@ -16496,8 +15744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Inaccessible Home Page </span>"
                   }
@@ -16534,8 +15780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li class=\"accessible\"><strong>Accessible:</strong><a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a><a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a></li>"
                   }
@@ -16572,8 +15816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Accessible:</strong>"
                   }
@@ -16610,8 +15852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/home.html\" class=\"page\"><span class=\"hidden\">Accessible </span>Home Page</a>"
                   }
@@ -16648,8 +15888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible </span>"
                   }
@@ -16686,8 +15924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../after/reports/home.html\" class=\"report\"><span class=\"hidden\">Accessible Home Page </span> Report</a>"
                   }
@@ -16724,8 +15960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span class=\"hidden\">Accessible Home Page </span>"
                   }
@@ -16762,8 +15996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }
@@ -16800,8 +16032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -16838,8 +16068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"news.html\">News</a></li>"
                   }
@@ -16876,8 +16104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\">News</a>"
                   }
@@ -16914,8 +16140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"tickets.html\">Tickets</a></li>"
                   }
@@ -16952,8 +16176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\">Tickets</a>"
                   }
@@ -16990,8 +16212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"survey.html\">Survey</a></li>"
                   }
@@ -17028,8 +16248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\">Survey</a>"
                   }
@@ -17066,8 +16284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<li><a href=\"template.html\">Template</a></li>"
                   }
@@ -17104,8 +16320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"template.html\">Template</a>"
                   }
@@ -17142,8 +16356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"page\">"
                   }
@@ -17180,8 +16392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -17218,8 +16428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17256,8 +16464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr valign=\"MIDDLE\">"
                   }
@@ -17294,8 +16500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"100%\" align=\"CENTER\">"
                   }
@@ -17332,8 +16536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -17370,8 +16572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17408,8 +16608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_left_top.gif\"><img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17446,8 +16644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17484,8 +16680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/border_top.gif\"><img src=\"./img/border_top.gif\" height=\"10px\"></td>"
                   }
@@ -17522,8 +16716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_top.gif\" height=\"10px\">"
                   }
@@ -17560,8 +16752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" background=\"./img/border_right_top.gif\"><img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -17598,8 +16788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right_top.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -17636,8 +16824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -17674,8 +16860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_left.gif\" width=\"10px\">"
                   }
@@ -17712,8 +16896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" align=\"CENTER\">"
                   }
@@ -17750,8 +16932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -17788,8 +16968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"86px\">"
                   }
@@ -17826,8 +17004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"443px\" background=\"./img/top_logo_next.gif\" valign=\"MIDDLE\">"
                   }
@@ -17864,8 +17040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>"
                   }
@@ -17902,8 +17076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"home.html\">"
                   }
@@ -17940,8 +17112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo.gif\" width=\"443px\" height=\"86px\" alt=\"Red dot with a white letter 'C' that symbolizes a moon crescent as well as the sun. This logo is followed by a black banner that says 'CITYLIGHTS' which is the name of this online portal. Finally, the slogan of the portal, 'your access to the city', follows in a turquoise green handwriting style and with a slight slant across the top banner.\">"
                   }
@@ -17978,8 +17148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"24px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\"></td>"
                   }
@@ -18016,8 +17184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_end.gif\" width=\"24px\" height=\"86px\">"
                   }
@@ -18054,8 +17220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"128px\" valign=\"MIDDLE\"><img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\"></td>"
                   }
@@ -18092,8 +17256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_weather.gif\" width=\"128px\" height=\"86px\">"
                   }
@@ -18130,8 +17292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"22px\" valign=\"MIDDLE\"><img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\"></td>"
                   }
@@ -18168,8 +17328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/top_logo_next_start.gif\" width=\"22px\" height=\"86px\">"
                   }
@@ -18206,8 +17364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"163px\" background=\"./img/top_logo_next.gif\" align=\"CENTER\" valign=\"MIDDLE\">"
                   }
@@ -18244,8 +17400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<select onchange=\"location.href = this.value;\">"
                   }
@@ -18282,8 +17436,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option selected=\"\">QUICKMENU ----&gt;\n            </option>"
                   }
@@ -18320,8 +17472,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Broadcasting\n            </option>"
                   }
@@ -18358,8 +17508,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Education\n            </option>"
                   }
@@ -18396,8 +17544,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Electricity\n            </option>"
                   }
@@ -18434,8 +17580,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Fire service\n            </option>"
                   }
@@ -18472,8 +17616,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Gas service\n            </option>"
                   }
@@ -18510,8 +17652,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Health care\n            </option>"
                   }
@@ -18548,8 +17688,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Police service\n            </option>"
                   }
@@ -18586,8 +17724,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Public Libraries\n            </option>"
                   }
@@ -18624,8 +17760,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social services\n            </option>"
                   }
@@ -18662,8 +17796,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Social housing\n            </option>"
                   }
@@ -18700,8 +17832,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Telecommunications\n            </option>"
                   }
@@ -18738,8 +17868,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Town planning\n            </option>"
                   }
@@ -18776,8 +17904,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Transportation\n            </option>"
                   }
@@ -18814,8 +17940,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Waste management\n            </option>"
                   }
@@ -18852,8 +17976,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<option value=\"../offsite.html\">Water services\n          </option>"
                   }
@@ -18890,8 +18012,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"7px\">\n        <td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>\n      </tr>"
                   }
@@ -18928,8 +18048,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/mark.gif\" colspan=\"5\"><img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\"></td>"
                   }
@@ -18966,8 +18084,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/mark.gif\" width=\"158px\" height=\"7px\">"
                   }
@@ -19004,8 +18120,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19042,8 +18156,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">"
                   }
@@ -19080,8 +18192,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19118,8 +18228,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19156,8 +18264,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">"
                   }
@@ -19194,8 +18300,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" width=\"380px\"><font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font></td>"
                   }
@@ -19232,8 +18336,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">&nbsp;&nbsp;<b>Traffic:</b> Construction work on Main Road</font>"
                   }
@@ -19270,8 +18372,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Traffic:</b>"
                   }
@@ -19308,8 +18408,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td bgcolor=\"#EDEDED\" align=\"RIGHT\" id=\"WEATHER\">"
                   }
@@ -19346,8 +18444,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"2\">"
                   }
@@ -19384,8 +18480,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Today:</b>"
                   }
@@ -19422,8 +18516,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n        <td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n      </tr>"
                   }
@@ -19460,8 +18552,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" background=\"./img/marker2_w.gif\" colspan=\"5\"><img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19498,8 +18588,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\".img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19536,8 +18624,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n        <td colspan=\"5\">&nbsp;</td>\n      </tr>"
                   }
@@ -19574,8 +18660,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td colspan=\"5\">&nbsp;</td>"
                   }
@@ -19612,8 +18696,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -19650,8 +18732,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19688,8 +18768,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr width=\"780px\">"
                   }
@@ -19726,8 +18804,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -19764,8 +18840,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -19802,8 +18876,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -19840,8 +18912,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"155px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -19878,8 +18948,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -19916,8 +18984,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"9\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\"></td>"
                   }
@@ -19954,8 +19020,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1\" height=\"30px\">"
                   }
@@ -19992,8 +19056,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20030,8 +19092,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"home\" onmouseover=\"switchImage('nav_home', './img/nav_home2.gif'); ChangeColor('home','#FFF')\" onmouseout=\"switchImage('nav_home', './img/nav_home.gif'); ChangeColor('home','#EDEDED')\">"
                   }
@@ -20068,8 +19128,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='home.html';\" onfocus=\"blur();\"><img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\"></a>"
                   }
@@ -20106,8 +19164,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_home\" src=\"./img/nav_home.gif\" width=\"88\" height=\"27\" hspace=\"15\" border=\"0px\">"
                   }
@@ -20144,8 +19200,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20182,8 +19236,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20220,8 +19272,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20258,8 +19308,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20296,8 +19344,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"news\" onmouseover=\"switchImage('nav_news', './img/nav_news2.gif'); ChangeColor('news','#FFF')\" onmouseout=\"switchImage('nav_news', './img/nav_news.gif'); ChangeColor('news','#EDEDED')\">"
                   }
@@ -20334,8 +19380,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='news.html';\" onfocus=\"blur();\"><img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\"></a>"
                   }
@@ -20372,8 +19416,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_news.gif\" name=\"nav_news\" width=\"90\" height=\"21\" hspace=\"12\" border=\"0px\">"
                   }
@@ -20410,8 +19452,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20448,8 +19488,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20486,8 +19524,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20524,8 +19560,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20562,8 +19596,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"tickets\" onmouseover=\"switchImage('nav_facts', './img/nav_facts2.gif'); ChangeColor('tickets','#FFF')\" onmouseout=\"switchImage('nav_facts', './img/nav_facts.gif'); ChangeColor('tickets','#EDEDED')\">"
                   }
@@ -20600,8 +19632,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='tickets.html';\" onfocus=\"blur();\"><img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\"></a>"
                   }
@@ -20638,8 +19668,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img name=\"nav_facts\" src=\"./img/nav_facts.gif\" width=\"105\" height=\"23\" hspace=\"9\" border=\"0px\">"
                   }
@@ -20676,8 +19704,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20714,8 +19740,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -20752,8 +19776,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -20790,8 +19812,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"34px\">"
                   }
@@ -20828,8 +19848,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" bgcolor=\"#EDEDED\" id=\"survey\" onmouseover=\"switchImage('nav_survey', './img/nav_survey2.gif'); ChangeColor('survey','#FFF')\" onmouseout=\"switchImage('nav_survey', './img/nav_survey.gif'); ChangeColor('survey','#EDEDED')\">"
                   }
@@ -20866,8 +19884,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"javascript:location.href='survey.html';\" onfocus=\"blur();\"><img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\"></a>"
                   }
@@ -20904,8 +19920,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/nav_survey.gif\" name=\"nav_survey\" width=\"107\" height=\"32\" hspace=\"8\" border=\"0px\">"
                   }
@@ -20942,8 +19956,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -20980,8 +19992,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"154px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -21018,8 +20028,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -21056,8 +20064,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -21094,8 +20100,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"434px\" height=\"600px\" valign=\"TOP\" id=\"main\">"
                   }
@@ -21132,8 +20136,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div id=\"content\">"
                   }
@@ -21170,8 +20172,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"midwidth\"><div></div></div>"
                   }
@@ -21208,8 +20208,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div></div>"
                   }
@@ -21246,8 +20244,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a></div>"
                   }
@@ -21284,8 +20280,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21322,8 +20316,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Heat wave linked to temperatures</a>"
                   }
@@ -21360,8 +20352,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a></div>"
                   }
@@ -21398,8 +20388,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21436,8 +20424,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Man Gets Nine Months in Violin Case</a>"
                   }
@@ -21474,8 +20460,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsheadline\"><img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\"> <a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a></div>"
                   }
@@ -21512,8 +20496,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/headline_middle.gif\" width=\"23\" height=\"24\" align=\"absmiddle\">"
                   }
@@ -21550,8 +20532,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\">Lack of brains hinders research</a>"
                   }
@@ -21588,8 +20568,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21626,8 +20604,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21664,8 +20640,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"newsbar\">"
                   }
@@ -21702,8 +20676,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/panda-sm.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21740,8 +20712,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21778,8 +20748,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/oldenburgstudentviolin34.jpg) center center no-repeat #cccccc\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21816,8 +20784,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21854,8 +20820,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"image\" style=\"background: url(./img/BrainInJar.jpg) center center no-repeat #cccccc;\" title=\"image\"><div class=\"null\"></div></div>"
                   }
@@ -21892,8 +20856,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -21930,8 +20892,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"clear\"><div class=\"null\"></div></div>"
                   }
@@ -21968,8 +20928,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"null\"></div>"
                   }
@@ -22006,8 +20964,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22044,8 +21000,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22082,8 +21036,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22120,8 +21072,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22158,8 +21108,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22196,8 +21144,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22234,8 +21180,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22272,8 +21216,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22310,8 +21252,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"story\">"
                   }
@@ -22348,8 +21288,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22386,8 +21324,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"news.html\" onfocus=\"blur();\"><img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\"></a>"
                   }
@@ -22424,8 +21360,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/morearrow.gif\" width=\"48\" height=\"10\" alt=\"\" border=\"0\" onmouseover=\"this.src='./img/morearrow_a.gif'\" onmouseout=\"this.src='./img/morearrow.gif'\" style=\"vertical-align: bottom\">"
                   }
@@ -22462,8 +21396,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22500,8 +21432,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22538,8 +21468,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<span>"
                   }
@@ -22576,8 +21504,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22614,8 +21540,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22652,8 +21576,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22690,8 +21612,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/list_bullets.gif\" alt=\"bullet\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22728,8 +21648,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a onfocus=\"blur();\" href=\"../offsite.html\" target=\"_blank\">Click here</a>"
                   }
@@ -22766,8 +21684,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22804,8 +21720,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -22842,8 +21756,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Artichoke advice telephone hotline: </b>"
                   }
@@ -22880,8 +21792,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/telefon_white_bg.gif\" alt=\"1234 56789\" border=\"0\" align=\"absmiddle\">"
                   }
@@ -22918,8 +21828,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/blank_5x5.gif\" width=\"20px\" height=\"5px\">"
                   }
@@ -22956,8 +21864,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -22994,8 +21900,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -23032,8 +21936,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">"
                   }
@@ -23070,8 +21972,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"1px\" background=\"./img/marker2_t.gif\" rowspan=\"11\" valign=\"TOP\"><img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\"></td>"
                   }
@@ -23108,8 +22008,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_t.gif\" width=\"1px\" height=\"30px\">"
                   }
@@ -23146,8 +22044,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"151px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -23184,8 +22080,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -23222,8 +22116,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>\n            </tr>"
                   }
@@ -23260,8 +22152,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font></td>"
                   }
@@ -23298,8 +22188,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>Free Penguins</b></font>"
                   }
@@ -23336,8 +22224,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>Free Penguins</b>"
                   }
@@ -23374,8 +22260,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"106px\">\n              <td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>\n            </tr>"
                   }
@@ -23412,8 +22296,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div></td>"
                   }
@@ -23450,8 +22332,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div><img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\"></div>"
                   }
@@ -23488,8 +22368,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right1.jpg\" width=\"150px\" height=\"106px\">"
                   }
@@ -23526,8 +22404,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -23564,8 +22440,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -23602,8 +22476,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -23640,8 +22512,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>\n                </tbody>"
                   }
@@ -23678,8 +22548,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>\n                  </tr>"
                   }
@@ -23716,8 +22584,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td><div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div></td>"
                   }
@@ -23754,8 +22620,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div>\"Free penguins\" slogan at zoo benefit concert causes confusion among city rockers. Adjective or verb?<br><a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></div>"
                   }
@@ -23792,8 +22656,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -23830,8 +22692,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"tickets.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -23868,8 +22728,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">\n              <td>&nbsp;</td>\n            </tr>"
                   }
@@ -23906,8 +22764,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>&nbsp;</td>"
                   }
@@ -23944,8 +22800,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"1px\">\n              <td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>\n            </tr>"
                   }
@@ -23982,8 +22836,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" background=\"./img/marker2_w.gif\"><img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\"></td>"
                   }
@@ -24020,8 +22872,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/marker2_w.gif\" width=\"78px\" height=\"1px\">"
                   }
@@ -24058,8 +22908,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"25px\">\n              <td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>\n            </tr>"
                   }
@@ -24096,8 +22944,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\" bgcolor=\"#A9B8BF\"><font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font></td>"
                   }
@@ -24134,8 +22980,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"#41545D\" face=\"Verdana\" size=\"2\">&nbsp;<b>More City Parks</b></font>"
                   }
@@ -24172,8 +23016,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<b>More City Parks</b>"
                   }
@@ -24210,8 +23052,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"154px\">\n              <td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>\n            </tr>"
                   }
@@ -24248,8 +23088,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\"><img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\"></td>"
                   }
@@ -24286,8 +23124,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/teaser_right2.jpg\" width=\"150px\" height=\"154px\">"
                   }
@@ -24324,8 +23160,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>"
                   }
@@ -24362,8 +23196,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"150px\">"
                   }
@@ -24400,8 +23232,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -24438,8 +23268,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody><tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>\n                </tbody>"
                   }
@@ -24476,8 +23304,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr>\n                    <td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>\n                  </tr>"
                   }
@@ -24514,8 +23340,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td>More parks and more green throughout the city at the price of already rare car parking spaces, how will this affect you?<br><a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a></td>"
                   }
@@ -24552,8 +23376,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -24590,8 +23412,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"survey.html\" onfocus=\"blur();\" style=\"text-decoration:none;\">Read More...</a>"
                   }
@@ -24628,8 +23448,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tbody>"
                   }
@@ -24666,8 +23484,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<tr height=\"17px\">"
                   }
@@ -24704,8 +23520,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td align=\"RIGHT\">"
                   }
@@ -24742,8 +23556,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<font color=\"BLACK\" face=\"Verdana\" size=\"1\">"
                   }
@@ -24780,8 +23592,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -24818,8 +23628,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -24856,8 +23664,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -24894,8 +23700,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -24932,8 +23736,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -24970,8 +23772,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -25008,8 +23808,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -25046,8 +23844,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -25084,8 +23880,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -25122,8 +23916,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_right.gif\" width=\"10px\">"
                   }
@@ -25160,8 +23952,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_left.gif\"><img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -25198,8 +23988,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_left.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -25236,8 +24024,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"780px\" height=\"10px\" background=\"./img/border_bottom.gif\"><img src=\"./img/border_bottom.gif\" height=\"10px\"></td>"
                   }
@@ -25274,8 +24060,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom.gif\" height=\"10px\">"
                   }
@@ -25312,8 +24096,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<td width=\"10px\" height=\"10px\" background=\"./img/border_bottom_right.gif\"><img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\"></td>"
                   }
@@ -25350,8 +24132,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<img src=\"./img/border_bottom_right.gif\" width=\"10px\" height=\"10px\">"
                   }
@@ -25388,8 +24168,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<hr>"
                   }
@@ -25426,8 +24204,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25464,8 +24240,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Status:</strong>"
                   }
@@ -25502,8 +24276,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../changelog.html\">changelog</a>"
                   }
@@ -25540,8 +24312,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25578,8 +24348,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/People/shadi/\">Shadi Abou-Zahra</a>"
                   }
@@ -25616,8 +24384,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/EO/\">Education and Outreach Working Group (EOWG)</a>"
                   }
@@ -25654,8 +24420,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -25692,8 +24456,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/TIES/\"><acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym></a>"
                   }
@@ -25730,8 +24492,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Training, Implementation, Education, Support\">WAI-TIES</acronym>"
                   }
@@ -25768,8 +24528,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/WAI-AGE/\"><acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym></a>"
                   }
@@ -25806,8 +24564,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Web Accessibility Initiative: Ageing Education and Harmonisation\">WAI-AGE</acronym>"
                   }
@@ -25844,8 +24600,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Information Society Technologies\">IST</acronym>"
                   }
@@ -25882,8 +24636,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"../acks.html\">Acknowledgements</a>"
                   }
@@ -25920,8 +24672,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -25958,8 +24708,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitemap.html\" shape=\"rect\">WAI Site Map</a>"
                   }
@@ -25996,8 +24744,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/sitehelp.html\" shape=\"rect\">Help with WAI Website</a>"
                   }
@@ -26034,8 +24780,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/search.php\" shape=\"rect\">Search</a>"
                   }
@@ -26072,8 +24816,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/WAI/contacts\" shape=\"rect\">Contacting WAI</a>"
                   }
@@ -26110,8 +24852,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<br>"
                   }
@@ -26148,8 +24888,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<strong>Feedback welcome to <a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a></strong>"
                   }
@@ -26186,8 +24924,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai-eo-editors@w3.org\" shape=\"rect\">wai-eo-editors@w3.org</a>"
                   }
@@ -26224,8 +24960,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"mailto:wai@w3.org\" shape=\"rect\">wai@w3.org</a>"
                   }
@@ -26262,8 +24996,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<div class=\"copyright\">"
                   }
@@ -26300,8 +25032,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<p>"
                   }
@@ -26338,8 +25068,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Copyright\">Copyright</a>"
                   }
@@ -26376,8 +25104,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/\"><acronym title=\"World Wide Web Consortium\">W3C</acronym></a>"
                   }
@@ -26414,8 +25140,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"World Wide Web Consortium\">W3C</acronym>"
                   }
@@ -26452,8 +25176,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<sup>®</sup>"
                   }
@@ -26490,8 +25212,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.csail.mit.edu/\"><acronym title=\"Massachusetts Institute of Technology\">MIT</acronym></a>"
                   }
@@ -26528,8 +25248,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"Massachusetts Institute of Technology\">MIT</acronym>"
                   }
@@ -26566,8 +25284,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.ercim.org/\"><acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym></a>"
                   }
@@ -26604,8 +25320,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<acronym title=\"European Research Consortium for Informatics and Mathematics\">ERCIM</acronym>"
                   }
@@ -26642,8 +25356,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.keio.ac.jp/\">Keio</a>"
                   }
@@ -26680,8 +25392,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer\">liability</a>"
                   }
@@ -26718,8 +25428,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks\">trademark</a>"
                   }
@@ -26756,8 +25464,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-documents\">document use</a>"
                   }
@@ -26794,8 +25500,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a rel=\"Copyright\" href=\"http://www.w3.org/Consortium/Legal/copyright-software\">software licensing</a>"
                   }
@@ -26832,8 +25536,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Public\">public</a>"
                   }
@@ -26870,8 +25572,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"http://www.w3.org/Consortium/Legal/privacy-statement#Members\">Member</a>"
                   }
@@ -26908,8 +25608,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"#page\">Skip to inaccessible demo page</a>"
                   }
@@ -26946,8 +25644,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -26984,8 +25680,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27022,8 +25716,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27060,8 +25752,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27098,8 +25788,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27136,8 +25824,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27174,8 +25860,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27212,8 +25896,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27250,8 +25932,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27288,8 +25968,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -27326,8 +26004,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"100%\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#D7D7CD\">"
                   }
@@ -27364,8 +26040,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"800px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27402,8 +26076,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"144px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27440,8 +26112,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27478,8 +26148,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"WHITE\">"
                   }
@@ -27516,8 +26184,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"155px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27554,8 +26220,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"151px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\">"
                   }
@@ -27592,8 +26256,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27630,8 +26292,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"150px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"3px\">"
                   }
@@ -27668,8 +26328,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<table width=\"780px\" height=\"17px\" border=\"0px\" cellspacing=\"0px\" cellpadding=\"0px\" bgcolor=\"#EDEDED\">"
                   }
@@ -27706,8 +26364,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a class=\"page current\"><span class=\"hidden\">Inaccessible </span>Home Page</a>"
                   }
@@ -27744,8 +26400,6 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endColumn": 1,
                   "snippet": {
                     "text": "<a href=\"./annotated/home.html\" class=\"annotoggle\">Show <br>Annotations</a>"
                   }


### PR DESCRIPTION
#### Details

As called out in #961, our SARIF doesn't have a fully formed location. Since we don't have meaningful data for this, the "least bad" solution was to insert dummy data for the `startLine` property. This PR includes 2 code changes, plus a bunch of refreshed SARIF files generated via the CLI tool. I noticed that the refreshed version of `basic-axe-3.2.2.sarif` is pretty-printed differently than what we had before. I'm guessing that the tool shifted at some point and that this is the first time the file has been regenerated with the current tool.

##### Motivation

Address #961 for better tool compatibility

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #961
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
