### PR TITLE
Chore(oncall-vendor-transition): Move Dependabot to 08:30 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -29,7 +29,7 @@ updates:
   directory: "/src/test-resources/generator"
   schedule:
     interval: daily
-    time: "8:30"
+    time: "08:30"
   labels:
   - "category: engineering"
   - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -25,12 +24,12 @@ updates:
   commit-message:
     prefix: chore
     include: scope
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic
 - package-ecosystem: npm
   directory: "/src/test-resources/generator"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"
   labels:
   - "category: engineering"
   - dependencies
@@ -55,3 +54,4 @@ updates:
   commit-message:
     prefix: chore
     include: scope
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic


### PR DESCRIPTION
#### Details
Dependabot for our repos is scheduled to run at fairly different times that are inconvenient for some geographies. This PR moves this repo's dependabot time to 08:30 UTC (14:00 IST, 01:30 PDT, 00:30 PST).

##### Motivation
Part of [Feature 2083093](https://mseng.visualstudio.com/1ES/_queries/edit/2083093) (internal access required to view).

#### Pull request checklist
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [n/a] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
