### PR TITLE
fix: Added skip setting for 1ES PT tag in PR pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ extends:
     # For productions pipelines, use "Official".
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
     parameters:
+        settings:
+            skipBuildTagsForGitHubPullRequests: true
         # Update the pool with your team's 1ES hosted pool.
         pool:
             name: a11y-insights-pool-dev


### PR DESCRIPTION
#### Details

1ES PT adds tags to pipeline runs using the access token provided by ADO. In the case of pipeline runs against forked repos of a GitHub repo, the access token does not have Edit build quality permissions and hence cannot add tags. To unblock those pipelines, skipped tagging by using the option SkipBuildTagsForGitHubPullRequests.

Verified that the only change in the pipeline run is that it do not add "1ES.PT.Unofficial" tag on the Run. In place of that it adds below warning message.

##[warning]1ES PT Warning: Skipping build tags as this build is a pull request form GitHub which does not have permissions to add tags.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [na] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [na] (if applicable) Addresses issue: #0000
- [na] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [na] Verified code coverage for the changes made
