### PR TITLE
fix: update PR template for PR title naming convention.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@
 <!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
 - [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
 - [ ] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
+- [ ] Verify PR title contain space after `:` for example `feat(feature): feature title` otherwise it will not be considered by semantic-release for release.
 - [ ] (if applicable) Addresses issue: #0000
 - [ ] Added relevant unit tests for your changes
 - [ ] Ran `yarn precheckin`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 <!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
 - [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
 - [ ] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
-- [ ] Verify PR title contain space after `:` for example `feat(feature): feature title` otherwise it will not be considered by semantic-release for release.
+- [ ] Verify PR title and final merge commit contain space after `:` for example `feat(feature): feature title` otherwise it will not be considered by semantic-release for release.
 - [ ] (if applicable) Addresses issue: #0000
 - [ ] Added relevant unit tests for your changes
 - [ ] Ran `yarn precheckin`


### PR DESCRIPTION
#### Details

semantic-release uses PR title for deciding release version and it follows https://www.conventionalcommits.org/en/v1.0.0/. It is required to have terminal colon and space. So added this in PR checklist to verify PR title before merging it.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [ ] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [ ] (if applicable) Addresses issue: #0000
- [ ] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [ ] Verified code coverage for the changes made
