### PR TITLE
chore(rotation): returning README to standard formatting/reverting trivial change

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Convert [axe-core](https://github.com/dequelabs/axe-core) accessibility scan res
 
 Use this with the [Sarif Viewer Build Tab Azure DevOps Extension](https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab) to visualize accessibility scan results in the build results of an [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) build.
 
-## USAGE
+## Usage
 
 Before using axe-sarif-converter, you will need to run an [axe](https://github.com/dequelabs/axe-core) accessibility scan to produce some axe results to convert. Typically, you would do this by using an axe integration library for your favorite browser automation tool ([@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer), [@axe-core/webdriverjs](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/webdriverjs), [cypress-axe](https://github.com/avanslaars/cypress-axe)).
 


### PR DESCRIPTION
Returning back to standard format after trivial change in #1180. "USAGE" is now back to "Usage". Will sync with vendor team to see how migration is affecting token consumption

#### Details
Part of quarterly rotation
<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [ ] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [ ] (if applicable) Addresses issue: #0000
- [ ] Added relevant unit tests for your changes
- [ ] Ran `yarn precheckin`
- [ ] Verified code coverage for the changes made
