### PR TITLE
fix: ES-4.2.4 CFS compliance - redirect npm/yarn to Azure Artifacts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+registry=https://pkgs.dev.azure.com/mseng/1ES/_packaging/A11yAgent_PublicPackages/npm/registry/
+always-auth=true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,4 @@
 
 nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-3.5.0.cjs
+npmRegistryServer: "https://pkgs.dev.azure.com/mseng/1ES/_packaging/A11yAgent_PublicPackages/npm/registry/"

--- a/pipelines/shared-template.yml
+++ b/pipelines/shared-template.yml
@@ -26,6 +26,7 @@ extends:
     parameters:
         settings:
             skipBuildTagsForGitHubPullRequests: true
+            networkIsolationPolicy: Permissive,CFSClean
         pool:
             name: $(a11yInsightsPool)
             image: ubuntu-22.04-secure
@@ -57,6 +58,11 @@ extends:
                           inputs:
                               versionSpec: '20.17.0'
                           displayName: use node 20.17.0
+
+                        - task: npmAuthenticate@0
+                          inputs:
+                              workingFile: '.npmrc'
+                          displayName: authenticate npm feed
 
                         - script: yarn install --immutable
                           displayName: yarn install


### PR DESCRIPTION
- .yarnrc.yml: add npmRegistryServer pointing to A11yAgent_PublicPackages feed
- .npmrc: add registry config for npmAuthenticate task authentication
- pipelines/shared-template.yml: add networkIsolationPolicy Permissive,CFSClean and npmAuthenticate@0 task before yarn install

#### Details

Remediate S360 items for ES4.2.4, must use central feed services for network isolation.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [ ] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] Verify PR title and final merge commit contain space after `:` for example `feat(feature): feature title` otherwise it will not be considered by semantic-release for release.
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [ ] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
