### PR TITLE
BREAKING CHANGE: Update node version to 20.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
         "LICENSE",
         "README.md"
     ],
-    "engines": {
-        "node": ">= 8"
-    },
+  "engines": {
+    "node": ">= 20.17.0"
+  },
     "packageManager": "yarn@3.5.0",
     "dependencies": {
         "@puppeteer/browsers": "^2.1.0",

--- a/pipelines/shared-template.yml
+++ b/pipelines/shared-template.yml
@@ -55,8 +55,8 @@ extends:
                         # can require of our users without a breaking change
                         - task: NodeTool@0
                           inputs:
-                              versionSpec: '18.17.0'
-                          displayName: use node 18.17.0
+                              versionSpec: '20.17.0'
+                          displayName: use node 20.17.0
 
                         - script: yarn install --immutable
                           displayName: yarn install


### PR DESCRIPTION
#### Details

Node 16 left support in October 2023. The only known consumer of axe-sarif-converter is the accessibility-insights-service repo, which already uses Node 20.

##### Motivation

Get on a supported version that we expect to last for a while



##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] Verify PR title and final merge commit contain space after `:` for example `feat(feature): feature title` otherwise it will not be considered by semantic-release for release.
- [ ] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made

BREAKING CHANGE: Bump Node requirement to Node 20